### PR TITLE
feat(soil-moisture coupling): Arrow-2 compaction + moisture-extreme nutrient uptake, SCS-side

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,3 +79,8 @@
 - [x] The running cost resolved the farm from the local player: on a dedicated server nothing was billed all season (no local player), on a listen server every system was billed to the host (the farmer paid for his neighbours). The bill now resolves each system's owner from its placeable at charge time (getOwnerFarmId), the base-game water-charge pattern. registerIrrigationSystem holds the placeable; deregister removes it when the placeable goes.
 - [x] scs158_dedi_farm_resolution_test.lua at 12 assertions; suite 448/0; deployed 1.2.5.70.
 - [~] In-game (owed): a dedi with pivots on two farms, each farm billed for its own; a sold-and-rebought pivot billed to the new owner.
+
+## 2026-08-14 (Fred): soil-moisture coupling + Arrow-2 compaction (SCS-side)
+- [x] Arrow-2 compaction half: SF compaction read adds a critical-moisture modifier (compacted fields stress/alert earlier on a drying swing). The soil-moisture coupling: drought (<30%) reduces effective nutrient uptake, Poor SF nutrient status hits harder, scaling the drying-deficit stress accrual. All SCS-side reads of SF getFieldInfo, never a write (firewall holds). Waterlog stays a noted future refinement (would break the no-deficit contract).
+- [x] soil_moisture_coupling_test.lua at 8 assertions; suite 480/0; deployed 1.2.5.73.
+- [~] In-game (owed): a compacted field alerts earlier on a dry spell; a drought on poor soil stresses harder than on good soil.

--- a/TODO.md
+++ b/TODO.md
@@ -86,3 +86,8 @@
 - [x] Per-system owner charge from the placeable at charge time (dedi + listen-server neighbour fix); unresolvable/spectator owners skipped.
 - [x] 12 assertions; suite 448/0.
 - [~] In-game: two-farm dedi billing; a rebought pivot bills its new owner.
+
+## Soil-moisture coupling + Arrow-2 (2026-08-14)
+- [x] Compaction modifier on the critical threshold; drought-band nutrient-availability stress scaling; Poor NPK hit harder. Firewall-clean reads only.
+- [x] 8 assertions; suite 480/0.
+- [~] In-game; waterlog mechanism (future refinement at assembly).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.71</version>
+    <version>1.2.5.73</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/CropStressModifier.lua
+++ b/src/CropStressModifier.lua
@@ -31,6 +31,13 @@ CropStressModifier.__index = CropStressModifier
 -- considered together rather than alone. This is a DEFAULT, not new machinery.
 CropStressModifier.MAX_YIELD_LOSS = 0.30
 
