### PR TITLE
fix(SCS-043): reel N binding, pump turn-on, gate diagnostics, hose ground clamp

### DIFF
--- a/src/ScsPumpHoseConnection.lua
+++ b/src/ScsPumpHoseConnection.lua
@@ -117,6 +117,19 @@ local function phIsPumpRunning(pump)
     return false
 end
 
+-- The connected Rainstar, but only when it actually carries the reel spec.
+local function phGetReelPartner(pump)
+    local spec = pump ~= nil and pump.spec_scsPumpHose or nil
+    if spec == nil or not spec.connected then
+        return nil
+    end
+    local partner = spec.partner
+    if partner == nil or partner.RAR == nil then
+        return nil
+    end
+    return partner
+end
+
 local function phWaterFillType()
     if g_fillTypeManager ~= nil then
         local idx = g_fillTypeManager:getFillTypeIndexByName("WATER")
@@ -148,6 +161,7 @@ function ScsPumpHoseConnection.registerEventListeners(vehicleType)
     SpecializationUtil.registerEventListener(vehicleType, "onDelete", ScsPumpHoseConnection)
     SpecializationUtil.registerEventListener(vehicleType, "onUpdate", ScsPumpHoseConnection)
     SpecializationUtil.registerEventListener(vehicleType, "onUpdateTick", ScsPumpHoseConnection)
+    SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", ScsPumpHoseConnection)
 end
 
 function ScsPumpHoseConnection:onLoad(savegame)
@@ -168,6 +182,11 @@ function ScsPumpHoseConnection:onLoad(savegame)
     spec.hoseTemplate = nil
     spec.hoseSegments = {}
     spec.candidate = nil
+    spec.reelActionEvents = {}
+    -- Motor start is asynchronous: getIsPowered() is still false in the frame
+    -- tryStartMotor is called, so the turn-on has to be retried until it takes.
+    spec.pendingTurnOn = false
+    spec.pendingTurnOnTimer = 0
 
     -- Soft path for vendored parking brake / COBD (RPC.virtualHoseConnected).
     if self.RPC == nil then
@@ -484,6 +503,124 @@ function ScsPumpHoseConnection.transferWater(pump, dt)
     rainstar:addFillUnitFillLevel(farmId, fillUnit, actuallyDrained, waterIndex, toolType, nil)
 end
 
