### PR TITLE
fix: add missing ScsRainstarPumpPower file (Esc handoff)

### DIFF
--- a/src/ScsRainstarPumpPower.lua
+++ b/src/ScsRainstarPumpPower.lua
@@ -1,0 +1,86 @@
+-- =========================================================
+-- ScsRainstarPumpPower
+-- BUILD 22:25 - the EMP pump is the Rainstar's power source.
+--
+-- Why the reel demanded a tractor
+-- ------------------------------
+-- Rainstar's <attachable> block carries no <power> element, and the schema default
+-- for vehicle.attachable.power#requiresExternalPower is TRUE. So unattached, with no
+-- Motorized specialization of its own, Attachable:getIsPowered returned
+-- (false, attachToPowerWarning). TurnOnVehicle.getCanBeTurnedOn gates on getIsPowered,
+-- so the sprinkler could never be switched on without a tractor on the drawbar.
+--
+-- The tempting fix is requiresExternalPower="false" in the XML. That is wrong: it makes
+-- the reel permanently self-powered, so it would run with no tractor AND no pump, and
+-- "no EMP path -> cannot stay on" would fail. Power has to be conditional on the pump
+-- actually running, which is a runtime question, so it belongs in an overwrite.
+--
+-- What counts as powered
+-- ----------------------
+-- ScsPumpHoseConnection already back-links the reel on connect (partner.rwsmVirtualPump)
+-- and clears it on disconnect, so the Rainstar can see its own supply hose without any
+-- new plumbing. Powered means: that pump still names THIS reel as its partner, and the
+-- pump is running. Both halves matter - a connected hose on a dead pump is not power.
+--
+-- Everything else defers to superFunc, so a tractor on the drawbar behaves exactly as
+-- before and the pump path is purely additive. No Motorized on the Rainstar, no fake
+-- attach, no invented PTO.
+-- =========================================================
+
+ScsRainstarPumpPower = {}
+
+function ScsRainstarPumpPower.prerequisitesPresent(specializations)
+    return true
+end
+
+function ScsRainstarPumpPower.registerOverwrittenFunctions(vehicleType)
+    SpecializationUtil.registerOverwrittenFunction(
+        vehicleType, "getIsPowered", ScsRainstarPumpPower.getIsPowered)
+end
+
+--- True only while a live supply hose from a RUNNING pump reaches this reel.
+local function poweredByPump(vehicle)
+    local pump = vehicle ~= nil and vehicle.rwsmVirtualPump or nil
+    if pump == nil then
+        return false
+    end
+    -- The pump owns the link, so ask it rather than trusting the back-reference alone;
+    -- a stale rwsmVirtualPump must not read as power.
+    if type(pump.getScsHosePartner) == "function" then
+        local ok, partner = pcall(pump.getScsHosePartner, pump)
+        if not ok or partner ~= vehicle then
+            return false
+        end
+    end
+    if ScsPumpHoseConnection == nil or type(ScsPumpHoseConnection.getIsPumpRunning) ~= "function" then
+        return false
+    end
+    local ok, running = pcall(ScsPumpHoseConnection.getIsPumpRunning, pump)
+    return ok and running == true
+end
+
+function ScsRainstarPumpPower:getIsPowered(superFunc)
+    if poweredByPump(self) then
+        return true
+    end
+    local isPowered, warning = superFunc(self)
+    if not isPowered and self.getAttacherVehicle ~= nil then
+        local ok, attacher = pcall(self.getAttacherVehicle, self)
+        -- Unhitched and unpowered: the vanilla warning tells the player to attach to a
+        -- vehicle with a motor, which is no longer the only way to run this reel. Say
+        -- what actually works instead of repeating an instruction that is now half true.
+        if ok and attacher == nil then
+            local text = warning
+            if g_i18n ~= nil and type(g_i18n.getText) == "function" then
+                local okTr, t = pcall(g_i18n.getText, g_i18n, "cs_rainstar_needs_pump")
+                if okTr and type(t) == "string" and t ~= "" and t ~= "cs_rainstar_needs_pump" then
+                    text = t
+                end
+            end
+            return false, text
+        end
+    end
+    return isPowered, warning
+end
+
+print("[CropStress] ScsRainstarPumpPower loaded")


### PR DESCRIPTION
﻿## Summary
- Adds `src/ScsRainstarPumpPower.lua` that `modDesc` already declares for the Rainstar play vehicle.
- Closes the live Can't load resource / unknown specialization load error Fred logged during the irrigator pass.
- **Not fully finished:** this restores the missing specialization file only. The EMP-powered reel path still depends on hose-connection helpers (for example `getIsPumpRunning`) that are not on `development` yet. Do not treat this PR as a complete irrigator power story.

## Test plan
- [ ] Load Crop Stress with Rainstar play kit; confirm no Can't load resource for ScsRainstarPumpPower
- [ ] Confirm vehicle type rwsmPlayRainstar no longer reports unknown specialization
- [ ] Note: full EMP-without-tractor spray may still need the follow-up hose helpers before it works end to end