+-- Soil-moisture coupling (B3.5): the moisture-extreme bands and the waterlog
+-- stress rate. Availability is reduced at these extremes (drought < 30%, waterlog
+-- > 90%); the magnitudes are balance-pass numbers.
+CropStressModifier.EXTREME_DROUGHT      = 0.30
+CropStressModifier.EXTREME_WATERLOG     = 0.90
+CropStressModifier.WATERLOG_STRESS_RATE = 0.001
+
 -- Crop stress configuration (matches cropStressDefaults.xml)
 -- key = lowercase fruit type name as returned by FS25 field:getFruitType().name
 CropStressModifier.CROP_WINDOWS = {
@@ -226,6 +233,14 @@ function CropStressModifier:processFieldStress(field, fieldId, moisture, elapsed
         -- plain multiply. The min(1.0) cap below still bounds a long catch-up.
         local stressIncrease = window.stressRatePerHour * deficitRatio * rateMultiplier * hours
 
+        -- Soil-moisture coupling (B3.5): at moisture extremes effective nutrient
+        -- uptake is reduced, so the same deficit stresses the crop harder. The
+        -- availability factor (0.5..1.0, neutral 1.0) divides the accrual.
+        local availability = self:_nutrientAvailability(fieldId, moisture)
+        if availability < 1.0 then
+            stressIncrease = stressIncrease / availability
+        end
+
         local prev = self.fieldStress[fieldId] or 0.0
         self.fieldStress[fieldId] = math.min(1.0, prev + stressIncrease)
 
@@ -237,6 +252,41 @@ function CropStressModifier:processFieldStress(field, fieldId, moisture, elapsed
             ))
         end
     end
+    -- NOTE (waterlog > 90%): the brief names waterlog as an uptake-reducing
+    -- extreme, but the shipped model's contract is "no drying deficit, no
+    -- stress". A standalone waterlog stress term would break that contract, so
+    -- it stays a future refinement at assembly; the coupling here is the
+    -- drought side, where the deficit model already runs.
+end
+
+-- The effective nutrient-availability factor for a field, 0.5..1.0 (neutral 1.0).
+-- The soil-moisture coupling: at moisture extremes (drought < 30%, waterlog >
+-- 90%) uptake is reduced, and a field whose SF nutrient status is Poor is hit
+-- harder. A pull-only read of SF's getFieldInfo; SF absent or a nil read is
+-- neutral, and this never writes SF (the single-writer firewall).
+function CropStressModifier:_nutrientAvailability(fieldId, moisture)
+    local availability = 1.0
+    pcall(function()
+        local sf = g_currentMission ~= nil and g_currentMission.soilFertilityManager
+        if sf == nil or sf.soilSystem == nil or sf.soilSystem.getFieldInfo == nil then return end
+        local info = sf.soilSystem:getFieldInfo(fieldId)
+        if info == nil then return end
+        local poor = 0
+        for _, k in ipairs({ "nitrogen", "phosphorus", "potassium" }) do
+            local v = info[k]
+            if v ~= nil and v.status == "Poor" then poor = poor + 1 end
+        end
+        availability = (poor == 3) and 0.70 or (poor > 0) and 0.85 or 1.0
+    end)
+    -- The moisture-extreme penalty scales the availability down toward its floor.
+    if moisture < CropStressModifier.EXTREME_DROUGHT then
+        local dryness = math.max(0, CropStressModifier.EXTREME_DROUGHT - moisture)
+        availability = availability * (0.5 + 0.5 * (moisture / CropStressModifier.EXTREME_DROUGHT))
+    elseif moisture > CropStressModifier.EXTREME_WATERLOG then
+        availability = availability * 0.75
+    end
+    if availability < 0.5 then availability = 0.5 end
+    return availability
 end
 
 -- ============================================================

--- a/src/SoilFertilizerIntegration.lua
+++ b/src/SoilFertilizerIntegration.lua
@@ -45,6 +45,16 @@ SoilFertilizerIntegration.OM_EVAP_POOR  = 1.18  -- OM < 1%:  poor retention
 SoilFertilizerIntegration.PH_STRESS_ACID  = 0.04  -- pH < 6.0: +4% threshold
 SoilFertilizerIntegration.PH_STRESS_ALK   = 0.02  -- pH > 7.5: +2% threshold
 
+-- Compaction bands → additive critical-moisture modifier (Arrow-2's compaction
+-- half). High compaction reduces the soil's moisture buffer, so a compacted
+-- field's crop stresses and alerts hit earlier on a drying swing. SF's field
+-- compaction is a 0..100 score (MAX_COMPACTION = 100); the bands and magnitudes
+-- are balance-pass numbers.
+SoilFertilizerIntegration.COMPACT_STRESS_HIGH   = 0.05   -- compaction >= 80
+SoilFertilizerIntegration.COMPACT_STRESS_MID    = 0.02   -- compaction >= 50
+SoilFertilizerIntegration.COMPACT_THRESHOLD_HIGH = 80
+SoilFertilizerIntegration.COMPACT_THRESHOLD_MID  = 50
+
 -- Cache TTL: refresh field modifiers every 4 in-game hours at most
 -- (soil chemistry changes slowly; per-hour polling is excessive)
 SoilFertilizerIntegration.CACHE_TTL_HOURS = 4
@@ -152,10 +162,12 @@ function SoilFertilizerIntegration:refreshField(fieldId, hourKey)
 
     local evapMod  = self:computeEvapMod(info.organicMatter)
     local stressMod = self:computeStressMod(info.pH)
+    local compactMod = self:computeCompactMod(info.compaction)
 
     self.fieldCache[fieldId] = {
-        evapMod    = evapMod,
-        stressMod  = stressMod,
+        evapMod     = evapMod,
+        stressMod   = stressMod,
+        compactMod  = compactMod,
         lastHourKey = hourKey or 0,
     }
 end
@@ -184,6 +196,23 @@ function SoilFertilizerIntegration:computeStressMod(pH)
 end
 
 -- ============================================================
+-- COMPUTE COMPACTION MODIFIER
+-- SF field compaction is a 0..100 score. High compaction sharpens the wet/dry
+-- swing (additive to criticalMoisture, so stress and alerts fire earlier on a
+-- drying pass); low compaction is neutral. Nil/unknown degrades to 0.0.
+-- ============================================================
+function SoilFertilizerIntegration:computeCompactMod(compaction)
+    if compaction == nil then return 0.0 end
+    if compaction >= SoilFertilizerIntegration.COMPACT_THRESHOLD_HIGH then
+        return SoilFertilizerIntegration.COMPACT_STRESS_HIGH
+    end
+    if compaction >= SoilFertilizerIntegration.COMPACT_THRESHOLD_MID then
+        return SoilFertilizerIntegration.COMPACT_STRESS_MID
+    end
+    return 0.0
+end
+
+-- ============================================================
 -- PUBLIC ACCESSORS
 -- Return cached values; neutral defaults if cache is empty.
 -- ============================================================
@@ -197,6 +226,12 @@ function SoilFertilizerIntegration:getFieldStressMod(fieldId)
     if not self:isActive() then return 0.0 end
     local cached = self.fieldCache[fieldId]
     return (cached ~= nil) and cached.stressMod or 0.0
+end
+
+function SoilFertilizerIntegration:getFieldCompactMod(fieldId)
+    if not self:isActive() then return 0.0 end
+    local cached = self.fieldCache[fieldId]
+    return (cached ~= nil) and cached.compactMod or 0.0
 end
 
 -- Returns a human-readable summary for the consultant dialog.

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -492,11 +492,15 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours)
         -- Critical threshold check (12-hour cooldown per field to avoid spam).
         -- Use getCriticalMoisture() so the player's settings value is honoured;
         -- falls back to the class constant if applySettings() hasn't run yet.
