### PR TITLE
fix(F160): the weekly irrigation schedule honours the picked days, derived from the monotonic day

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,3 +69,8 @@
 - [x] F154 retired the UsedPlus wear bridge and deleted updateSystemWearLevel, leaving system.wearLevel nil on every system. The schedule dialog read that field in updatePerformance and threw on nil during onOpen, leaving the dialog visible with input never initialised (could not be interacted with or closed). Found in-game on the 72h skip test.
 - [x] Fixed by reading wear as system.wearLevel or 0. Per F154 the wear factor is a permanent multiply by one after the retirement, so nil and zero are the same number and no player-observable behaviour changes (F154 invariant 1). F154 bench gains the dialog-consumer assertion. Suite 382/0, syntax clean, built and deployed.
 - [~] Re-open the dialog in-game on the fixed zip to confirm it interacts and closes normally.
+
+## 2026-08-14 (Fred): F160 - the weekly irrigation schedule honours the picked days
+- [x] The day-of-week index was read from env.currentDayInPeriod, which the base game pins at 1 on a default save (daysPerPeriod defaults to 1), so a weekday schedule ran every day and unticking day one stopped the pivot forever. IrrigationManager:dayOfWeekIndex now derives the index from the monotonic day modulo 7, so the weekend-off entries are reachable.
+- [x] scs160_schedule_day_index_test.lua at 17 assertions; suite 465/0; deployed 1.2.5.71.
+- [~] In-game (owed): a weekday pivot rests on the weekend and a Wednesday-only schedule runs Wednesdays on a fresh save.

--- a/TODO.md
+++ b/TODO.md
@@ -76,3 +76,8 @@
 - [x] Root cause: system.wearLevel nil (F154 deleted the wear setter) -> updatePerformance threw on nil in onOpen, dialog left visible but dead.
 - [x] Fix: wearLevel or 0 in the two readouts. Suite 382/0, deployed.
 - [~] In-game confirm: open the irrigation schedule dialog and interact/close normally.
+
+## F160 weekly schedule day index (2026-08-14)
+- [x] Day-of-week derived from the monotonic day modulo 7, ignoring the pinned currentDayInPeriod; TaxMod mirror ships as its own PR.
+- [x] 17 assertions; suite 465/0.
+- [~] In-game: weekend rest + Wednesday-only run on a fresh save.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.69</version>
+    <version>1.2.5.71</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -354,6 +354,23 @@ end
 -- ============================================================
 -- Hourly Schedule Check
 -- ============================================================
+
+--- F160: the 1..7 day-of-week index for a schedule's activeDays. Derived from the
+--- MONOTONIC day modulo 7, never read from env.currentDayInPeriod. The base game
+--- computes currentDayInPeriod as (currentDay - 1) % daysPerPeriod + 1 and
+--- daysPerPeriod defaults to 1, so on a default save currentDayInPeriod is ALWAYS
+--- 1: a weekday schedule ran every day (activeDays[1] pinned true) and unticking
+--- day one stopped the pivot forever. Deriving from the monotonic day makes the
+--- index actually advance day to day, so the weekend-off entries are reachable.
+function IrrigationManager:dayOfWeekIndex(env)
+    if env == nil then return 1 end
+    local currentDay = env.currentDay or env.currentMonotonicDay or 1
+    if type(currentDay) ~= "number" or currentDay < 1 then currentDay = 1 end
+    local dow = ((currentDay - 1) % 7) + 1
+    if dow < 1 or dow > 7 then dow = 1 end
+    return dow
+end
+
 function IrrigationManager:hourlyScheduleCheck()
     if not self.isInitialized then return end
     if g_currentMission == nil then return end
@@ -361,20 +378,8 @@ function IrrigationManager:hourlyScheduleCheck()
     local env = g_currentMission.environment
     if env == nil then return end
 
-    -- env.currentHour and env.currentDayInPeriod are direct properties in FS25.
-    -- currentDayInPeriod is 1–7 within the current growth period (matches schedule activeDays).
-    -- IMPORTANT: currentDayInPeriod may be nil on some FS25 builds/map combinations.
-    -- Fallback: derive a 1-7 day index from currentDay (monotonic) so scheduling
-    -- never silently defaults to day 1 and makes schedules appear broken.
-    local hour      = env.currentHour         or 0
-    local dayOfWeek = env.currentDayInPeriod
-    if dayOfWeek == nil then
-        -- env.currentDay is 1-based within the current period; use modulo as fallback
-        local currentDay = env.currentDay or env.currentMonotonicDay or 0
-        dayOfWeek = (currentDay % 7) + 1   -- maps any integer → 1..7
-    end
-    -- Clamp to valid range in case the API returns an unexpected value
-    if dayOfWeek < 1 or dayOfWeek > 7 then dayOfWeek = 1 end
+    local hour      = env.currentHour or 0
+    local dayOfWeek = self:dayOfWeekIndex(env)
 
     for id, system in pairs(self.systems) do
         -- Check if water source is still valid

