### PR TITLE
F155: Esc RF button translations for language testing

### DIFF
--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gerenciador de trabalhadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planejador de rotação" />
+        <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
 </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="開啟工人管理員" />
+        <text name="sf_pda_btn_rotation_planner" text="輪作規劃" />
+        <text name="sf_pda_btn_field_detail" text="田地詳情" />
 </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -458,5 +458,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Otevřít správce pracovníků" />
+        <text name="sf_pda_btn_rotation_planner" text="Plánovač osevního postupu" />
+        <text name="sf_pda_btn_field_detail" text="Detail pole" />
 </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -442,5 +442,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Åbn medarbejderstyring" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotationsplanlægger" />
+        <text name="sf_pda_btn_field_detail" text="Markdetaljer" />
 </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -457,5 +457,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Arbeitermanager öffnen" />
+        <text name="sf_pda_btn_rotation_planner" text="Fruchtfolgeplaner" />
+        <text name="sf_pda_btn_field_detail" text="Felddetails" />
 </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
+        <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
 </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -461,5 +461,9 @@
     <text name="cs_rainstar_needs_pump" text="Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Open Worker Manager" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotation Planner" />
+        <text name="sf_pda_btn_field_detail" text="Field Detail" />
 </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabajadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificador de rotación" />
+        <text name="sf_pda_btn_field_detail" text="Detalle del campo" />
 </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
+        <text name="sf_pda_btn_field_detail" text="Détail du champ" />
 </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Avaa työntekijähallinta" />
+        <text name="sf_pda_btn_rotation_planner" text="Viljelykiertosuunnittelija" />
+        <text name="sf_pda_btn_field_detail" text="Pellon tiedot" />
 </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -455,5 +455,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Ouvrir le gestionnaire d'ouvriers" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificateur de rotation" />
+        <text name="sf_pda_btn_field_detail" text="Détail du champ" />
 </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Dolgozókezelő megnyitása" />
+        <text name="sf_pda_btn_rotation_planner" text="Vetésforgó-tervező" />
+        <text name="sf_pda_btn_field_detail" text="Táblarészletek" />
 </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Buka manajer pekerja" />
+        <text name="sf_pda_btn_rotation_planner" text="Perencana rotasi" />
+        <text name="sf_pda_btn_field_detail" text="Detail lahan" />
 </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -455,5 +455,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Apri gestore operai" />
+        <text name="sf_pda_btn_rotation_planner" text="Pianificatore rotazioni" />
+        <text name="sf_pda_btn_field_detail" text="Dettaglio campo" />
 </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="作業員マネージャーを開く" />
+        <text name="sf_pda_btn_rotation_planner" text="輪作プランナー" />
+        <text name="sf_pda_btn_field_detail" text="畑の詳細" />
 </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="작업자 관리자 열기" />
+        <text name="sf_pda_btn_rotation_planner" text="윤작 계획기" />
+        <text name="sf_pda_btn_field_detail" text="밯 상세" />
 </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -455,5 +455,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Werkersbeheer openen" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotatieplanner" />
+        <text name="sf_pda_btn_field_detail" text="Veldgegevens" />
 </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Åpne arbeiderbehandler" />
+        <text name="sf_pda_btn_rotation_planner" text="Rotasjonsplanlegger" />
+        <text name="sf_pda_btn_field_detail" text="Feltdetaljer" />
 </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -455,5 +455,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Otwórz menedżera pracowników" />
+        <text name="sf_pda_btn_rotation_planner" text="Planer płodozmianu" />
+        <text name="sf_pda_btn_field_detail" text="Szczegóły pola" />
 </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Abrir gestor de trabalhadores" />
+        <text name="sf_pda_btn_rotation_planner" text="Planeador de rotação" />
+        <text name="sf_pda_btn_field_detail" text="Detalhe do campo" />
 </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Deschide managerul de muncitori" />
+        <text name="sf_pda_btn_rotation_planner" text="Planificator de rotație" />
+        <text name="sf_pda_btn_field_detail" text="Detaliu câmp" />
 </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Открыть менеджер работников" />
+        <text name="sf_pda_btn_rotation_planner" text="Планировщик севооборота" />
+        <text name="sf_pda_btn_field_detail" text="Сведения о поле" />
 </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Öppna arbetshanteraren" />
+        <text name="sf_pda_btn_rotation_planner" text="Växtföljdsplanerare" />
+        <text name="sf_pda_btn_field_detail" text="Fältdetaljer" />
 </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="İşçi yöneticisini aç" />
+        <text name="sf_pda_btn_rotation_planner" text="Ekim nöbeti planlayıcı" />
+        <text name="sf_pda_btn_field_detail" text="Tarla detayı" />
 </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -442,5 +442,9 @@
     <text name="cs_rainstar_needs_pump" text="[EN] Connect the supply hose from the pump and start the pump. This reel runs on pump pressure, not a tractor."/>
     <text name="cs_playkit_pump_power_teach" text="[EN] The pump is the power. Hitch the reel only to tow it: to spray, run the hose from the pump, start the pump, then switch the reel on. Stop the pump or pull the hose and the spray stops."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Відкрити менеджер працівників" />
+        <text name="sf_pda_btn_rotation_planner" text="Планувальник сівозміни" />
+        <text name="sf_pda_btn_field_detail" text="Деталі поля" />
 </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -348,5 +348,9 @@
     <text name="cs_rf_pda_next_covered_idle" text="[EN] Irrigation covers this field - confirm it is running when dry, then recheck Moisture."/>
     <text name="cs_rf_pda_next_looking_good" text="[EN] Looking good - recheck later; handle Critical fields first."/>
     <text name="cs_rf_pda_pivot_dial_position" text="[EN] POSITION"/>
+        <!-- BUILD 11:27 F155 Esc RF button labels -->
+        <text name="wc_rf_pda_open_manager" text="Mở trình quản lý công nhân" />
+        <text name="sf_pda_btn_rotation_planner" text="Lập kế hoạch luân canh" />
+        <text name="sf_pda_btn_field_detail" text="Chi tiết thửa ruộng" />
 </texts>
 </l10n>


### PR DESCRIPTION
## Summary
- Adds Esc RF PDA button labels for team language testing: Open Worker Manager, Rotation Planner, and Field Detail.
- Keys: `wc_rf_pda_open_manager`, `sf_pda_btn_rotation_planner`, `sf_pda_btn_field_detail`.
- Translation-only change onto `development` (no Esc chrome / farm patches).

## Test plan
- [ ] Set a non-English game language (e.g. German or French).
- [ ] Load the suite with Esc RF PDA available.
- [ ] Confirm the three Esc RF buttons show translated labels (not raw keys).
- [ ] Spot-check English still reads: Open Worker Manager / Rotation Planner / Field Detail.