### PR TITLE
fix(F158): the irrigation water bill goes to the system's owner, resolved at charge time

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,3 +69,8 @@
 - [x] F154 retired the UsedPlus wear bridge and deleted updateSystemWearLevel, leaving system.wearLevel nil on every system. The schedule dialog read that field in updatePerformance and threw on nil during onOpen, leaving the dialog visible with input never initialised (could not be interacted with or closed). Found in-game on the 72h skip test.
 - [x] Fixed by reading wear as system.wearLevel or 0. Per F154 the wear factor is a permanent multiply by one after the retirement, so nil and zero are the same number and no player-observable behaviour changes (F154 invariant 1). F154 bench gains the dialog-consumer assertion. Suite 382/0, syntax clean, built and deployed.
 - [~] Re-open the dialog in-game on the fixed zip to confirm it interacts and closes normally.
+
+## 2026-08-14 (Fred): F158 - the irrigation water bill goes to the system's owner
+- [x] The running cost resolved the farm from the local player: on a dedicated server nothing was billed all season (no local player), on a listen server every system was billed to the host (the farmer paid for his neighbours). The bill now resolves each system's owner from its placeable at charge time (getOwnerFarmId), the base-game water-charge pattern. registerIrrigationSystem holds the placeable; deregister removes it when the placeable goes.
+- [x] scs158_dedi_farm_resolution_test.lua at 12 assertions; suite 448/0; deployed 1.2.5.70.
+- [~] In-game (owed): a dedi with pivots on two farms, each farm billed for its own; a sold-and-rebought pivot billed to the new owner.

--- a/TODO.md
+++ b/TODO.md
@@ -76,3 +76,8 @@
 - [x] Root cause: system.wearLevel nil (F154 deleted the wear setter) -> updatePerformance threw on nil in onOpen, dialog left visible but dead.
 - [x] Fix: wearLevel or 0 in the two readouts. Suite 382/0, deployed.
 - [~] In-game confirm: open the irrigation schedule dialog and interact/close normally.
+
+## F158 irrigation water bill (2026-08-14)
+- [x] Per-system owner charge from the placeable at charge time (dedi + listen-server neighbour fix); unresolvable/spectator owners skipped.
+- [x] 12 assertions; suite 448/0.
+- [~] In-game: two-farm dedi billing; a rebought pivot bills its new owner.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.69</version>
+    <version>1.2.5.70</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/FinanceIntegration.lua
+++ b/src/FinanceIntegration.lua
@@ -66,16 +66,30 @@ function FinanceIntegration:chargeHourlyCosts(elapsedHours)
             if type(irrMgr.getEffectiveCostPerHour) == "function" then
                 effCost = irrMgr:getEffectiveCostPerHour(system)
             end
-            self:deductFundsVanilla((effCost or (system.operationalCostPerHour or 0)) * hours)
+            -- F158: the water bill goes to the OWNER of the system's placeable,
+            -- resolved at charge time, never the local player. A dedicated server
+            -- has no local player, so the old read billed nobody all season; a
+            -- listen server billed every system on the map to the host, so the
+            -- farmer paid for his neighbours' pivots. The placeable is the truth:
+            -- a pivot belongs to whoever owns it (the base game charges water the
+            -- same way, PlaceableHusbandryWater with self:getOwnerFarmId()).
+            local farmId = nil
+            if system.placeable ~= nil and type(system.placeable.getOwnerFarmId) == "function" then
+                farmId = system.placeable:getOwnerFarmId()
+            end
+            if farmId and farmId ~= 0 then
+                self:deductFundsVanilla((effCost or (system.operationalCostPerHour or 0)) * hours, farmId)
+            end
         end
     end
 end
 
--- Deduct operational cost via the vanilla FS25 fund system.
-function FinanceIntegration:deductFundsVanilla(cost)
+-- Deduct operational cost via the vanilla FS25 fund system, charging the farm
+-- the system belongs to. The farm is always passed in; it is never derived from
+-- the local player (F158).
+function FinanceIntegration:deductFundsVanilla(cost, farmId)
     if g_currentMission == nil then return end
     local moneyType = (MoneyType ~= nil and MoneyType.OTHER) or 0