--- a/tools/test/lua/scs160_schedule_day_index_test.lua
+++ b/tools/test/lua/scs160_schedule_day_index_test.lua
@@ -1,0 +1,87 @@
+-- scs160_schedule_day_index_test.lua
+-- F160 THE WEEKLY SCHEDULE. The day-of-week index was read from
+-- env.currentDayInPeriod, which the base game computes as
+-- (currentDay - 1) % daysPerPeriod + 1 with daysPerPeriod defaulting to 1, so on
+-- a default save it is ALWAYS 1: a weekday schedule ran every day (activeDays[1]
+-- pinned true) and unticking day one stopped the pivot forever. The index is now
+-- derived from the monotonic day modulo 7, so the weekend-off entries are
+-- reachable and the schedule honours the days the player actually picked.
+--
+--!load: src/IrrigationManager.lua
+
+-- 1. THE INDEX ADVANCES 1..7 FROM THE MONOTONIC DAY, IGNORING currentDayInPeriod.
+do
+  local mgr = IrrigationManager.new(nil)
+  -- A default-save environment pins currentDayInPeriod at 1; the monotonic
+  -- currentDay still advances. Day 1 is Monday, days 6 and 7 are the weekend.
+  local function idx(currentDay)
+    return mgr:dayOfWeekIndex({ currentDay = currentDay, currentDayInPeriod = 1 })
+  end
+  local expected = { 1, 2, 3, 4, 5, 6, 7, 1 }
+  for day, want in ipairs(expected) do
+    T.eq('index.advancesDay' .. day, idx(day), want)
+  end
+  -- The pinned currentDayInPeriod must NOT be consulted: on day 5 the index is 5,
+  -- not the pinned 1.
+  T.eq('index.ignoresPinnedDayInPeriod', idx(5), 5)
+  T.eq('index.nilEnvIsOne', mgr:dayOfWeekIndex(nil), 1)
+end
+
+-- 2. THE WEEKEND-OFF DAYS ARE REACHABLE (the core defect).
+-- A weekday schedule (five true, two false) must NOT run on Saturday or Sunday
+-- even when currentDayInPeriod is pinned at 1 by the default save.
+do
+  local mgr = IrrigationManager.new(nil)
+  mgr.isInitialized = true
+  mgr.systems = {
+    [1] = {
+      waterSourceId = 1, pressureMultiplier = 1.0, flowRatePerHour = 1,
+      coveredFields = { 1 },
+      schedule = { startHour = 6, endHour = 10, activeDays = { true, true, true, true, true, false, false } },
+    },
+  }
+  mgr.waterSources = { [1] = {} }
+
+  -- Monday (day 1) runs; Saturday (6) and Sunday (7) rest, despite the pinned
+  -- currentDayInPeriod = 1 that used to make every day a Monday.
+  local function runOn(day)
+    g_currentMission = { environment = { currentHour = 7, currentDay = day, currentDayInPeriod = 1 } }
+    mgr.systems[1].isActive = false
+    mgr:hourlyScheduleCheck()
+    return mgr.systems[1].isActive
+  end
+
+  T.eq('weekday.mondayRuns', runOn(1), true)
+  T.eq('weekday.fridayRuns', runOn(5), true)
+  T.eq('weekday.saturdayRests', runOn(6), false)
+  T.eq('weekday.sundayRests', runOn(7), false)
+  T.eq('weekday.nextMondayRunsAgain', runOn(8), true)
+end
+
+-- 3. THE MIRROR CASE: UNTICKING DAY ONE NO LONGER STOPS THE PIVOT FOREVER.
+-- A schedule active only on Wednesday runs on Wednesday even when the default save
+-- would have pinned the day index at 1.
+do
+  local mgr = IrrigationManager.new(nil)
+  mgr.isInitialized = true
+  mgr.systems = {
+    [1] = {
+      waterSourceId = 1, pressureMultiplier = 1.0, flowRatePerHour = 1,
+      coveredFields = { 1 },
+      schedule = { startHour = 6, endHour = 10, activeDays = { false, false, true, false, false, false, false } },
+    },
+  }
+  mgr.waterSources = { [1] = {} }
+
+  local function runOn(day)
+    g_currentMission = { environment = { currentHour = 7, currentDay = day, currentDayInPeriod = 1 } }
+    mgr.systems[1].isActive = false
+    mgr:hourlyScheduleCheck()
+    return mgr.systems[1].isActive
+  end
+
+  T.eq('mirror.wednesdayRuns', runOn(3), true)
+  T.eq('mirror.mondayRests', runOn(1), false)
+end
+
+T.summary()


### PR DESCRIPTION
F160, the weekly irrigation schedule ran seven days on a default save. The day-of-week index was read from env.currentDayInPeriod, which the base game computes as (currentDay - 1) % daysPerPeriod + 1 with daysPerPeriod defaulting to 1. On a default save that value is always 1, so a weekday schedule (five true, two false) ran every day because activeDays[1] was pinned true, and unticking day one stopped the pivot forever, with no error and nothing in the log.

The fix: IrrigationManager:dayOfWeekIndex derives the 1..7 index from the monotonic day modulo 7, never from currentDayInPeriod, so the index actually advances day to day and the weekend-off entries are reachable. The schedule now honours the days the player actually picked.

This is the defect Claude(A) certified on 2026-08-08 at the decompiled base game (Environment.lua:360/381), the second half of the F159/F160 pair. F159 (the skipped-hours charge) is already closed in shipped code; this closes F160.

Verified: 17 new assertions (scs160_schedule_day_index_test.lua): the index advances 1..7 from the monotonic day and ignores the pinned currentDayInPeriod, a weekday schedule rests on Saturday and Sunday, and the mirror case (a schedule active only on Wednesday) runs on Wednesday instead of never. Full suite 465/0, syntax and lint clean. Built and deployed as 1.2.5.71. Not yet observed in a running game.

The TaxMod mirror (its irrigation-expense day index) ships as a companion PR on FS25_TaxMod, so the accrual lands on the same days SCS actually runs a system.