+-- ------------------------------------------------------------
+-- Reel toggle (N) on the pump side.
+--
+-- The vendored RWSM53AutoReel used to hand N to "the pump" whenever the hose was
+-- connected, but nothing on this side ever claimed it, so connecting the hose
+-- just deleted the binding. The Rainstar keeps its own N now; this is the second
+-- surface, so the reel can also be started from the machine the player is
+-- standing at when the hose goes on.
+-- ------------------------------------------------------------
+
+function ScsPumpHoseConnection:onRegisterActionEvents(isActiveForInput, isActiveForInputIgnoreSelection)
+    local spec = self.spec_scsPumpHose
+    if not self.isClient or spec == nil or InputAction.RWSM53_REEL_TOGGLE == nil then
+        return
+    end
+
+    self:clearActionEventsTable(spec.reelActionEvents)
+
+    if not isActiveForInputIgnoreSelection then
+        return
+    end
+
+    local _, actionEventId = self:addActionEvent(
+        spec.reelActionEvents,
+        InputAction.RWSM53_REEL_TOGGLE,
+        self,
+        ScsPumpHoseConnection.actionEventReelToggle,
+        false,
+        true,
+        false,
+        true,
+        nil
+    )
+
+    if actionEventId ~= nil then
+        g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_NORMAL)
+        -- Hidden until a Rainstar is actually on the hose.
+        g_inputBinding:setActionEventActive(actionEventId, false)
+    end
+end
+
+function ScsPumpHoseConnection.updateReelActionEvent(pump)
+    local spec = pump ~= nil and pump.spec_scsPumpHose or nil
+    local action = spec ~= nil and spec.reelActionEvents ~= nil
+        and spec.reelActionEvents[InputAction.RWSM53_REEL_TOGGLE] or nil
+    if action == nil or action.actionEventId == nil then
+        return
+    end
+
+    local partner = phGetReelPartner(pump)
+    g_inputBinding:setActionEventActive(action.actionEventId, partner ~= nil)
+    if partner ~= nil then
+        g_inputBinding:setActionEventText(action.actionEventId, g_i18n:getText(
+            partner.RAR.reelCommandActive
+                and "action_RAINSTAR_REEL_STOP"
+                or "action_RAINSTAR_REEL_START"))
+    end
+end
+
+function ScsPumpHoseConnection.actionEventReelToggle(self, actionName, inputValue, callbackState, isAnalog)
+    local partner = phGetReelPartner(self)
+    if partner == nil or RWSM53AutoReel == nil or RWSM53AutoReel.toggleReel == nil then
+        return
+    end
+    RWSM53AutoReel.toggleReel(partner)
+    ScsPumpHoseConnection.updateReelActionEvent(self)
+end
+
+-- Vanilla tryStartMotor only brings the motor to STARTING, and getCanBeTurnedOn
+-- resolves to getIsPowered(), which stays false until the motor has finished
+-- cranking. Turning on in the same frame therefore always declined silently: the
+-- walk-up prompt flipped to "Stop pump" while getIsTurnedOn() stayed false, so
+-- both the reel gate and the spray effect still read the pump as off.
+function ScsPumpHoseConnection.updatePendingTurnOn(pump, dt)
+    local spec = pump ~= nil and pump.spec_scsPumpHose or nil
+    if spec == nil or not spec.pendingTurnOn then
+        return
+    end
+
+    -- Give up if the player stopped the motor again while the start was pending.
+    local motorStarted = true
+    if pump.getIsMotorStarted ~= nil then
+        local ok, value = pcall(pump.getIsMotorStarted, pump)
+        motorStarted = (not ok) or (value == true)
+    end
+    if not motorStarted then
+        spec.pendingTurnOn = false
+        spec.pendingTurnOnTimer = 0
+        return
+    end
+
+    if pump.getIsTurnedOn ~= nil then
+        local ok, value = pcall(pump.getIsTurnedOn, pump)
+        if ok and value == true then
+            spec.pendingTurnOn = false
+            spec.pendingTurnOnTimer = 0
+            return
+        end
+    end
+
+    spec.pendingTurnOnTimer = (spec.pendingTurnOnTimer or 0) + (tonumber(dt) or 0)
+    if spec.pendingTurnOnTimer > 15000 then
+        spec.pendingTurnOn = false
+        spec.pendingTurnOnTimer = 0
+        print("[CropStress] ScsPumpHose: pump turn-on timed out, motor never reported powered")
+        return
+    end
+
+    local canTurnOn = true
+    if pump.getCanBeTurnedOn ~= nil then
+        local ok, value = pcall(pump.getCanBeTurnedOn, pump)
+        canTurnOn = ok and value == true
+    end
+    if canTurnOn and pump.setIsTurnedOn ~= nil then
+        pcall(pump.setIsTurnedOn, pump, true)
+    end
+end
+
 function ScsPumpHoseConnection:onUpdate(dt, isActiveForInput, isActiveForInputIgnoreSelection, isSelected)
     local spec = self.spec_scsPumpHose
     if spec == nil then
