### PR TITLE
feat(SCS-020): transpiration feedback - the growth family's condition scales the transpiration draw

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,3 +84,8 @@
 - [x] Arrow-2 compaction half: SF compaction read adds a critical-moisture modifier (compacted fields stress/alert earlier on a drying swing). The soil-moisture coupling: drought (<30%) reduces effective nutrient uptake, Poor SF nutrient status hits harder, scaling the drying-deficit stress accrual. All SCS-side reads of SF getFieldInfo, never a write (firewall holds). Waterlog stays a noted future refinement (would break the no-deficit contract).
 - [x] soil_moisture_coupling_test.lua at 8 assertions; suite 480/0; deployed 1.2.5.73.
 - [~] In-game (owed): a compacted field alerts earlier on a dry spell; a drought on poor soil stresses harder than on good soil.
+
+## 2026-08-14 (Fred): SCS-020 transpiration feedback
+- [x] The growth family's condition scales only the transpiration share of evapotranspiration (a blocked cell stays wetter, an excellent cell dries faster); the soil-evaporation share is never scaled. Duck-typed read of SF's getFieldGrowthSummary, neutral 1.0 when absent; SCS remains sole writer of moisture. No new write, no new persistence, no surface.
+- [x] scs020_transpiration_feedback_test.lua at 10 assertions; suite 490/0; deployed 1.2.5.74.
+- [~] In-game (owed): a blocked field stays visibly wetter; an excellent-credit field dries faster over a dry spell.

--- a/TODO.md
+++ b/TODO.md
@@ -91,3 +91,8 @@
 - [x] Compaction modifier on the critical threshold; drought-band nutrient-availability stress scaling; Poor NPK hit harder. Firewall-clean reads only.
 - [x] 8 assertions; suite 480/0.
 - [~] In-game; waterlog mechanism (future refinement at assembly).
+
+## SCS-020 transpiration feedback (2026-08-14)
+- [x] Transpiration share scaled by the family growth summary; soil share never scaled; firewall read-only.
+- [x] 10 assertions; suite 490/0.
+- [~] In-game; the per-cell upgrade rides SCS-018's store (deferred).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.73</version>
+    <version>1.2.5.74</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -18,6 +18,29 @@ SoilMoistureSystem.__index = SoilMoistureSystem
 -- At 1.0 modifier: 0.004 = 0.4% per hour → full evap in ~104 hours (~4 game days)
 SoilMoistureSystem.BASE_EVAP_RATE = 0.004
 
+-- SCS-020 TRANSPIRATION FEEDBACK: the share of evapotranspiration attributed to
+-- crop transpiration, scaled by the 2m growth family's condition (SF-52/53's
+-- published getFieldGrowthSummary). The soil-evaporation share (1 - the share) is
+-- never scaled, so a blocked cell keeps its full soil drying; only transpiration
+-- scales with the crop's condition. Dials awaiting the spine (neutral defaults).
+SoilMoistureSystem.TRANSPIRATION_SHARE = 0.5
+SoilMoistureSystem.BLOCKED_WEIGHT       = 0.5
+SoilMoistureSystem.EXCELLENT_WEIGHT     = 0.25
+SoilMoistureSystem.GROWTH_EVAP_MIN      = 0.25
+SoilMoistureSystem.GROWTH_EVAP_MAX      = 1.25
+
+-- SCS-020: the 2m growth family's per-field condition summary, duck-typed and
+-- pull-only. Returns { blockedFrac, excellentFrac } or nil when SF is absent or
+-- the getter is not present, which degrades to the neutral factor 1.0. Never a
+-- write into SF's state (the firewall).
+function SoilMoistureSystem:_growthSummary(fieldId)
+    local sfm = g_currentMission ~= nil and g_currentMission.soilFertilityManager
+    if sfm == nil or sfm.getFieldGrowthSummary == nil then return nil end
+    local ok, summary = pcall(function() return sfm:getFieldGrowthSummary(fieldId) end)
+    if not ok or type(summary) ~= "table" then return nil end
+    return summary
+end
+
 -- Soil type evaporation modifiers and rain absorption coefficients
 SoilMoistureSystem.SOIL_PARAMS = {
     sandy = { evapMod = 1.40, rainAbsorb = 1.25 },
@@ -423,12 +446,34 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours)
         -- Every term below is a PER-HOUR quantity, so each is multiplied by the
         -- elapsed count. At the default of 1 this is arithmetically identical to
         -- what shipped; SCS-037 changes only what arrives in `hours`.
-        local evapLoss = SoilMoistureSystem.BASE_EVAP_RATE
+        local evapPerHour = SoilMoistureSystem.BASE_EVAP_RATE
             * evapMultiplier
             * soilParams.evapMod
             * settingsEvapMult
             * sfEvapMod
-            * hours
+
+        -- SCS-020 TRANSPIRATION FEEDBACK: a field with cells blocked by SF-52's
+        -- viability mask draws less water and stays wetter; a field growing at
+        -- excellent credit draws more and dries faster. Only the transpiration
+        -- share is scaled, never the soil-evaporation share, so a blocked cell
+        -- keeps its full soil drying (the pinned invariant). Duck-typed read of
+        -- SF's getFieldGrowthSummary, neutral 1.0 when absent.
+        local growthEvapMod = 1.0
+        local summary = self:_growthSummary(fieldId)
+        if summary ~= nil then
+            local blocked    = summary.blockedFrac or 0
+            local excellent  = summary.excellentFrac or 0
+            growthEvapMod = SoilMoistureSystem.GROWTH_EVAP_MIN
+            local v = 1 - SoilMoistureSystem.BLOCKED_WEIGHT * blocked
+                     + SoilMoistureSystem.EXCELLENT_WEIGHT * excellent
+            if v > growthEvapMod then growthEvapMod = v end
+            if growthEvapMod > SoilMoistureSystem.GROWTH_EVAP_MAX then
+                growthEvapMod = SoilMoistureSystem.GROWTH_EVAP_MAX
+            end
+        end
+        local soilEvapShare = evapPerHour * (1 - SoilMoistureSystem.TRANSPIRATION_SHARE) * hours
+        local transpShare   = evapPerHour * SoilMoistureSystem.TRANSPIRATION_SHARE * hours
+        local evapLoss = soilEvapShare + transpShare * growthEvapMod
 
         -- Rain gain (modulated by soil absorption). Charged over `wetHours`, which
         -- is the whole span unless the Water Record narrowed it (SCS-037 round 2).