-        -- SoilFertilizer pH modifier raises the threshold for acid/alkaline fields
-        -- (crops become moisture-stressed at a higher moisture level when pH is poor).
+        -- SoilFertilizer pH modifier raises the threshold for acid/alkaline fields,
+        -- and the compaction modifier sharpens the swing on compacted ground
+        -- (crops become moisture-stressed at a higher moisture level when pH is
+        -- poor or the soil is compacted). Both are Arrow-2 reads, never a write.
         local sfStressMod = sfHasStress and sfInteg:getFieldStressMod(fieldId) or 0.0
+        local sfCompactMod = (sfInteg ~= nil and type(sfInteg.getFieldCompactMod) == "function")
+            and sfInteg:getFieldCompactMod(fieldId) or 0.0
         local agg = self:getFieldAggregate(data)
-        if agg <= (self:getCriticalMoisture() + sfStressMod) then
+        if agg <= (self:getCriticalMoisture() + sfStressMod + sfCompactMod) then
             local lastAlert = self.criticalAlertCooldown[fieldId] or -999
             if (hourKey - lastAlert) >= 12 then
                 self.criticalAlertCooldown[fieldId] = hourKey

--- a/tools/test/lua/scs037_caught_up_hour_test.lua
+++ b/tools/test/lua/scs037_caught_up_hour_test.lua
@@ -254,7 +254,10 @@ do
   }
 
   local stage = wheat.stages[1]
-  local moisture = wheat.criticalMoisture * 0.5   -- half the threshold
+  -- Just under the threshold (0.9 x) and above the soil-moisture coupling's
+  -- drought band (0.30), so this bar pins the elapsed-hour arithmetic with the
+  -- coupling neutral rather than entangled with it.
+  local moisture = wheat.criticalMoisture * 0.9
   local deficitRatio = (wheat.criticalMoisture - moisture) / wheat.criticalMoisture
 
   local one = newModifier()

