### PR TITLE
chore: correct the stale SCS-037 round-2 inert comment (round 2 is live)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,3 +55,8 @@
 ## 2026-08-08 (Fred): SCS-018 positional read facade fixed
 - [x] The SCS-018 contract claimed getMoisture(fieldId, x, z) shipped, but the CropStressManager facade forwarded only fieldId, so SF-18's positional reads degraded to the field aggregate. SoilMoistureSystem already had the positional getter; the facade now forwards x, z. One-arg callers unchanged. Suite 162/0 across 9 files. Built and deployed. The SF-18 keystone (FS25_SoilFertilizer) consumes the positional read.
 
+
+## 2026-08-10 (Fred): SCS-037 round 2 is live - the rain switch across a skip
+- [x] The Water Record delegate exists now (SF PR #811), so getSkipRainHours binds to g_currentMission.soilFertilityManager:getWaterDaysInLast per SoilFertilizer's own cross-boundary rule, instead of the three-field-deep path it refused to take. Round 2 reconstructs rain-bearing hours across a skipped span from SF-49's per-day verdicts: 72 hours with 2 of 3 recorded days wet yields 48 rain hours, and the daily settle stays on its own clock per the one-clock rule. The nil paths are kept on purpose, they are still the honest answer when the record is absent or the gate is closed.
+- [x] The stale "IT IS INERT TODAY" comment block in CropStressManager.lua and the matching "inertness guard" framing in the SCS-037 bench were corrected to state round 2 is live. No code change: the consumer already probed for the delegate and its bench already covered the live path. Suite 381/0 across 14 files; syntax clean.
+- [~] The 72-hour skip test is owed in-game: sleep or fast-forward about 72 hours on a save with a dry field and an active pivot, then read csStatus; the moisture drop, the stress accrual and the money charged should each be about 72x a single hour.

--- a/TODO.md
+++ b/TODO.md
@@ -61,3 +61,7 @@
 - [x] SCS-018 positional read facade fixed: CropStressManager.getMoisture forwards x, z to SoilMoistureSystem (the 1-arg facade was the uncommitted gap; SF-18 consumes the positional read). Suite 162/0.
 - [~] In-game acceptance owed: hollow stays wetter over dry days; continuity on old saves; skip lands exactly; cell round-trip on both save paths; Irrigate Now survives broadcast on a client; RW map moisture evolves on our model.
 
+
+## SCS-037 round 2 live (2026-08-10)
+- [x] Comment correction only: the round-2 rain-switch reconstruction is LIVE because the Water Record delegate ships (SF PR #811). CropStressManager.lua comment and the SCS-037 bench framing updated to say so. No code change, suite 381/0.
+- [~] In-game skip test owed: ~72h skip with a dry field and an active pivot; moisture drop, stress and irrigation cost each read about 72x a single hour in csStatus.

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -621,23 +621,17 @@ end
 -- Round 1 holds the sky at its last-known state for the whole span, so a skip
 -- that ends in rain charges the field rain for every skipped hour and a skip that
 -- ends dry charges none. SoilFertilizer's Water Record (SF-49) already freezes ONE
--- VERDICT PER DAY — did water arrive, from any source — which is exactly the
+-- VERDICT PER DAY, did water arrive, from any source, which is exactly the
 -- switch needed to reconstruct those hours instead of guessing them.
 --
--- IT IS INERT TODAY, AND THE REASON IS THE CONTRACT, NOT THE FEATURE.
--- `MaterialWetness:waterDaysInLast(days, throughDay)` exists and works, but it is
--- NOT PUBLISHED: the only path to it from here is
--- `g_currentMission.soilFertilityManager.soilSystem.materialWetness`, three
--- internal field names deep. SoilFertilizer's own cross-boundary rule (its
--- `getCellGrowthInfo` / `getFieldGrowthSummary` delegates, 2026-08-09) is that a
--- consumer binds to a METHOD ON THE MANAGER and nothing else, precisely so a
--- refactor there cannot rename this read out from under us. So we probe for the
--- delegate and take round-1 behaviour until it exists.
---
--- THE ASK, stated so it can be built as one method: a manager-level
--- `getWaterDaysInLast(days, throughDay)` on SoilFertilityManager returning
--- (count, known), nil-safe in every direction, neutral when the Water Record is
--- absent or the ground_material gate is closed.
+-- LIVE since 2026-08-10. The delegate `getWaterDaysInLast(days, throughDay)` is
+-- published on `g_currentMission.soilFertilityManager`, so we bind to a METHOD ON
+-- THE MANAGER and nothing else, per SoilFertilizer's own cross-boundary rule (its
+-- `getCellGrowthInfo` / `getFieldGrowthSummary` delegates, 2026-08-09), so a
+-- refactor there cannot rename this read out from under us. Before the delegate
+-- existed we probed for it and took round-1 behaviour; the nil paths in
+-- `getSkipRainHours` below are kept because they are still the honest answer
+-- when the record is absent or the ground_material gate is closed.
 --
 -- Temperature and humidity stay last-known sky either way; only the rain switch
 -- is reconstructable, because only the rain switch is recorded.

--- a/tools/test/lua/scs037_caught_up_hour_test.lua
+++ b/tools/test/lua/scs037_caught_up_hour_test.lua
@@ -158,10 +158,11 @@ do
 end
 
 do
-  -- THE INERTNESS GUARD. SoilFertilizer publishes no manager-level Water Record
-  -- delegate today, so the reader must answer nil and round-1 must hold. This
-  -- assertion is the reason the feature is honest rather than half-wired: when
-  -- somebody publishes `getWaterDaysInLast`, this test is what changes.
+  -- THE NIL-SAFETY GUARD. SoilFertilizer publishes the manager-level delegate
+  -- (`getWaterDaysInLast`, 2026-08-10), but the reader still must answer nil on
+  -- every unknown path: absent SoilFertilizer, no delegate, a throwing delegate,
+  -- and an empty record. nil is the honest answer and round-1 holds; these
+  -- assertions pin that the unknown never masquerades as a dry guess.
   local mgr = setmetatable({}, CropStressManager)
 
   g_currentMission.soilFertilityManager = nil


### PR DESCRIPTION
Correct the stale comment: SCS-037 round 2 is live, not inert.

## Why

The round-2 rain-switch reconstruction in `getSkipRainHours` was written inert on purpose, probing for a manager-level Water Record delegate that did not exist yet. SoilFertilizer shipped that delegate in PR #811, so the probe now succeeds and round 2 is live. The code needed no change, it was already correct and its bench already covered the live path. What was left behind was the narrative: the comment block still said "IT IS INERT TODAY" and the bench still framed itself as the inertness guard.

## What

- Corrected the `SCS-037 ROUND 2` comment block in `CropStressManager.lua` to state the delegate is published and round 2 is live, and that the nil paths are kept because they remain the honest answer when the record is absent or the ground_material gate is closed.
- Corrected the matching "inertness guard" framing in `scs037_caught_up_hour_test.lua` to the nil-safety guard it actually is.
- Removed the em dashes in the rewritten comment block.

## Verification

Comment-only change. Suite 381/0 across 14 files; Lua 5.1 syntax clean. Not a build or gameplay change, nothing to deploy.

The 72-hour in-game skip test is still owed and is the only remaining item on the SCS-037 chain.