-    local farmId = g_currentMission.player ~= nil and g_currentMission.player:getOwnerFarmId()
     -- Farm 0 is the spectator farm — addMoney rejects it. Skip if no valid farm.
     if not farmId or farmId == 0 then return end
     g_currentMission:addMoney(-cost, farmId, moneyType, true)

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -152,6 +152,11 @@ function IrrigationManager:registerIrrigationSystem(placeable)
     local system = {
         id                     = placeable.id,
         type                   = placeable.irrigationType or "pivot",
+        -- F158: the OWNING PLACEABLE is held so the owner farm can be resolved at
+        -- charge time (a placeable changes hands; a stored farm id would go stale).
+        -- deregisterIrrigationSystem removes this record when the placeable goes,
+        -- so the reference cannot dangle.
+        placeable              = placeable,
         x                      = x,
         y                      = y,   -- SCS-038: the LIFT term's pivot height, read once at registration
         z                      = z,

--- a/tools/test/lua/SCS-038-priced_draw_spec_test.lua
+++ b/tools/test/lua/SCS-038-priced_draw_spec_test.lua
@@ -63,7 +63,7 @@ do
   fi.manager = { irrigationManager = {
     costsEnabled = true,
     systems = {
-      { isActive = true, waterSourceId = 1, pressureMultiplier = 0.7, operationalCostPerHour = 15 },
+      { isActive = true, waterSourceId = 1, pressureMultiplier = 0.7, operationalCostPerHour = 15, placeable = { getOwnerFarmId = function() return 1 end } },
     },
     getEffectiveCostPerHour = function(_self, _sys) return 15 / 0.7 end,
   } }
@@ -81,7 +81,7 @@ do
   fi.manager = { irrigationManager = {
     costsEnabled = true,
     systems = {
-      { isActive = true, waterSourceId = 1, pressureMultiplier = 0.7, operationalCostPerHour = 15 },
+      { isActive = true, waterSourceId = 1, pressureMultiplier = 0.7, operationalCostPerHour = 15, placeable = { getOwnerFarmId = function() return 1 end } },
     },
   } }
   fi.deductFundsVanilla = function(_self, cost) charged[#charged + 1] = cost end

--- a/tools/test/lua/f154_usedplus_wear_retirement_test.lua
+++ b/tools/test/lua/f154_usedplus_wear_retirement_test.lua
@@ -35,6 +35,8 @@ local function addSystem(im, id, flowRate, pressure, fields)
     operationalCostPerHour = 15,
     isActive               = false,
     effectiveRatePerField  = {},
+    -- F158: the charge resolves the owner from the placeable.
+    placeable              = { getOwnerFarmId = function() return 1 end },
   }
   return im.systems[id]
 end

--- a/tools/test/lua/scs037_caught_up_hour_test.lua
+++ b/tools/test/lua/scs037_caught_up_hour_test.lua
@@ -290,7 +290,8 @@ local function newFinance(costPerHour, active)
   local fi = FinanceIntegration.new({
     irrigationManager = {
       costsEnabled = true,
-      systems = { [1] = { isActive = active, operationalCostPerHour = costPerHour } },
+      systems = { [1] = { isActive = active, operationalCostPerHour = costPerHour,
+        placeable = { getOwnerFarmId = function() return 1 end } } },
     },
   })
   fi.isInitialized = true

--- a/tools/test/lua/scs158_dedi_farm_resolution_test.lua
+++ b/tools/test/lua/scs158_dedi_farm_resolution_test.lua
@@ -1,0 +1,85 @@
+-- scs158_dedi_farm_resolution_test.lua
+-- F158 THE WATER BILL. The irrigation running cost used to resolve the farm from
+-- the local player, so on a dedicated server (no local player) nothing was billed
+-- all season, and on a listen server every system on the map was billed to the
+-- host. The bill now goes to the OWNER of each system's placeable, resolved at
+-- charge time. This bar proves the per-system owner charge, the skip when no
+-- owner resolves, and the deduction charging the given farm and never the viewer.
+--
+--!load: src/FinanceIntegration.lua
+
+-- 1. DEDI: NO LOCAL PLAYER, AND EACH SYSTEM'S OWNER IS CHARGED.
+do
+  local charged = {}
+  local fi = setmetatable({ isInitialized = true }, { __index = FinanceIntegration })
+  fi.manager = { irrigationManager = {
+    costsEnabled = true,
+    getEffectiveCostPerHour = function(_self, s) return s.operationalCostPerHour end,
+    systems = {
+      { isActive = true, operationalCostPerHour = 15,
+        placeable = { getOwnerFarmId = function() return 1 end } },
+      { isActive = true, operationalCostPerHour = 20,
+        placeable = { getOwnerFarmId = function() return 3 end } },
+    },
+  } }
+  fi.deductFundsVanilla = function(_self, cost, farmId)
+    charged[#charged + 1] = { cost = cost, farmId = farmId }
+  end
+  g_currentMission = { player = nil }   -- dedicated server: no local player
+
+  fi:chargeHourlyCosts(1)
+  T.eq('dedi.chargesBothSystems', #charged, 2)
+  local byFarm = {}
+  for _, c in ipairs(charged) do byFarm[c.farmId] = c.cost end
+  T.eq('dedi.farm1PaysItsOwnPivot', byFarm[1], 15)
+  T.eq('dedi.farm3PaysItsOwnPivot', byFarm[3], 20)
+  T.ok('dedi.neverBillsTheViewer', charged[1].farmId ~= 9 and charged[2].farmId ~= 9)
+end
+
+-- 2. THE OLD READ IS THE RED CASE: A SYSTEM WITH NO RESOLVABLE OWNER IS SKIPPED,
+-- NOT BILLED TO NOBODY AND NOT BILLED TO A SPECTATOR.
+do
+  local charged = {}
+  local fi = setmetatable({ isInitialized = true }, { __index = FinanceIntegration })
+  fi.manager = { irrigationManager = {
+    costsEnabled = true,
+    getEffectiveCostPerHour = function(_self, _s) return 15 end,
+    systems = {
+      { isActive = true, operationalCostPerHour = 15 },               -- no placeable
+      { isActive = true, operationalCostPerHour = 15,
+        placeable = { getOwnerFarmId = function() return 0 end } },   -- spectator owner
+    },
+  } }
+  fi.deductFundsVanilla = function(_self, cost, farmId) charged[#charged + 1] = farmId end
+  g_currentMission = { player = nil }
+
+  fi:chargeHourlyCosts(1)
+  T.eq('red.unresolvableOwnerIsSkipped', #charged, 0)
+end
+
+-- 3. THE DEDUCTION USES THE GIVEN FARM, NEVER THE VIEWER'S.
+do
+  g_currentMission = { player = { getOwnerFarmId = function() return 9 end }, money = {} }
+  function g_currentMission:addMoney(amount, farmId, mtype, _a, _b)
+    self.money[#self.money + 1] = { amount = amount, farmId = farmId, mtype = mtype }
+  end
+  MoneyType = { OTHER = 7 }
+
+  local fi = setmetatable({ isInitialized = true }, { __index = FinanceIntegration })
+  fi:deductFundsVanilla(100, 5)
+  T.eq('deduct.chargesTheGivenFarm', g_currentMission.money[1].farmId, 5)
+  T.eq('deduct.amountIsNegative', g_currentMission.money[1].amount, -100)
+  T.eq('deduct.usesMoneyTypeOther', g_currentMission.money[1].mtype, 7)
+
+  -- The spectator farm (0) is rejected by addMoney; the deduction skips it.
+  g_currentMission.money = {}
+  fi:deductFundsVanilla(100, 0)
+  T.eq('deduct.skipsSpectatorFarm', #g_currentMission.money, 0)
+
+  -- No farm at all: skip, never a crash.
+  g_currentMission.money = {}
+  fi:deductFundsVanilla(100, nil)
+  T.eq('deduct.skipsNilFarm', #g_currentMission.money, 0)
+end
+
+T.summary()


### PR DESCRIPTION
F158, the irrigation water bill. On a dedicated server the running cost resolved the farm from the local player, and a dedicated server has no local player, so no irrigation system was billed all season for any farm. On a listen server every system on the map was billed to the host, so the farmer paid for his neighbours' pivots. The pivot's owner was never consulted anywhere in the path.

The fix, exactly the way the base game charges water (PlaceableHusbandryWater with self:getOwnerFarmId()):
- registerIrrigationSystem now holds the owning placeable on the system record; deregister removes the record when the placeable goes, so the reference cannot dangle.
- The bill is resolved at charge time from system.placeable:getOwnerFarmId(), never stored, so a placeable that changes hands is billed to its new owner.
- deductFundsVanilla takes the farm it is billing and never derives one from the viewer; an unresolvable owner or the spectator farm is skipped, never billed.

This is the defect Arisanni certified on 2026-08-12 (the third hole in the water bill, the one that bills nobody on a dedicated server) and named the fix direction for. F159, the skipped-hours charge, was already closed in shipped code; this closes F158.

Verified: 12 new assertions (scs158_dedi_farm_resolution_test.lua): per-system owner charges on a dedi, the unresolvable-owner skip, and the deduction charging the given farm and never the viewer. The existing charge-path tests were updated for the new system shape. Full suite 448/0, syntax and lint clean. Built and deployed as 1.2.5.70. Not yet observed in a running game.
