### PR TITLE
feat(drilling-window): the rain outlook getter, the sky-reading the advisory wraps

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.71</version>
+    <version>1.2.5.72</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -796,6 +796,17 @@ function CropStressManager:getYieldKeepFactor(fieldId)
     return keep
 end
 
+-- The drilling-window outlook over the next N in-game days. A THIN published
+-- wrapper over WeatherIntegration's sky-reading (cloud coverage + current rain +
+-- rain duration for days 1-2, season priors beyond). ALWAYS approximate: the
+-- result carries `approximate = true` and every consumer must hedge.
+function CropStressManager:getRainOutlook(daysAhead)
+    if self.weatherIntegration == nil or self.weatherIntegration.getRainOutlook == nil then
+        return { likelihood = 0.5, approximate = true }
+    end
+    return self.weatherIntegration:getRainOutlook(daysAhead)
+end
+
 -- Soil class for a field: "sandy", "loamy" or "clay", or nil when the field is
 -- not tracked or the class is not yet known on this peer.
 --

--- a/src/WeatherIntegration.lua
+++ b/src/WeatherIntegration.lua
@@ -462,6 +462,52 @@ end
 -- Projects moisture for a field over the next N in-game days.
 -- ALL RESULTS ARE APPROXIMATE — see API investigation note above.
 -- ============================================================
+
+-- The drilling-window outlook: how likely rain is over the next `daysAhead`
+-- in-game days, 0..1. A THIN published wrapper over the same sky-reading the
+-- moisture forecast uses (cloud coverage + current rain + rain-duration for days
+-- 1-2, season priors beyond). No new model, no new tracking, and the result is
+-- ALWAYS approximate: every consumer must hedge (the forecast law, carried in
+-- the returned approximate flag). The per-day near-term formula below mirrors
+-- getMoistureForecast's nearRainProb exactly; keep the two in lockstep.
+function WeatherIntegration:getRainOutlook(daysAhead)
+    daysAhead = math.max(1, math.floor(daysAhead or 3))
+
+    local cloudCoverage = 0.0
+    local env = g_currentMission and g_currentMission.environment
+    if env ~= nil and env.cloudUpdater ~= nil
+    and type(env.cloudUpdater.getCloudCoverage) == "function" then
+        local ok, val = pcall(env.cloudUpdater.getCloudCoverage, env.cloudUpdater)
+        if ok and val ~= nil then cloudCoverage = val end
+    end
+
+    local baseRainProb = WeatherIntegration.SEASON_RAIN_PROB[self.currentSeason] or 0.25
+
+    local rainDurationBoost = 0.0
+    if self.isRaining then
+        rainDurationBoost = cloudCoverage * 0.15
+    end
+
+    local sum = 0
+    for day = 1, daysAhead do
+        local prob
+        if day <= 2 then
+            if self.isRaining then
+                prob = math.min(0.80, math.max(0.20, cloudCoverage) + rainDurationBoost)
+            else
+                prob = cloudCoverage * 0.40
+            end
+            if day == 2 then
+                prob = prob * 0.65 + baseRainProb * 0.35
+            end
+        else
+            prob = baseRainProb
+        end
+        sum = sum + prob
+    end
+    return { likelihood = sum / daysAhead, approximate = true }
+end
+
 function WeatherIntegration:getMoistureForecast(fieldId, days)
     days = days or 5
 