@@ -515,6 +652,12 @@ function ScsPumpHoseConnection:onUpdateTick(dt, isActiveForInput, isActiveForInp
     local spec = self.spec_scsPumpHose
     if spec == nil then
         return
+    end
+
+    ScsPumpHoseConnection.updatePendingTurnOn(self, dt)
+
+    if self.isClient then
+        ScsPumpHoseConnection.updateReelActionEvent(self)
     end
 
     if self.isServer and spec.connected then
@@ -783,10 +926,15 @@ function ScsPumpStartActivatable:run()
     if vehicle == nil then
         return
     end
+    local spec = vehicle.spec_scsPumpHose
     local running = phIsPumpRunning(vehicle)
     if running then
         -- Turn-on off first, then stop the motor, so the hose spec sees a clean stop
         -- rather than a turned-on pump with a dead engine.
+        if spec ~= nil then
+            spec.pendingTurnOn = false
+            spec.pendingTurnOnTimer = 0
+        end
         if vehicle.setIsTurnedOn ~= nil then
             pcall(vehicle.setIsTurnedOn, vehicle, false)
         end
@@ -800,18 +948,20 @@ function ScsPumpStartActivatable:run()
         if Motorized ~= nil and type(Motorized.tryStartMotor) == "function" then
             pcall(Motorized.tryStartMotor, vehicle)
         end
-        -- getCanBeTurnedOn wants getIsPowered, which is false until the motor is at least
-        -- STARTING, so this is attempted after the start and is allowed to decline.
-        if vehicle.setIsTurnedOn ~= nil then
-            local canTurnOn = true
-            if vehicle.getCanBeTurnedOn ~= nil then
-                local ok, value = pcall(vehicle.getCanBeTurnedOn, vehicle)
-                canTurnOn = (not ok) or (value ~= false)
-            end
-            if canTurnOn then
-                pcall(vehicle.setIsTurnedOn, vehicle, true)
-            end
+        -- getCanBeTurnedOn resolves to getIsPowered, which is still false while the
+        -- motor is only STARTING. Arm the retry instead of firing one attempt that
+        -- always declines; ScsPumpHoseConnection.updatePendingTurnOn finishes the job
+        -- once the motor reports powered.
+        if spec ~= nil then
+            spec.pendingTurnOn = true
+            spec.pendingTurnOnTimer = 0
         end
+        -- Keep the pump scheduled so the retry actually gets update ticks while the
+        -- player is still standing outside it.
+        if vehicle.raiseActive ~= nil then
+            pcall(vehicle.raiseActive, vehicle)
+        end
+        ScsPumpHoseConnection.updatePendingTurnOn(vehicle, 0)
     end
     self:updateActivateText()
 end

--- a/src/ScsPumpHoseConnection.lua
+++ b/src/ScsPumpHoseConnection.lua
@@ -25,6 +25,11 @@ ScsPumpHoseConnection.HOSE_SHAPE_NAME = "rwsmGroundHoseTemplate"
 ScsPumpHoseConnection.HOSE_TEMPLATE_LENGTH = 0.5
 ScsPumpHoseConnection.HOSE_SEGMENTS = 3
 ScsPumpHoseConnection.SAG_M = 0.35
+-- The sag is applied to a straight line between two joints that both sit low on
+-- their machines. On level or rising ground the middle of that curve ends up
+-- under the terrain, which is the hose disappearing into the map. Every point is
+-- clamped to at least this far above the ground.
+ScsPumpHoseConnection.GROUND_CLEARANCE_M = 0.08
 
 local function phNormalizePath(path)
     return string.lower(string.gsub(tostring(path or ""), "\\", "/"))
@@ -58,6 +63,18 @@ end
 local function phWorldDistance(ax, ay, az, bx, by, bz)
     local dx, dy, dz = bx - ax, by - ay, bz - az
     return math.sqrt(dx * dx + dy * dy + dz * dz)
+end
+
+local function phGroundHeight(x, z)
+    local terrainNode = g_currentMission ~= nil and g_currentMission.terrainRootNode or g_terrainNode
+    if terrainNode == nil or getTerrainHeightAtWorldPos == nil then
+        return nil
+    end
+    local ok, height = pcall(getTerrainHeightAtWorldPos, terrainNode, x, 0, z)
+    if not ok then
+        return nil
+    end
+    return tonumber(height)
 end
 
 local function phFindNodeByName(node, wantedName)
@@ -103,17 +120,14 @@ local function phIsPumpRunning(pump)
     if pump.spec_turnOnVehicle ~= nil and pump.spec_turnOnVehicle.isTurnedOn == true then
         return true
     end
-    -- Aggregat ships motorized with turnOnVehicle XML commented out; motor start
-    -- is the player-facing "start the pump" gate for this kit.
-    if pump.getIsMotorStarted ~= nil then
-        local ok, value = pcall(pump.getIsMotorStarted, pump)
-        if ok and value == true then
-            return true
-        end
-    end
-    if pump.spec_motorized ~= nil and pump.spec_motorized.isMotorStarted == true then
-        return true
-    end
+    -- A running diesel engine is NOT a running pump. The old motor-started fallback
+    -- here rested on a note that the Aggregat shipped with its turnOnVehicle block
+    -- commented out; it does not (Aggregat.xml:217). The fallback made the walk-up
+    -- prompt read "Stop pump" the moment the engine caught, so the player saw a pump
+    -- that claimed to be running while getIsTurnedOn stayed false, the reel gate kept
+    -- refusing, and pressing the prompt killed the engine instead of stopping a pump
+    -- that had never started. The reel gate and the water transfer both mean this
+    -- state, so this helper has to mean it too.
     return false
 end
 
@@ -432,6 +446,16 @@ function ScsPumpHoseConnection.updateHosePose(vehicle)
         -- Soft mid sag so the short supply hose does not read as a rigid rod.
         local sagFactor = 4 * t * (1 - t)
         y = y - ScsPumpHoseConnection.SAG_M * sagFactor
+        -- A sagging hose lies on the ground, it does not sink through it. Only the
+        -- interior points are lifted: the two ends stay exactly on their couplings,
+        -- so a joint that sits below the sampled terrain height on a slope cannot
+        -- tear the hose visual off the machine it is plugged into.
+        if i > 0 and i < n then
+            local groundY = phGroundHeight(x, z)
+            if groundY ~= nil then
+                y = math.max(y, groundY + ScsPumpHoseConnection.GROUND_CLEARANCE_M)
+            end
+        end
         points[i + 1] = { x, y, z }
     end
 
@@ -564,6 +588,10 @@ end
 
 function ScsPumpHoseConnection.actionEventReelToggle(self, actionName, inputValue, callbackState, isAnalog)
     local partner = phGetReelPartner(self)
+    print(string.format(
+        "[CropStress] Reel toggle pressed from the pump (partner=%s, reelSpec=%s)",
+        tostring(partner ~= nil),
+        tostring(RWSM53AutoReel ~= nil and RWSM53AutoReel.toggleReel ~= nil)))
     if partner == nil or RWSM53AutoReel == nil or RWSM53AutoReel.toggleReel == nil then
         return
     end
@@ -599,24 +627,37 @@ function ScsPumpHoseConnection.updatePendingTurnOn(pump, dt)
         if ok and value == true then
             spec.pendingTurnOn = false
             spec.pendingTurnOnTimer = 0
+            print("[CropStress] ScsPumpHose: pump turned on, reel gate is open")
             return
         end
+    end
+
+    -- The retry only runs while the pump is getting update ticks, and a pump
+    -- nobody is standing in can drop out of the active list mid-crank.
+    if pump.raiseActive ~= nil then
+        pcall(pump.raiseActive, pump)
     end
 
     spec.pendingTurnOnTimer = (spec.pendingTurnOnTimer or 0) + (tonumber(dt) or 0)
     if spec.pendingTurnOnTimer > 15000 then
         spec.pendingTurnOn = false
         spec.pendingTurnOnTimer = 0
-        print("[CropStress] ScsPumpHose: pump turn-on timed out, motor never reported powered")
+        print("[CropStress] ScsPumpHose: pump turn-on timed out, motor never finished starting")
         return
     end
 
-    local canTurnOn = true
-    if pump.getCanBeTurnedOn ~= nil then
-        local ok, value = pcall(pump.getCanBeTurnedOn, pump)
-        canTurnOn = ok and value == true
+    -- Wait for the motor to finish cranking, then set the state directly. This is
+    -- the walk-up equivalent of what the player does by hand: start the engine,
+    -- then press the turn-on binding. TurnOnVehicle:setIsTurnedOn carries no
+    -- precondition of its own (TurnOnVehicle.lua:282); getCanBeTurnedOn is a guard
+    -- the vanilla ACTION handler applies, and it resolves to getIsPowered, which is
+    -- still false mid-crank. Gating the retry on it was what kept the pump off.
+    local motorFinished = false
+    if pump.getIsMotorStarted ~= nil then
+        local ok, value = pcall(pump.getIsMotorStarted, pump)
+        motorFinished = ok and value == true
     end
-    if canTurnOn and pump.setIsTurnedOn ~= nil then
+    if motorFinished and pump.setIsTurnedOn ~= nil then
         pcall(pump.setIsTurnedOn, pump, true)
     end
 end

--- a/src/vendor/rwsm/rainstarAutoReel.lua
+++ b/src/vendor/rwsm/rainstarAutoReel.lua
@@ -1217,16 +1217,12 @@ function RWSM53AutoReel:onRegisterActionEvents(
         data.actionEvents
     )
 
-    -- With the hose-only pump connection, N belongs exclusively to the pump.
-    -- Registering the same action on both independent vehicles can toggle twice
-    -- in one key press (start + immediate stop), which looks like no reaction.
-    local virtualPump = self.rwsmVirtualPump
-    if virtualPump ~= nil and virtualPump.RPC ~= nil
-        and virtualPump.RPC.virtualHoseConnected == true
-        and virtualPump.RPC.virtualRainstar == self then
-        return
-    end
-
+    -- SCS vendor note: the Rainstar always registers N. The old guard handed N
+    -- to the pump whenever the hose was connected, but the suite-owned hose spec
+    -- never claimed it, so connecting the hose simply deleted the binding. The
+    -- pump now registers N as well (ScsPumpHoseConnection), and the double-toggle
+    -- the guard feared cannot happen: both are vehicle action events, and a
+    -- player can only be active for input in one vehicle at a time.
     if isActiveForInputIgnoreSelection then
         local _, actionEventId =
             self:addActionEvent(

--- a/src/vendor/rwsm/rainstarAutoReel.lua
+++ b/src/vendor/rwsm/rainstarAutoReel.lua
@@ -777,12 +777,47 @@ local function rarComplete(vehicle)
     )
 end
 
+-- SCS vendor note: every start gate used to refuse silently, so a player who
+-- could not start the reel had a one-line blinking warning and the log had
+-- nothing at all. Each refusal now names itself and the state it read.
+local function rarRefuse(vehicle, warningKey, reason)
+    if vehicle ~= nil and vehicle.isClient and warningKey ~= nil then
+        rarShowWarning(warningKey)
+    end
+
+    local pump = rarGetConnectedPump(vehicle)
+    print(string.format(
+        "[CropStress] Reel start refused: %s | workMode=%s distance=%.1f m "
+        .. "tractorOnCart=%s virtualPump=%s cobdPump=%s pumpResolved=%s "
+        .. "pumpTurnedOn=%s motorStarted=%s",
+        tostring(reason),
+        tostring(rarIsWorkMode(vehicle)),
+        rarGetDistance(vehicle),
+        tostring(rarIsTractorAttachedToCart(vehicle)),
+        tostring(vehicle ~= nil and vehicle.rwsmVirtualPump ~= nil),
+        tostring(vehicle ~= nil and vehicle.COBD ~= nil and vehicle.COBD.connectedPump ~= nil),
+        tostring(pump ~= nil),
+        tostring(pump ~= nil and pump.getIsTurnedOn ~= nil and pump:getIsTurnedOn() == true),
+        tostring(pump ~= nil and pump.getIsMotorStarted ~= nil and pump:getIsMotorStarted() == true)
+    ))
+    return false
+end
+
+-- Up-vector Y of a component, for the rollover diagnostic. nil when unresolvable.
+local function rarGetComponentUpY(vehicle, componentIndex)
+    local node = rarGetComponentNode(vehicle, componentIndex)
+    if node == nil or localDirectionToWorld == nil then return nil end
+    local ok, _, upY, _ = pcall(localDirectionToWorld, node, 0, 1, 0)
+    if not ok then return nil end
+    return tonumber(upY)
+end
+
 local function rarStart(vehicle)
     local data = vehicle.RAR
 
     if data == nil
         or not data.animationAvailable then
-        return false
+        return rarRefuse(vehicle, nil, "reel animation unavailable")
     end
 
     local distance = rarGetDistance(vehicle)
@@ -795,42 +830,33 @@ local function rarStart(vehicle)
         if vehicle.isServer then
             rarSetJointSpring(vehicle, TIP_SAFETY_SPRING, TIP_SAFETY_DAMPING)
         end
-        return false
+        local up1 = rarGetComponentUpY(vehicle, 1)
+        local up2 = rarGetComponentUpY(vehicle, 2)
+        return rarRefuse(vehicle, nil, string.format(
+            "rollover safety: upY comp1=%s comp2=%s, needs >= %.2f",
+            up1 ~= nil and string.format("%.3f", up1) or "nil",
+            up2 ~= nil and string.format("%.3f", up2) or "nil",
+            ASSEMBLY_TIPPED_UP_DOT))
     end
 
     if not rarIsWorkMode(vehicle) then
-        if vehicle.isClient then
-            rarShowWarning("warning_RAINSTAR_SELECT_WORKMODE")
-        end
-        return false
+        return rarRefuse(vehicle, "warning_RAINSTAR_SELECT_WORKMODE", "not in work mode")
     end
 
     if distance <= STOP_DISTANCE + 0.2 then
-        if vehicle.isClient then
-            rarShowWarning("warning_RAINSTAR_HOSE_NOT_EXTENDED")
-        end
-        return false
+        return rarRefuse(vehicle, "warning_RAINSTAR_HOSE_NOT_EXTENDED", "hose not extended")
     end
 
     if rarIsTractorAttachedToCart(vehicle) then
-        if vehicle.isClient then
-            rarShowWarning("warning_RAINSTAR_CART_ATTACHED")
-        end
-        return false
+        return rarRefuse(vehicle, "warning_RAINSTAR_CART_ATTACHED", "tractor still on the cart")
     end
 
     if not rarIsPumpConnected(vehicle) then
-        if vehicle.isClient then
-            rarShowWarning("warning_RAINSTAR_PUMP_NOT_CONNECTED")
-        end
-        return false
+        return rarRefuse(vehicle, "warning_RAINSTAR_PUMP_NOT_CONNECTED", "pump not connected")
     end
 
     if not rarIsPumpRunning(vehicle) then
-        if vehicle.isClient then
-            rarShowWarning("warning_RAINSTAR_PUMP_NOT_RUNNING")
-        end
-        return false
+        return rarRefuse(vehicle, "warning_RAINSTAR_PUMP_NOT_RUNNING", "pump not running")
     end
 
     local startTime = rarGetStartAnimationTime(vehicle)
@@ -1256,6 +1282,10 @@ function RWSM53AutoReel.actionEventToggle(
     if self.RAR == nil then
         return
     end
+
+    print(string.format(
+        "[CropStress] Reel toggle pressed from the Rainstar (currently %s)",
+        self.RAR.reelCommandActive and "running" or "stopped"))
 
     if self.RAR.reelCommandActive then
         rarStop(self, true)


### PR DESCRIPTION
Found by Tyson's in-game pass on the irrigator play kit (Rainstar T32, Aggregat EMP, sprinkler cart), 2026-08-12.

**Original symptom:** connecting the pump hose deletes the N binding for automatic hose retraction. Disconnecting brings N back, but pressing it then warns that the motor pump hose must be connected. Unwinnable in both directions.

Restoring the binding exposed three further defects behind it, each of which had been unreachable while the control itself was missing. This PR carries both passes.

## Commits

| | |
|---|---|
| `b651939` | `fix(SCS-043): restore reel N binding while the pump hose is connected` |
| `3cb49be` | `fix(SCS-043): turn the pump on, make every reel gate speak, keep the hose above ground` |

**Retitled and rebodied 2026-08-12** when the second commit landed, so the title describes everything inside. No approval had been given at that point, so none needed refreshing.

## Pass one: the binding

**1. N was handed to a seat that never took it.** `rainstarAutoReel.lua:1204` deliberately skipped registering `RWSM53_REEL_TOGGLE` whenever the hose was connected, on the stated intent that N belongs to the pump. That action is registered in exactly one place in the whole mod: the block behind that guard. Connecting the hose simply deleted the binding.

The Rainstar always registers N now. The double-toggle the guard was written against cannot happen, because both surfaces are vehicle action events and a player is active for input in one vehicle at a time.

**2. N came back only when it could not work.** `rarStart()` gates on `rarIsPumpConnected`, which reads `vehicle.rwsmVirtualPump` - cleared by the disconnect that just restored the binding.

`ScsPumpHoseConnection` now registers N as well, proxying to `RWSM53AutoReel.toggleReel`, a public helper that shipped with the vendored file and had zero callers. Hidden until a Rainstar is actually on the hose; label follows start/stop state.

## Pass two: what was behind it

**3. The pump could never be turned on, by any path.** `Sprayer:getCanBeTurnedOn` returns false unconditionally when `allowsSpraying` is false (`Sprayer.lua:696`), and `Aggregat.xml:167` sets exactly that. The flag is correct - this is a water pump and must not behave as a sprayer - but it also walls off the vanilla turn-on binding, so no build of this mod could ever open the reel's pump-running gate. `log.txt` read `running=false` across every session on record.

`TurnOnVehicle:setIsTurnedOn` carries no precondition of its own (`TurnOnVehicle.lua:282`); `getCanBeTurnedOn` is a guard the vanilla *action handler* applies. The walk-up start now waits for the motor to finish cranking and sets the state directly. The XML already anticipated this: `turnOffIfNotAllowed="false"` is the flag that stops the game reverting a turn-on that is not "allowed".

`phIsPumpRunning` also no longer accepts a running diesel as a running pump. That fallback made the walk-up prompt read "Stop pump" the moment the engine caught, so the player pressed what looked like a stop and got an engine shutdown, because no pump had ever started.

**4. All six `rarStart` gates refused silently**, the rollover check included, which left the player with a bare blinking warning at best and the log with nothing at all. Each gate now names itself and the state it read, the rollover one with its measured up-vector values, and both N surfaces announce the press so a refusal can be told apart from a key that never fired.

**5. The supply hose was drawn below the terrain.** `updateHosePose` sagged a straight line between two couplings that both sit low on their machines, with no ground check anywhere. Interior points now clamp to terrain + 8 cm; the two ends keep their exact coupling positions so a joint sampling below terrain height on a slope cannot tear the hose visual off the machine it is plugged into.

## Verification

- Lua 5.1 syntax gate green, 44 files, on every commit. Control-tested with a deliberate break first, because that checker has passed broken files before.
- Engine behaviour verified against the decompile at `D:\FS25_Decoded`, not from memory: `Sprayer.lua:696`, `TurnOnVehicle.lua:282/343`, `Motorized.lua:2499`, `Vehicle.lua:2067`.
- In-game, after the turn-on fix: `connected=true running=true pressure=8.5 bar radius=33 m flow=34.0 m3/h`, followed by `[CropStress] ScsPumpHose: pump turned on, reel gate is open`.
- Retraction observed working by Tyson. Not captured in a log, since that session's log.txt was overwritten by the next launch.
- No file overlap with #121 (SCS-038).

## Filed separately, not in this PR

- **`src/ScsRainstarPumpPower.lua` does not exist** but `modDesc.xml:217` declares it, so `vehicle type 'rwsmPlayRainstar' has unknown specialization` on every load. **Resolved by Claude(A) 2026-08-12: neither write nor drop.** Wizard's local Crop Stress clone carries the file, and a PR of it closes the load error; writing it here would duplicate existing work, and dropping the declaration would delete design intent that went missing in the Esc handoff. Nothing for this PR to do.
- **Reel position does not persist.** `initSpecialization` registers `vehicles.vehicle(?).rwsmAutoReel#animationTime`, but mod specializations are handed a namespaced key and the write is rejected every save. FAST TRACK, its own branch next.
- **The Schiene falls through the world**, resetting to terrain level every twenty seconds or so through the whole test window. Unexplained, untouched by anything here, and its own defect.
- Every hose connect reloads `rwsmPumpHoseTemplate.i3d` at about 45 ms because disconnect deletes it. **Deferred by Claude(A) 2026-08-12 (item 7)**: a real fix, but it ranks behind the load error and the open defect PRs on this mod. Raise again once this PR and the pump-power file are closed.