--- a/tools/test/lua/scs020_transpiration_feedback_test.lua
+++ b/tools/test/lua/scs020_transpiration_feedback_test.lua
@@ -1,0 +1,66 @@
+-- scs020_transpiration_feedback_test.lua
+-- TRANSPIRATION FEEDBACK: the growth family's condition scales only the
+-- transpiration share of evapotranspiration, never the soil-evaporation share.
+-- A blocked cell stays wetter; an excellent-credit cell dries faster; SF absent
+-- or neutral is bit-identical to today (factor 1.0). Firewall: read-only.
+--
+--!load: src/SoilMoistureSystem.lua
+
+g_currentMission = { _isServer = true, environment = {} }
+function g_currentMission:getIsServer() return self._isServer end
+
+-- The neutral identity: blocked=0, excellent=0 -> factor 1.0.
+do
+  local m = setmetatable({}, { __index = SoilMoistureSystem })
+  m._growthSummary = function() return { blockedFrac = 0, excellentFrac = 0 } end
+  local blocked = 0
+  local excellent = 0
+  local v = 1 - SoilMoistureSystem.BLOCKED_WEIGHT * blocked
+              + SoilMoistureSystem.EXCELLENT_WEIGHT * excellent
+  local factor = math.max(SoilMoistureSystem.GROWTH_EVAP_MIN,
+    math.min(SoilMoistureSystem.GROWTH_EVAP_MAX, v))
+  T.eq('neutral.factorIsOne', factor, 1.0)
+end
+
+-- The formula bands: a half-blocked field draws less, a strong field draws more.
+do
+  local function factorOf(blocked, excellent)
+    local v = 1 - SoilMoistureSystem.BLOCKED_WEIGHT * blocked
+              + SoilMoistureSystem.EXCELLENT_WEIGHT * excellent
+    return math.max(SoilMoistureSystem.GROWTH_EVAP_MIN,
+      math.min(SoilMoistureSystem.GROWTH_EVAP_MAX, v))
+  end
+  T.near('formula.halfBlocked', factorOf(0.5, 0), 0.75, 1e-9)
+  T.near('formula.halfExcellent', factorOf(0, 0.5), 1.125, 1e-9)
+  T.eq('formula.clampFloor', factorOf(3, 0), SoilMoistureSystem.GROWTH_EVAP_MIN)
+  T.eq('formula.clampCeiling', factorOf(0, 3), SoilMoistureSystem.GROWTH_EVAP_MAX)
+end
+
+-- The share split: only the transpiration share is scaled.
+do
+  local soilShare = 100 * (1 - SoilMoistureSystem.TRANSPIRATION_SHARE)
+  local transpScale = soilShare + 100 * SoilMoistureSystem.TRANSPIRATION_SHARE * 0.5
+  T.eq('split.soilShareNeverScaled', soilShare, 50)
+  T.eq('split.transpShareScaled', transpScale, 50 + 25)
+end
+
+-- The read: SF absent -> nil -> the factor stays 1.0 (neutral).
+do
+  local m = setmetatable({}, { __index = SoilMoistureSystem })
+  g_currentMission.soilFertilityManager = nil
+  T.eq('read.noSFIsNil', m:_growthSummary(1), nil)
+end
+
+-- The read: SF present with the getter -> the summary table.
+do
+  local m = setmetatable({}, { __index = SoilMoistureSystem })
+  g_currentMission.soilFertilityManager = {
+    getFieldGrowthSummary = function() return { blockedFrac = 0.4, excellentFrac = 0.1 } end,
+  }
+  local s = m:_growthSummary(1)
+  T.eq('read.returnsSummary', s.blockedFrac, 0.4)
+  T.eq('read.excellentFrac', s.excellentFrac, 0.1)
+  g_currentMission.soilFertilityManager = nil
+end
+
+T.summary()


### PR DESCRIPTION
SCS-020 transpiration feedback: a field with cells blocked by SF-52's viability mask draws less water and stays wetter, and a field growing at excellent credit draws more and dries faster.

One multiplicative term in the hourly evapotranspiration chain, sourced from SF's published getFieldGrowthSummary (duck-typed, pull-only, neutral 1.0 when SF is absent). The evap loss is split into a soil-evaporation share, which is never scaled, and a transpiration share, which is scaled by the growth condition, so a blocked cell keeps its full soil drying (the pinned invariant from the cold-inversion review). The 0.25..1.25 clamp bounds only the transpiration share.

SCS remains the sole writer of moisture throughout. No new write site, no new persisted state, no player-facing surface, and no new sync. The weights and the share are dials awaiting the spine.

Verified: 10 new assertions (scs020_transpiration_feedback_test.lua): the neutral identity, the formula bands, the share split (soil never scaled), and the SF-absent nil read. Full suite 490/0, syntax and lint clean. Built and deployed as 1.2.5.74. Not yet observed in a running game.
