### PR TITLE
fix: remove source() of the unshipped FarmPatchUtil.lua

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -78,7 +78,9 @@ source(modDir .. "src/ui/RfPdaMenuPage.lua")
 source(modDir .. "src/ui/RfEscBootstrap.lua")
 -- DEV: Esc UIDebugger (F6). Install no-ops if Soil (or another mod) already registered.
 source(modDir .. "src/ui/RfEscUiDebugger.lua")
-source(modDir .. "src/ui/FarmPatchUtil.lua")
+-- FarmPatchUtil is deliberately NOT shipped: Wizard's leftover wave excluded the
+-- farm-patch code (it stays local). CsRfPdaGuest references it nil-guarded, so
+-- this mod works without it. Do not re-add the source line without the file.
 source(modDir .. "src/ui/CsRfPdaGuest.lua")
 source(modDir .. "src/ui/CsHelpDialog.lua")
 


### PR DESCRIPTION
# fix: remove source() of the unshipped FarmPatchUtil.lua

Wizard's leftover PR kept source(modDir .. src/ui/FarmPatchUtil.lua) while excluding the farm-patch code from the share, so every load errors with Can't load resource FarmPatchUtil.lua. Farm patches are deliberately local (unpaid playtest). CsRfPdaGuest references it nil-guarded, so dropping the source call is safe.