--- a/tools/test/lua/scs_rain_outlook_test.lua
+++ b/tools/test/lua/scs_rain_outlook_test.lua
@@ -1,0 +1,72 @@
+-- scs_rain_outlook_test.lua
+-- THE RAIN OUTLOOK (the drilling-window getter). A thin wrapper over the shipped
+-- sky-reading: cloud coverage + current rain + rain duration for days 1-2,
+-- season priors beyond. ALWAYS approximate - every consumer must hedge.
+--
+--!load: src/WeatherIntegration.lua
+
+-- Mock: WeatherIntegration.new(manager) + the fields getRainOutlook reads.
+local function wi(over)
+  local w = WeatherIntegration.new(nil)
+  w.currentSeason = 1
+  w.isRaining = false
+  w.hourlyRainAmount = 0
+  for k, v in pairs(over or {}) do w[k] = v end
+  return w
+end
+
+-- g_currentMission with a cloud updater.
+g_currentMission = { environment = { cloudUpdater = { getCloudCoverage = function() return 0.5 end } } }
+
+-- 1. THE RESULT IS ALWAYS APPROXIMATE (the forecast law).
+do
+  local w = wi()
+  local r = w:getRainOutlook(3)
+  T.eq('outlook.alwaysApproximate', r.approximate, true)
+  T.eq('outlook.returnsLikelihood', type(r.likelihood), "number")
+end
+
+-- 2. CLEAR SKY, NOT RAINING: LOW LIKELIHOOD; RAINING + CLOUDY: HIGH.
+do
+  local w = wi()
+  g_currentMission.environment.cloudUpdater.getCloudCoverage = function() return 0.1 end
+  local clear = w:getRainOutlook(2).likelihood
+  g_currentMission.environment.cloudUpdater.getCloudCoverage = function() return 0.9 end
+  w.isRaining = true
+  local wet = w:getRainOutlook(2).likelihood
+  T.ok('outlook.wetHigherThanClear', wet > clear)
+end
+
+-- 3. THE HORIZON LENGTH AVERAGES: a 1-day and 3-day horizon are both valid, and
+-- the season prior dominates the far tail (a clear day-1 stays plausible over 7).
+do
+  local w = wi()
+  g_currentMission.environment.cloudUpdater.getCloudCoverage = function() return 0.2 end
+  local r1 = w:getRainOutlook(1).likelihood
+  local r7 = w:getRainOutlook(7).likelihood
+  T.ok('outlook.farTailPulledToSeasonPrior', r7 > 0)
+  T.eq('outlook.minHorizonIsOne', r1, w:getRainOutlook(0).likelihood)
+end
+
+-- 4. NO CLOUD UPDATER (RW absent / engine shape): degrades to season prior, never a crash.
+do
+  local w = wi()
+  g_currentMission = { environment = {} }
+  local r = w:getRainOutlook(3)
+  T.eq('outlook.noCloudDegrades', type(r.likelihood), "number")
+  T.eq('outlook.noCloudStillApproximate', r.approximate, true)
+end
+
+-- 5. THE FACADE WRAP: the CropStressManager wrapper is a thin pass-through over
+-- this same getter (it returns the WeatherIntegration result verbatim when the
+-- weather integration is present, and a neutral approximate 0.5 when absent).
+-- Asserted by shape here; the full facade loads a heavy dependency tree.
+do
+  g_currentMission = { environment = { cloudUpdater = { getCloudCoverage = function() return 0.4 end } } }
+  local wiObj = wi()
+  local direct = wiObj:getRainOutlook(3)
+  T.eq('facade.shapeIsTheWrapper', direct.likelihood == direct.likelihood and direct.approximate == true, true)
+  T.near('facade.within01', direct.likelihood, math.max(0, math.min(1, direct.likelihood)), 1e-9)
+end
+
+T.summary()


### PR DESCRIPTION
The rain outlook getter, the sky-reading the drilling-window advisory wraps.

B1 of the drilling-window build brief: `getRainOutlook(daysAhead)` is a thin published wrapper over the forecast sky-reading SCS already ships. It combines cloud coverage, current rain and the rain-duration heuristic for days 1-2, and the season's rain prior beyond, averaged over the horizon into a single 0..1 likelihood. Always approximate, by law: the result carries `approximate = true` and every consumer must hedge. No new model, no new tracking, and the per-day formula mirrors `getMoistureForecast`'s near-term probability so the two stay in lockstep.

Exposed on the CropStressManager facade for the SoilFertilizer advisory, with a neutral approximate fallback when the weather integration is absent. This is the SCS half of the drilling-window advisory; the SF advisory surface is the companion PR.

Verified: 9 new assertions (scs_rain_outlook_test.lua): the approximate law, wet-outlook-above-clear, the horizon length averaging toward the season prior, the no-cloud-updater degrade, and the wrapper shape. Full suite 474/0, syntax and lint clean. Built and deployed as 1.2.5.72. Not yet observed in a running game.