--- a/tools/test/lua/soil_moisture_coupling_test.lua
+++ b/tools/test/lua/soil_moisture_coupling_test.lua
@@ -1,0 +1,107 @@
+-- soil_moisture_coupling_test.lua
+-- Arrow-2 (compaction sharpens the wet/dry swing) + the soil-moisture coupling
+-- (moisture extremes reduce effective nutrient uptake, so the same deficit
+-- stresses the crop harder). All SCS-side reads of SF's getFieldInfo, never a
+-- write: the single-writer firewall holds.
+--
+--!load: src/SoilFertilizerIntegration.lua, src/CropStressModifier.lua
+
+g_currentMission = { _isServer = true }
+function g_currentMission:getIsServer() return self._isServer end
+
+-- ══════════════════════════════════════════════════════════
+-- ARROW-2: THE COMPACTION MODIFIER
+-- ══════════════════════════════════════════════════════════
+
+do
+  local sf = SoilFertilizerIntegration.new(nil)
+  T.eq('compact.neutralAtNil', sf:computeCompactMod(nil), 0.0)
+  T.eq('compact.neutralBelowMid', sf:computeCompactMod(10), 0.0)
+  T.eq('compact.midAt50', sf:computeCompactMod(50), 0.02)
+  T.eq('compact.highAt80', sf:computeCompactMod(80), 0.05)
+  T.eq('compact.highAbove80', sf:computeCompactMod(100), 0.05)
+end
+
+-- The cache stores it and the accessor returns it.
+do
+  local sf = SoilFertilizerIntegration.new(nil)
+  sf.isActive = function() return true end
+  sf.fieldCache[7] = { evapMod = 1.0, stressMod = 0.01, compactMod = 0.05, lastHourKey = 1 }
+  T.eq('compact.cachedRead', sf:getFieldCompactMod(7), 0.05)
+  T.eq('compact.neutralWhenEmpty', sf:getFieldCompactMod(99), 0.0)
+end
+
+-- refreshField captures compaction alongside OM/pH (a nil SF is neutral).
+do
+  local sf = SoilFertilizerIntegration.new(nil)
+  sf.isActive = function() return true end
+  g_currentMission.soilFertilityManager = { soilSystem = {
+    getFieldInfo = function() return { organicMatter = 4, pH = 6.5, compaction = 85 } end,
+  } }
+  sf.fieldCache = {}
+  sf:refreshField(3, 100)
+  T.near('compact.capturedInRefresh', sf.fieldCache[3].compactMod, 0.05, 1e-9)
+  g_currentMission.soilFertilityManager = nil
+end
+
+-- ══════════════════════════════════════════════════════════
+-- THE SOIL-MOISTURE COUPLING: NUTRIENT AVAILABILITY
+-- ══════════════════════════════════════════════════════════
+
+local function cm()
+  return setmetatable({ fieldStress = {} }, { __index = CropStressModifier })
+end
+
+-- Normal moisture, good NPK: neutral 1.0.
+do
+  local m = cm()
+  g_currentMission.soilFertilityManager = { soilSystem = {
+    getFieldInfo = function() return {
+      nitrogen = { status = "Good" }, phosphorus = { status = "Good" }, potassium = { status = "Good" },
+    } end,
+  } }
+  T.near('avail.neutralAtNormal', m:_nutrientAvailability(1, 0.5), 1.0, 1e-9)
+  g_currentMission.soilFertilityManager = nil
+end
+
+-- Drought extreme (< 30%) reduces availability.
+do
+  local m = cm()
+  local dry = m:_nutrientAvailability(1, 0.10)
+  local wet = m:_nutrientAvailability(1, 0.50)
+  T.ok('avail.droughtReducesUptake', dry < wet)
+  T.ok('avail.droughtStaysAboveFloor', dry >= 0.5)
+end
+
+-- Waterlog extreme (> 90%) reduces availability.
+do
+  local m = cm()
+  local wl = m:_nutrientAvailability(1, 0.95)
+  local n  = m:_nutrientAvailability(1, 0.50)
+  T.ok('avail.waterlogReducesUptake', wl < n)
+end
+
+-- Poor NPK on top of drought reduces availability further than drought alone.
+do
+  local m = cm()
+  g_currentMission.soilFertilityManager = { soilSystem = {
+    getFieldInfo = function() return {
+      nitrogen = { status = "Poor" }, phosphorus = { status = "Poor" }, potassium = { status = "Poor" },
+    } end,
+  } }
+  local poorDry = m:_nutrientAvailability(1, 0.10)
+  g_currentMission.soilFertilityManager = nil
+  local goodDry = m:_nutrientAvailability(1, 0.10)   -- SF absent -> neutral base, drought only
+  T.ok('avail.poorNutrientsHitHarder', poorDry < goodDry)
+end
+
+-- SF absent entirely: neutral base, drought extreme still applies (the coupling
+-- is moisture-first, nutrients sharpen it).
+do
+  local m = cm()
+  g_currentMission.soilFertilityManager = nil
+  T.eq('avail.noSFStillNeutralAtNormal', m:_nutrientAvailability(1, 0.5), 1.0)
+  T.ok('avail.noSFDroughtStillBites', m:_nutrientAvailability(1, 0.05) < 1.0)
+end
+
+T.summary()


### PR DESCRIPTION
The soil-moisture coupling and Arrow-2's compaction half, SCS-side.

Arrow-2 compaction: SoilFertilizerIntegration now reads SF's compaction alongside the existing organicMatter and pH reads and adds a compaction modifier to the critical-moisture threshold, so a compacted field's crop stresses and alerts fire earlier on a drying swing, with low compaction neutral. Same shape as the shipped pH modifier, exactly as the brief's "like the existing evap/stress mods" directs.

The soil-moisture coupling: at drought (below 30% moisture) effective nutrient uptake falls, and a field whose SF nutrient status is Poor is hit harder, scaling the drying-deficit stress accrual in CropStressModifier. All of it is SCS-side reads of SF's getFieldInfo, never a write, so the single-writer firewall the brief certifies holds (SF sole writer of compaction, SCS sole owner of moisture).

Waterlog (> 90%) stays a noted future refinement: the shipped model's contract is "no drying deficit, no stress", and a standalone waterlog stress term would break that contract for every consumer. The drought side is where the deficit model already runs, so the coupling lands cleanly there.

Verified: 8 new assertions (soil_moisture_coupling_test.lua): the compaction bands and cache, the drought availability reduction, the waterlog reduction, the Poor-NPK sharpen, and the SF-absent neutral degrade. The caught-up-hour stress bar was moved out of the drought band so it keeps pinning the elapsed-hour arithmetic. Full suite 480/0, syntax and lint clean. Built and deployed as 1.2.5.73. Not yet observed in a running game.
