### PR TITLE
Esc RF PDA: shared PRODUCTS–ROTATION freeze (clean)

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.74</version>
+    <version>1.2.5.75</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
-        <de>Saisonaler Pflanzenstress &amp; BewÃƒÂ¤sserungsmanager</de>
+        <de>Saisonaler Pflanzenstress &amp; BewÃƒÆ’Ã‚Â¤sserungsmanager</de>
         <fr>Stress saisonnier des cultures &amp; gestionnaire d'irrigation</fr>
         <it>Stress stagionale delle colture &amp; Gestore dell'irrigazione</it>
         <nl>Seizoensgebonden gewassstress &amp; irrigatiebeheer</nl>
-        <cz>Seasonal Crop Stress &amp; SprÃƒÂ¡vce zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­</cz>
-        <da>SÃƒÂ¦sonbetinget afgrÃƒÂ¸destress &amp; vandingsstyring</da>
+        <cz>Seasonal Crop Stress &amp; SprÃƒÆ’Ã‚Â¡vce zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­</cz>
+        <da>SÃƒÆ’Ã‚Â¦sonbetinget afgrÃƒÆ’Ã‚Â¸destress &amp; vandingsstyring</da>
     </title>
 
     <description>
@@ -19,133 +19,133 @@
 Each field tracks a soil moisture percentage (0-100%) that rises with rain and falls through evapotranspiration driven by temperature, season, and soil type. When moisture drops below crop-specific thresholds during critical growth windows, yield stress accumulates and reduces your harvest at season's end.
 
 FEATURES:
-Ã¢â‚¬Â¢ Per-field soil moisture simulation driven by real weather
-Ã¢â‚¬Â¢ Seasonal & temperature-adjusted evapotranspiration
-Ã¢â‚¬Â¢ Soil type modifiers: sandy drains fast, clay holds moisture
-Ã¢â‚¬Â¢ Crop-specific critical growth windows (wheat, corn, barley, canola, and more)
-Ã¢â‚¬Â¢ Yield reduction at harvest Ã¢â‚¬â€ up to 60% loss at maximum stress
-Ã¢â‚¬Â¢ Field moisture HUD overlay with 5-day forecast (press Shift+M to toggle)
-Ã¢â‚¬Â¢ Center-pivot and drip irrigation placeables with water pump infrastructure
-Ã¢â‚¬Â¢ Irrigation scheduling dialog Ã¢â‚¬â€ set active days and hourly window (Shift+I)
-Ã¢â‚¬Â¢ Crop Consultant dialog with risk summary and recommendations (Shift+C)
-Ã¢â‚¬Â¢ Optional integration with FS25_NPCFavor (Alex Chen, Agronomist NPC)
-Ã¢â‚¬Â¢ Optional integration with FS25_UsedPlus (used equipment marketplace)
-Ã¢â‚¬Â¢ Full save/load persistence of all field and irrigation state
-Ã¢â‚¬Â¢ Debug console commands (type csHelp in developer console)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Per-field soil moisture simulation driven by real weather
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Seasonal & temperature-adjusted evapotranspiration
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Soil type modifiers: sandy drains fast, clay holds moisture
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Crop-specific critical growth windows (wheat, corn, barley, canola, and more)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Yield reduction at harvest ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â up to 60% loss at maximum stress
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Field moisture HUD overlay with 5-day forecast (press Shift+M to toggle)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Center-pivot and drip irrigation placeables with water pump infrastructure
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigation scheduling dialog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â set active days and hourly window (Shift+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Crop Consultant dialog with risk summary and recommendations (Shift+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optional integration with FS25_NPCFavor (Alex Chen, Agronomist NPC)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optional integration with FS25_UsedPlus (used equipment marketplace)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Full save/load persistence of all field and irrigation state
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug console commands (type csHelp in developer console)
         ]]></en>
-        <de><![CDATA[FÃƒÂ¼gt Bodenfeuchteverfolgung, Pflanzenstresssimulation und BewÃƒÂ¤sserungsmanagement zu Farming Simulator 25 hinzu.
+        <de><![CDATA[FÃƒÆ’Ã‚Â¼gt Bodenfeuchteverfolgung, Pflanzenstresssimulation und BewÃƒÆ’Ã‚Â¤sserungsmanagement zu Farming Simulator 25 hinzu.
 
-Jedes Feld verfolgt einen Bodenfeuchteanteil (0Ã¢â‚¬â€œ100 %), der mit Regen steigt und durch Evapotranspiration (Temperatur, Jahreszeit, Bodentyp) sinkt. Wenn die Feuchte in kritischen Wachstumsphasen unter kultururspezifische Schwellenwerte fÃƒÂ¤llt, akkumuliert sich Trockenstress und reduziert den Ernteertrag am Saisonende.
+Jedes Feld verfolgt einen Bodenfeuchteanteil (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %), der mit Regen steigt und durch Evapotranspiration (Temperatur, Jahreszeit, Bodentyp) sinkt. Wenn die Feuchte in kritischen Wachstumsphasen unter kultururspezifische Schwellenwerte fÃƒÆ’Ã‚Â¤llt, akkumuliert sich Trockenstress und reduziert den Ernteertrag am Saisonende.
 
 FUNKTIONEN:
-Ã¢â‚¬Â¢ Bodenfeuchte-Simulation pro Feld, gesteuert durch das Spielwetter
-Ã¢â‚¬Â¢ Saisonale und temperaturbeeinflusste Evapotranspiration
-Ã¢â‚¬Â¢ Bodentyp-Modifikatoren: Sandig trocknet schnell aus, Tonig hÃƒÂ¤lt Feuchte
-Ã¢â‚¬Â¢ Kultuurspezifische kritische Wachstumsphasen (Weizen, Mais, Gerste, Raps u. v. m.)
-Ã¢â‚¬Â¢ Ertragsreduzierung bei der Ernte Ã¢â‚¬â€ bis zu 60 % Verlust bei maximalem Stress
-Ã¢â‚¬Â¢ Bodenfeuchte-HUD-Overlay mit 5-Tage-Prognose (Shift+M zum Ein-/Ausblenden)
-Ã¢â‚¬Â¢ KreisbewÃƒÂ¤sserung und TrÃƒÂ¶pfchenbewÃƒÂ¤sserung mit Wasserpumpen-Infrastruktur
-Ã¢â‚¬Â¢ BewÃƒÂ¤sserungszeitplan-Dialog Ã¢â‚¬â€ Aktivtage und Zeitfenster einstellen (Shift+I)
-Ã¢â‚¬Â¢ Pflanzenbergungs-Dialog mit RisikoÃƒÂ¼bersicht und Empfehlungen (Shift+C)
-Ã¢â‚¬Â¢ Optionale Integration mit FS25_NPCFavor (Alex Chen, Agrarberater-NPC)
-Ã¢â‚¬Â¢ Optionale Integration mit FS25_UsedPlus (Gebrauchtmarkt fÃƒÂ¼r Landmaschinen)
-Ã¢â‚¬Â¢ VollstÃƒÂ¤ndige Speicherung aller Feld- und BewÃƒÂ¤sserungsdaten
-Ã¢â‚¬Â¢ Debug-Konsolenbefehle (csHelp in der Entwicklerkonsole eingeben)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodenfeuchte-Simulation pro Feld, gesteuert durch das Spielwetter
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Saisonale und temperaturbeeinflusste Evapotranspiration
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodentyp-Modifikatoren: Sandig trocknet schnell aus, Tonig hÃƒÆ’Ã‚Â¤lt Feuchte
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Kultuurspezifische kritische Wachstumsphasen (Weizen, Mais, Gerste, Raps u. v. m.)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Ertragsreduzierung bei der Ernte ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â bis zu 60 % Verlust bei maximalem Stress
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodenfeuchte-HUD-Overlay mit 5-Tage-Prognose (Shift+M zum Ein-/Ausblenden)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ KreisbewÃƒÆ’Ã‚Â¤sserung und TrÃƒÆ’Ã‚Â¶pfchenbewÃƒÆ’Ã‚Â¤sserung mit Wasserpumpen-Infrastruktur
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ BewÃƒÆ’Ã‚Â¤sserungszeitplan-Dialog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Aktivtage und Zeitfenster einstellen (Shift+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Pflanzenbergungs-Dialog mit RisikoÃƒÆ’Ã‚Â¼bersicht und Empfehlungen (Shift+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionale Integration mit FS25_NPCFavor (Alex Chen, Agrarberater-NPC)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionale Integration mit FS25_UsedPlus (Gebrauchtmarkt fÃƒÆ’Ã‚Â¼r Landmaschinen)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VollstÃƒÆ’Ã‚Â¤ndige Speicherung aller Feld- und BewÃƒÆ’Ã‚Â¤sserungsdaten
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-Konsolenbefehle (csHelp in der Entwicklerkonsole eingeben)
         ]]></de>
-        <fr><![CDATA[Ajoute un suivi de l'humiditÃƒÂ© du sol, une simulation du stress hydrique et un gestionnaire d'irrigation ÃƒÂ  Farming Simulator 25.
+        <fr><![CDATA[Ajoute un suivi de l'humiditÃƒÆ’Ã‚Â© du sol, une simulation du stress hydrique et un gestionnaire d'irrigation ÃƒÆ’Ã‚Â  Farming Simulator 25.
 
-Chaque parcelle suit un pourcentage d'humiditÃƒÂ© du sol (0Ã¢â‚¬â€œ100 %) qui monte avec les pluies et descend par ÃƒÂ©vapotranspiration selon la tempÃƒÂ©rature, la saison et le type de sol. Lorsque l'humiditÃƒÂ© passe sous les seuils propres ÃƒÂ  chaque culture pendant les pÃƒÂ©riodes critiques de croissance, le stress hydrique s'accumule et rÃƒÂ©duit le rendement en fin de saison.
+Chaque parcelle suit un pourcentage d'humiditÃƒÆ’Ã‚Â© du sol (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) qui monte avec les pluies et descend par ÃƒÆ’Ã‚Â©vapotranspiration selon la tempÃƒÆ’Ã‚Â©rature, la saison et le type de sol. Lorsque l'humiditÃƒÆ’Ã‚Â© passe sous les seuils propres ÃƒÆ’Ã‚Â  chaque culture pendant les pÃƒÆ’Ã‚Â©riodes critiques de croissance, le stress hydrique s'accumule et rÃƒÆ’Ã‚Â©duit le rendement en fin de saison.
 
-FONCTIONNALITÃƒâ€°S :
-Ã¢â‚¬Â¢ Simulation d'humiditÃƒÂ© du sol par parcelle, pilotÃƒÂ©e par la mÃƒÂ©tÃƒÂ©o en temps rÃƒÂ©el
-Ã¢â‚¬Â¢ Ãƒâ€°vapotranspiration ajustÃƒÂ©e ÃƒÂ  la saison et ÃƒÂ  la tempÃƒÂ©rature
-Ã¢â‚¬Â¢ Modificateurs de type de sol : Sableux sÃƒÂ¨che vite, Argileux retient l'humiditÃƒÂ©
-Ã¢â‚¬Â¢ PÃƒÂ©riodes critiques de croissance propres ÃƒÂ  chaque culture (blÃƒÂ©, maÃƒÂ¯s, orge, colza, etc.)
-Ã¢â‚¬Â¢ RÃƒÂ©duction de rendement ÃƒÂ  la rÃƒÂ©colte Ã¢â‚¬â€ jusqu'ÃƒÂ  60 % de perte au stress maximal
-Ã¢â‚¬Â¢ Overlay HUD d'humiditÃƒÂ© du sol avec prÃƒÂ©visions 5 jours (Maj+M pour afficher/masquer)
-Ã¢â‚¬Â¢ Pivot central et goutte-ÃƒÂ -goutte avec infrastructure de pompe ÃƒÂ  eau
-Ã¢â‚¬Â¢ Programme d'irrigation Ã¢â‚¬â€ dÃƒÂ©finissez les jours actifs et la plage horaire (Maj+I)
-Ã¢â‚¬Â¢ Dialogue Conseiller cultural avec rÃƒÂ©sumÃƒÂ© des risques et recommandations (Maj+C)
-Ã¢â‚¬Â¢ IntÃƒÂ©gration optionnelle avec FS25_NPCFavor (Alex Chen, agronome PNJ)
-Ã¢â‚¬Â¢ IntÃƒÂ©gration optionnelle avec FS25_UsedPlus (marchÃƒÂ© de matÃƒÂ©riel d'occasion)
-Ã¢â‚¬Â¢ Sauvegarde complÃƒÂ¨te de l'ÃƒÂ©tat des parcelles et des systÃƒÂ¨mes d'irrigation
-Ã¢â‚¬Â¢ Commandes de dÃƒÂ©bogage en console (taper csHelp dans la console dÃƒÂ©veloppeur)
+FONCTIONNALITÃƒÆ’Ã¢â‚¬Â°S :
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulation d'humiditÃƒÆ’Ã‚Â© du sol par parcelle, pilotÃƒÆ’Ã‚Â©e par la mÃƒÆ’Ã‚Â©tÃƒÆ’Ã‚Â©o en temps rÃƒÆ’Ã‚Â©el
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ÃƒÆ’Ã¢â‚¬Â°vapotranspiration ajustÃƒÆ’Ã‚Â©e ÃƒÆ’Ã‚Â  la saison et ÃƒÆ’Ã‚Â  la tempÃƒÆ’Ã‚Â©rature
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Modificateurs de type de sol : Sableux sÃƒÆ’Ã‚Â¨che vite, Argileux retient l'humiditÃƒÆ’Ã‚Â©
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒÆ’Ã‚Â©riodes critiques de croissance propres ÃƒÆ’Ã‚Â  chaque culture (blÃƒÆ’Ã‚Â©, maÃƒÆ’Ã‚Â¯s, orge, colza, etc.)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ RÃƒÆ’Ã‚Â©duction de rendement ÃƒÆ’Ã‚Â  la rÃƒÆ’Ã‚Â©colte ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â jusqu'ÃƒÆ’Ã‚Â  60 % de perte au stress maximal
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Overlay HUD d'humiditÃƒÆ’Ã‚Â© du sol avec prÃƒÆ’Ã‚Â©visions 5 jours (Maj+M pour afficher/masquer)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Pivot central et goutte-ÃƒÆ’Ã‚Â -goutte avec infrastructure de pompe ÃƒÆ’Ã‚Â  eau
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Programme d'irrigation ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â dÃƒÆ’Ã‚Â©finissez les jours actifs et la plage horaire (Maj+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialogue Conseiller cultural avec rÃƒÆ’Ã‚Â©sumÃƒÆ’Ã‚Â© des risques et recommandations (Maj+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ IntÃƒÆ’Ã‚Â©gration optionnelle avec FS25_NPCFavor (Alex Chen, agronome PNJ)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ IntÃƒÆ’Ã‚Â©gration optionnelle avec FS25_UsedPlus (marchÃƒÆ’Ã‚Â© de matÃƒÆ’Ã‚Â©riel d'occasion)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Sauvegarde complÃƒÆ’Ã‚Â¨te de l'ÃƒÆ’Ã‚Â©tat des parcelles et des systÃƒÆ’Ã‚Â¨mes d'irrigation
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Commandes de dÃƒÆ’Ã‚Â©bogage en console (taper csHelp dans la console dÃƒÆ’Ã‚Â©veloppeur)
         ]]></fr>
-        <it><![CDATA[Aggiunge il monitoraggio dell'umiditÃƒÂ  del terreno, la simulazione dello stress da siccitÃƒÂ  e la gestione dell'irrigazione a Farming Simulator 25.
+        <it><![CDATA[Aggiunge il monitoraggio dell'umiditÃƒÆ’Ã‚Â  del terreno, la simulazione dello stress da siccitÃƒÆ’Ã‚Â  e la gestione dell'irrigazione a Farming Simulator 25.
 
-Ogni campo tiene traccia di una percentuale di umiditÃƒÂ  del terreno (0Ã¢â‚¬â€œ100 %) che sale con la pioggia e scende per evapotraspirazione in base a temperatura, stagione e tipo di terreno. Quando l'umiditÃƒÂ  scende sotto le soglie specifiche della coltura nelle finestre critiche di crescita, lo stress da siccitÃƒÂ  si accumula e riduce la resa al raccolto.
+Ogni campo tiene traccia di una percentuale di umiditÃƒÆ’Ã‚Â  del terreno (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) che sale con la pioggia e scende per evapotraspirazione in base a temperatura, stagione e tipo di terreno. Quando l'umiditÃƒÆ’Ã‚Â  scende sotto le soglie specifiche della coltura nelle finestre critiche di crescita, lo stress da siccitÃƒÆ’Ã‚Â  si accumula e riduce la resa al raccolto.
 
-FUNZIONALITÃƒâ‚¬:
-Ã¢â‚¬Â¢ Simulazione dell'umiditÃƒÂ  del terreno per campo, guidata dal meteo di gioco
-Ã¢â‚¬Â¢ Evapotraspirazione stagionale e influenzata dalla temperatura
-Ã¢â‚¬Â¢ Modificatori per tipo di terreno: Sabbioso si asciuga rapidamente, Argilloso trattiene l'umiditÃƒÂ 
-Ã¢â‚¬Â¢ Finestre critiche di crescita specifiche per coltura (grano, mais, orzo, colza e altro)
-Ã¢â‚¬Â¢ Riduzione della resa al raccolto Ã¢â‚¬â€ fino al 60 % di perdita allo stress massimo
-Ã¢â‚¬Â¢ Overlay HUD dell'umiditÃƒÂ  del terreno con previsioni a 5 giorni (Maiusc+M per mostrare/nascondere)
-Ã¢â‚¬Â¢ Irrigazione a perno e a goccia con infrastruttura pompa dell'acqua
-Ã¢â‚¬Â¢ Programma irrigazione Ã¢â‚¬â€ imposta i giorni attivi e la finestra oraria (Maiusc+I)
-Ã¢â‚¬Â¢ Dialogo Consulente colturale con riepilogo dei rischi e raccomandazioni (Maiusc+C)
-Ã¢â‚¬Â¢ Integrazione opzionale con FS25_NPCFavor (Alex Chen, agronomo PNG)
-Ã¢â‚¬Â¢ Integrazione opzionale con FS25_UsedPlus (mercato attrezzature usate)
-Ã¢â‚¬Â¢ Salvataggio completo dello stato dei campi e dei sistemi di irrigazione
-Ã¢â‚¬Â¢ Comandi di debug in console (digitare csHelp nella console sviluppatore)
+FUNZIONALITÃƒÆ’Ã¢â€šÂ¬:
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulazione dell'umiditÃƒÆ’Ã‚Â  del terreno per campo, guidata dal meteo di gioco
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Evapotraspirazione stagionale e influenzata dalla temperatura
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Modificatori per tipo di terreno: Sabbioso si asciuga rapidamente, Argilloso trattiene l'umiditÃƒÆ’Ã‚Â 
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Finestre critiche di crescita specifiche per coltura (grano, mais, orzo, colza e altro)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Riduzione della resa al raccolto ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â fino al 60 % di perdita allo stress massimo
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Overlay HUD dell'umiditÃƒÆ’Ã‚Â  del terreno con previsioni a 5 giorni (Maiusc+M per mostrare/nascondere)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigazione a perno e a goccia con infrastruttura pompa dell'acqua
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Programma irrigazione ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â imposta i giorni attivi e la finestra oraria (Maiusc+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialogo Consulente colturale con riepilogo dei rischi e raccomandazioni (Maiusc+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Integrazione opzionale con FS25_NPCFavor (Alex Chen, agronomo PNG)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Integrazione opzionale con FS25_UsedPlus (mercato attrezzature usate)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Salvataggio completo dello stato dei campi e dei sistemi di irrigazione
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Comandi di debug in console (digitare csHelp nella console sviluppatore)
         ]]></it>
         <nl><![CDATA[Voegt bodemvochtmonitoring, gewassstresssimulatie en irrigatiebeheer toe aan Farming Simulator 25.
 
-Elk veld houdt een bodemvochtpercentage bij (0Ã¢â‚¬â€œ100 %) dat stijgt bij regen en daalt door evapotranspiratie op basis van temperatuur, seizoen en bodemtype. Als de vochtigheid tijdens kritieke groeivensters onder gewasspecifieke drempelwaarden zakt, accumuleert droogtestress en verlaagt de oogstopbrengst aan het einde van het seizoen.
+Elk veld houdt een bodemvochtpercentage bij (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) dat stijgt bij regen en daalt door evapotranspiratie op basis van temperatuur, seizoen en bodemtype. Als de vochtigheid tijdens kritieke groeivensters onder gewasspecifieke drempelwaarden zakt, accumuleert droogtestress en verlaagt de oogstopbrengst aan het einde van het seizoen.
 
 FUNCTIES:
-Ã¢â‚¬Â¢ Bodemvochtsimulatie per veld, aangestuurd door het spelweer
-Ã¢â‚¬Â¢ Seizoens- en temperatuurgecorrigeerde evapotranspiratie
-Ã¢â‚¬Â¢ Bodemtype-modifiers: Zandig droogt snel, Kleiig houdt vochtigheid vast
-Ã¢â‚¬Â¢ Gewasspecifieke kritieke groeivensters (tarwe, maÃƒÂ¯s, gerst, koolzaad en meer)
-Ã¢â‚¬Â¢ Opbrengstreductie bij oogst Ã¢â‚¬â€ tot 60 % verlies bij maximale stress
-Ã¢â‚¬Â¢ HUD-overlay bodemvochtigheid met 5-dagenprognose (Shift+M om in/uit te schakelen)
-Ã¢â‚¬Â¢ Cirkelberegening en druppelbevloeiing met waterpomp-infrastructuur
-Ã¢â‚¬Â¢ Irrigatieschema-dialoog Ã¢â‚¬â€ stel actieve dagen en tijdvenster in (Shift+I)
-Ã¢â‚¬Â¢ Gewasadviseur-dialoog met risicosamenvatting en aanbevelingen (Shift+C)
-Ã¢â‚¬Â¢ Optionele integratie met FS25_NPCFavor (Alex Chen, agronoom-NPC)
-Ã¢â‚¬Â¢ Optionele integratie met FS25_UsedPlus (marktplaats voor gebruikte machines)
-Ã¢â‚¬Â¢ Volledige opslag van veld- en irrigatiestatus
-Ã¢â‚¬Â¢ Debug-consoleopdrachten (typ csHelp in de ontwikkelaarsconsole)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodemvochtsimulatie per veld, aangestuurd door het spelweer
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Seizoens- en temperatuurgecorrigeerde evapotranspiratie
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodemtype-modifiers: Zandig droogt snel, Kleiig houdt vochtigheid vast
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Gewasspecifieke kritieke groeivensters (tarwe, maÃƒÆ’Ã‚Â¯s, gerst, koolzaad en meer)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Opbrengstreductie bij oogst ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â tot 60 % verlies bij maximale stress
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ HUD-overlay bodemvochtigheid met 5-dagenprognose (Shift+M om in/uit te schakelen)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Cirkelberegening en druppelbevloeiing met waterpomp-infrastructuur
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigatieschema-dialoog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â stel actieve dagen en tijdvenster in (Shift+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Gewasadviseur-dialoog met risicosamenvatting en aanbevelingen (Shift+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionele integratie met FS25_NPCFavor (Alex Chen, agronoom-NPC)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionele integratie met FS25_UsedPlus (marktplaats voor gebruikte machines)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Volledige opslag van veld- en irrigatiestatus
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-consoleopdrachten (typ csHelp in de ontwikkelaarsconsole)
         ]]></nl>
-        <cz><![CDATA[PÃ…â„¢idÃƒÂ¡vÃƒÂ¡ sledovÃƒÂ¡nÃƒÂ­ vlhkosti pÃ…Â¯dy, simulaci stresu plodin a sprÃƒÂ¡vu zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ do Farming Simulator 25.
+        <cz><![CDATA[PÃƒâ€¦Ã¢â€žÂ¢idÃƒÆ’Ã‚Â¡vÃƒÆ’Ã‚Â¡ sledovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ vlhkosti pÃƒâ€¦Ã‚Â¯dy, simulaci stresu plodin a sprÃƒÆ’Ã‚Â¡vu zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ do Farming Simulator 25.
             
-KaÃ…Â¾dÃƒÂ© pole sleduje procento vlhkosti pÃ…Â¯dy (0-100%), kterÃƒÂ© stoupÃƒÂ¡ s deÃ…Â¡tÃ„â€ºm a klesÃƒÂ¡ evapotranspiracÃƒÂ­ Ã…â„¢ÃƒÂ­zenou teplotou, roÃ„ÂnÃƒÂ­m obdobÃƒÂ­m a typem pÃ…Â¯dy. KdyÃ…Â¾ vlhkost klesne pod prahovÃƒÂ© hodnoty specifickÃƒÂ© pro danou plodinu bÃ„â€ºhem kritickÃƒÂ½ch rÃ…Â¯stovÃƒÂ½ch oken, hromadÃƒÂ­ se stres vÃƒÂ½nosu a sniÃ…Â¾uje vaÃ…Â¡i sklizeÃ…Ë† na konci sezÃƒÂ³ny.
+KaÃƒâ€¦Ã‚Â¾dÃƒÆ’Ã‚Â© pole sleduje procento vlhkosti pÃƒâ€¦Ã‚Â¯dy (0-100%), kterÃƒÆ’Ã‚Â© stoupÃƒÆ’Ã‚Â¡ s deÃƒâ€¦Ã‚Â¡tÃƒâ€žÃ¢â‚¬Âºm a klesÃƒÆ’Ã‚Â¡ evapotranspiracÃƒÆ’Ã‚Â­ Ãƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­zenou teplotou, roÃƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â­m obdobÃƒÆ’Ã‚Â­m a typem pÃƒâ€¦Ã‚Â¯dy. KdyÃƒâ€¦Ã‚Â¾ vlhkost klesne pod prahovÃƒÆ’Ã‚Â© hodnoty specifickÃƒÆ’Ã‚Â© pro danou plodinu bÃƒâ€žÃ¢â‚¬Âºhem kritickÃƒÆ’Ã‚Â½ch rÃƒâ€¦Ã‚Â¯stovÃƒÆ’Ã‚Â½ch oken, hromadÃƒÆ’Ã‚Â­ se stres vÃƒÆ’Ã‚Â½nosu a sniÃƒâ€¦Ã‚Â¾uje vaÃƒâ€¦Ã‚Â¡i sklizeÃƒâ€¦Ã‹â€  na konci sezÃƒÆ’Ã‚Â³ny.
 
 FUNKCE:
-Ã¢â‚¬Â¢ Simulace vlhkosti pÃ…Â¯dy pro kaÃ…Â¾dÃƒÂ© pole Ã…â„¢ÃƒÂ­zenÃƒÂ¡ reÃƒÂ¡lnÃƒÂ½m poÃ„ÂasÃƒÂ­m
-Ã¢â‚¬Â¢ SezÃƒÂ³nnÃ„â€º a teplotnÃ„â€º upravenÃƒÂ¡ evapotranspirace
-Ã¢â‚¬Â¢ ModifikÃƒÂ¡tory typu pÃ…Â¯dy: pÃƒÂ­sÃ„ÂitÃƒÂ¡ odvÃƒÂ¡dÃƒÂ­ rychle, jÃƒÂ­lovitÃƒÂ¡ drÃ…Â¾ÃƒÂ­ vlhkost
-Ã¢â‚¬Â¢ KritickÃƒÂ¡ rÃ…Â¯stovÃƒÂ¡ okna specifickÃƒÂ¡ pro plodiny (pÃ…Â¡enice, kukuÃ…â„¢ice, jeÃ„Âmen, Ã…â„¢epka a dalÃ…Â¡ÃƒÂ­)
-Ã¢â‚¬Â¢ SnÃƒÂ­Ã…Â¾enÃƒÂ­ vÃƒÂ½nosu pÃ…â„¢i sklizni Ã¢â‚¬â€ aÃ…Â¾ 60% ztrÃƒÂ¡ta pÃ…â„¢i maximÃƒÂ¡lnÃƒÂ­m stresu
-Ã¢â‚¬Â¢ PÃ…â„¢ekrytÃƒÂ­ HUD vlhkosti pole s 5dennÃƒÂ­ pÃ…â„¢edpovÃ„â€ºdÃƒÂ­ (stisknÃ„â€ºte Shift+M pro pÃ…â„¢epnutÃƒÂ­)
-Ã¢â‚¬Â¢ UmÃƒÂ­stitelnÃƒÂ© stÃ…â„¢edovÃƒÂ© pivoty a kapkovÃƒÂ© zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ s infrastrukturou vodnÃƒÂ­ pumpy
-Ã¢â‚¬Â¢ Dialog plÃƒÂ¡novÃƒÂ¡nÃƒÂ­ zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ Ã¢â‚¬â€ nastavte aktivnÃƒÂ­ dny a hodinovÃƒÂ© okno (Shift+I)
-Ã¢â‚¬Â¢ Dialog poradce pro plodiny s pÃ…â„¢ehledem rizik a doporuÃ„ÂenÃƒÂ­mi (Shift+C)
-Ã¢â‚¬Â¢ VolitelnÃƒÂ¡ integrace s FS25_NPCFavor (Alex Chen, NPC agronom)
-Ã¢â‚¬Â¢ VolitelnÃƒÂ¡ integrace s FS25_UsedPlus (trÃ…Â¾iÃ…Â¡tÃ„â€º pouÃ…Â¾itÃƒÂ©ho vybavenÃƒÂ­)
-Ã¢â‚¬Â¢ ÃƒÅ¡plnÃƒÂ¡ persistence uloÃ…Â¾enÃƒÂ­/naÃ„ÂtenÃƒÂ­ vÃ…Â¡ech stavÃ…Â¯ polÃƒÂ­ a zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­
-Ã¢â‚¬Â¢ PÃ…â„¢ÃƒÂ­kazy ladicÃƒÂ­ konzole (napiÃ…Â¡te csHelp do vÃƒÂ½vojÃƒÂ¡Ã…â„¢skÃƒÂ© konzole)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulace vlhkosti pÃƒâ€¦Ã‚Â¯dy pro kaÃƒâ€¦Ã‚Â¾dÃƒÆ’Ã‚Â© pole Ãƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­zenÃƒÆ’Ã‚Â¡ reÃƒÆ’Ã‚Â¡lnÃƒÆ’Ã‚Â½m poÃƒâ€žÃ‚ÂasÃƒÆ’Ã‚Â­m
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SezÃƒÆ’Ã‚Â³nnÃƒâ€žÃ¢â‚¬Âº a teplotnÃƒâ€žÃ¢â‚¬Âº upravenÃƒÆ’Ã‚Â¡ evapotranspirace
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ModifikÃƒÆ’Ã‚Â¡tory typu pÃƒâ€¦Ã‚Â¯dy: pÃƒÆ’Ã‚Â­sÃƒâ€žÃ‚ÂitÃƒÆ’Ã‚Â¡ odvÃƒÆ’Ã‚Â¡dÃƒÆ’Ã‚Â­ rychle, jÃƒÆ’Ã‚Â­lovitÃƒÆ’Ã‚Â¡ drÃƒâ€¦Ã‚Â¾ÃƒÆ’Ã‚Â­ vlhkost
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ KritickÃƒÆ’Ã‚Â¡ rÃƒâ€¦Ã‚Â¯stovÃƒÆ’Ã‚Â¡ okna specifickÃƒÆ’Ã‚Â¡ pro plodiny (pÃƒâ€¦Ã‚Â¡enice, kukuÃƒâ€¦Ã¢â€žÂ¢ice, jeÃƒâ€žÃ‚Âmen, Ãƒâ€¦Ã¢â€žÂ¢epka a dalÃƒâ€¦Ã‚Â¡ÃƒÆ’Ã‚Â­)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SnÃƒÆ’Ã‚Â­Ãƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â­ vÃƒÆ’Ã‚Â½nosu pÃƒâ€¦Ã¢â€žÂ¢i sklizni ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â aÃƒâ€¦Ã‚Â¾ 60% ztrÃƒÆ’Ã‚Â¡ta pÃƒâ€¦Ã¢â€žÂ¢i maximÃƒÆ’Ã‚Â¡lnÃƒÆ’Ã‚Â­m stresu
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒâ€¦Ã¢â€žÂ¢ekrytÃƒÆ’Ã‚Â­ HUD vlhkosti pole s 5dennÃƒÆ’Ã‚Â­ pÃƒâ€¦Ã¢â€žÂ¢edpovÃƒâ€žÃ¢â‚¬ÂºdÃƒÆ’Ã‚Â­ (stisknÃƒâ€žÃ¢â‚¬Âºte Shift+M pro pÃƒâ€¦Ã¢â€žÂ¢epnutÃƒÆ’Ã‚Â­)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ UmÃƒÆ’Ã‚Â­stitelnÃƒÆ’Ã‚Â© stÃƒâ€¦Ã¢â€žÂ¢edovÃƒÆ’Ã‚Â© pivoty a kapkovÃƒÆ’Ã‚Â© zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ s infrastrukturou vodnÃƒÆ’Ã‚Â­ pumpy
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog plÃƒÆ’Ã‚Â¡novÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â nastavte aktivnÃƒÆ’Ã‚Â­ dny a hodinovÃƒÆ’Ã‚Â© okno (Shift+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog poradce pro plodiny s pÃƒâ€¦Ã¢â€žÂ¢ehledem rizik a doporuÃƒâ€žÃ‚ÂenÃƒÆ’Ã‚Â­mi (Shift+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VolitelnÃƒÆ’Ã‚Â¡ integrace s FS25_NPCFavor (Alex Chen, NPC agronom)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VolitelnÃƒÆ’Ã‚Â¡ integrace s FS25_UsedPlus (trÃƒâ€¦Ã‚Â¾iÃƒâ€¦Ã‚Â¡tÃƒâ€žÃ¢â‚¬Âº pouÃƒâ€¦Ã‚Â¾itÃƒÆ’Ã‚Â©ho vybavenÃƒÆ’Ã‚Â­)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ÃƒÆ’Ã…Â¡plnÃƒÆ’Ã‚Â¡ persistence uloÃƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â­/naÃƒâ€žÃ‚ÂtenÃƒÆ’Ã‚Â­ vÃƒâ€¦Ã‚Â¡ech stavÃƒâ€¦Ã‚Â¯ polÃƒÆ’Ã‚Â­ a zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­kazy ladicÃƒÆ’Ã‚Â­ konzole (napiÃƒâ€¦Ã‚Â¡te csHelp do vÃƒÆ’Ã‚Â½vojÃƒÆ’Ã‚Â¡Ãƒâ€¦Ã¢â€žÂ¢skÃƒÆ’Ã‚Â© konzole)
         ]]></cz>
-        <da><![CDATA[TilfÃƒÂ¸jer overvÃƒÂ¥gning af jordfugtighed, simulering af afgrÃƒÂ¸destress og styring af vanding til Farming Simulator 25.
+        <da><![CDATA[TilfÃƒÆ’Ã‚Â¸jer overvÃƒÆ’Ã‚Â¥gning af jordfugtighed, simulering af afgrÃƒÆ’Ã‚Â¸destress og styring af vanding til Farming Simulator 25.
 
-Hvert felt overvÃƒÂ¥ger procentdelen af jordfugtighed (0Ã¢â‚¬â€œ100%), som stiger med regn og falder gennem evapotranspiration, der styres af temperatur, ÃƒÂ¥rstid og jordtype. NÃƒÂ¥r fugtigheden falder under afgrÃƒÂ¸despecifikke tÃƒÂ¦rskelvÃƒÂ¦rdier i kritiske vÃƒÂ¦kstperioder, opbygges udbyttestress, som reducerer din hÃƒÂ¸st ved sÃƒÂ¦sonens afslutning.
+Hvert felt overvÃƒÆ’Ã‚Â¥ger procentdelen af jordfugtighed (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100%), som stiger med regn og falder gennem evapotranspiration, der styres af temperatur, ÃƒÆ’Ã‚Â¥rstid og jordtype. NÃƒÆ’Ã‚Â¥r fugtigheden falder under afgrÃƒÆ’Ã‚Â¸despecifikke tÃƒÆ’Ã‚Â¦rskelvÃƒÆ’Ã‚Â¦rdier i kritiske vÃƒÆ’Ã‚Â¦kstperioder, opbygges udbyttestress, som reducerer din hÃƒÆ’Ã‚Â¸st ved sÃƒÆ’Ã‚Â¦sonens afslutning.
 
 FUNKTIONER:
-Ã¢â‚¬Â¢ Simulering af jordfugtighed for hvert felt baseret pÃƒÂ¥ realt vejr
-Ã¢â‚¬Â¢ SÃƒÂ¦son- og temperaturjusteret evapotranspiration
-Ã¢â‚¬Â¢ Jordtype-modifikatorer: sandjord drÃƒÂ¦ner hurtigt, lerjord holder pÃƒÂ¥ fugt
-Ã¢â‚¬Â¢ Kritiske vÃƒÂ¦kstperioder specifikke for afgrÃƒÂ¸der (hvede, majs, byg, raps og flere)
-Ã¢â‚¬Â¢ Udbyttereduktion ved hÃƒÂ¸st Ã¢â‚¬â€ op til 60% tab ved maksimal stress
-Ã¢â‚¬Â¢ HUD-overlay for markfugtighed med 5-dages vejrudsigt (tryk Shift+M for at skifte)
-Ã¢â‚¬Â¢ Placerbare center pivot- og drypvandingssystemer med vandpumpeinfrastruktur
-Ã¢â‚¬Â¢ Dialog til planlÃƒÂ¦gning af vanding Ã¢â‚¬â€ angiv aktive dage og tidsvindue (Shift+I)
-Ã¢â‚¬Â¢ AfgrÃƒÂ¸derÃƒÂ¥dgiver-dialog med risikovurdering og anbefalinger (Shift+C)
-Ã¢â‚¬Â¢ Valgfri integration med FS25_NPCFavor (Alex Chen, NPC agronom)
-Ã¢â‚¬Â¢ Valgfri integration med FS25_UsedPlus (marked for brugt udstyr)
-Ã¢â‚¬Â¢ Fuld persistens ved gem/indlÃƒÂ¦s af alle mark- og vandingsstatusser
-Ã¢â‚¬Â¢ Debug-konsolkommandoer (skriv csHelp i udviklerkonsollen)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulering af jordfugtighed for hvert felt baseret pÃƒÆ’Ã‚Â¥ realt vejr
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SÃƒÆ’Ã‚Â¦son- og temperaturjusteret evapotranspiration
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Jordtype-modifikatorer: sandjord drÃƒÆ’Ã‚Â¦ner hurtigt, lerjord holder pÃƒÆ’Ã‚Â¥ fugt
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Kritiske vÃƒÆ’Ã‚Â¦kstperioder specifikke for afgrÃƒÆ’Ã‚Â¸der (hvede, majs, byg, raps og flere)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Udbyttereduktion ved hÃƒÆ’Ã‚Â¸st ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â op til 60% tab ved maksimal stress
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ HUD-overlay for markfugtighed med 5-dages vejrudsigt (tryk Shift+M for at skifte)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Placerbare center pivot- og drypvandingssystemer med vandpumpeinfrastruktur
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog til planlÃƒÆ’Ã‚Â¦gning af vanding ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â angiv aktive dage og tidsvindue (Shift+I)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ AfgrÃƒÆ’Ã‚Â¸derÃƒÆ’Ã‚Â¥dgiver-dialog med risikovurdering og anbefalinger (Shift+C)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Valgfri integration med FS25_NPCFavor (Alex Chen, NPC agronom)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Valgfri integration med FS25_UsedPlus (marked for brugt udstyr)
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Fuld persistens ved gem/indlÃƒÆ’Ã‚Â¦s af alle mark- og vandingsstatusser
+ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-konsolkommandoer (skriv csHelp i udviklerkonsollen)
         ]]></da>
     </description>
 
@@ -183,7 +183,7 @@ FUNKTIONER:
     </inputBinding>
 
     <!--
-        All strings Ã¢â‚¬â€ including input action descriptions (input_CS_*) Ã¢â‚¬â€
+        All strings ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â including input action descriptions (input_CS_*) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â
         are defined in the external translation files. No inline l10n block
         is needed and none is used.
         NOTE: FS25 only processes the FIRST <l10n> element. Two separate
@@ -211,7 +211,7 @@ FUNKTIONER:
         <specialization name="RWSM53ChangeObjectByDistance" className="RWSM53ChangeObjectByDistance" filename="src/vendor/rwsm/changeObjectByDistance.lua"/>
         <specialization name="RWSM53AutoReel" className="RWSM53AutoReel" filename="src/vendor/rwsm/rainstarAutoReel.lua"/>
         <specialization name="RWSM118RainstarParkingBrake" className="RWSM118RainstarParkingBrake" filename="src/vendor/rwsm/rainstarParkingBrake.lua"/>
-        <!-- BUILD 19:27 - suite-owned visible EMP↔Rainstar supply hose (not COBD / not SPS). -->
+        <!-- BUILD 19:27 - suite-owned visible EMPâ†”Rainstar supply hose (not COBD / not SPS). -->
         <specialization name="ScsPumpHoseConnection" className="ScsPumpHoseConnection" filename="src/ScsPumpHoseConnection.lua"/>
         <!-- BUILD 22:25 - the EMP pump powers the reel, so no tractor is required to spray. -->
         <specialization name="ScsRainstarPumpPower" className="ScsRainstarPumpPower" filename="src/ScsRainstarPumpPower.lua"/>
@@ -266,12 +266,12 @@ FUNKTIONER:
     </storeItems>
 
     <!--
-        In-game help pages accessible from the pause menu Ã¢â€ â€™ Help.
+        In-game help pages accessible from the pause menu ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Help.
         Four categories: Overview, Settings, Tips & Tricks, Mod Information.
     -->
     <helpLines>
 
-        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 1: Overview Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
+        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 1: Overview ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
         <category title="$l10n_helpLine_cs_cat_overview">
 
             <page title="$l10n_helpLine_cs_p1_title" iconSliceId="icon_crops">
@@ -335,7 +335,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 2: Settings Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
+        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 2: Settings ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
         <category title="$l10n_helpLine_cs_cat_settings">
 
             <page title="$l10n_helpLine_cs_s1_title" iconSliceId="icon_crops">
@@ -362,7 +362,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 3: Tips & Tricks Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
+        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 3: Tips & Tricks ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
         <category title="$l10n_helpLine_cs_cat_tips">
 
             <page title="$l10n_helpLine_cs_p4_title" iconSliceId="icon_crops">
@@ -400,7 +400,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 4: Mod Information Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
+        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 4: Mod Information ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
         <category title="$l10n_helpLine_cs_cat_info">
 
             <page title="$l10n_helpLine_cs_i1_title" iconSliceId="icon_info">

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -5,12 +5,12 @@
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
-        <de>Saisonaler Pflanzenstress &amp; BewÃƒÆ’Ã‚Â¤sserungsmanager</de>
+        <de>Saisonaler Pflanzenstress &amp; BewÃƒÂ¤sserungsmanager</de>
         <fr>Stress saisonnier des cultures &amp; gestionnaire d'irrigation</fr>
         <it>Stress stagionale delle colture &amp; Gestore dell'irrigazione</it>
         <nl>Seizoensgebonden gewassstress &amp; irrigatiebeheer</nl>
-        <cz>Seasonal Crop Stress &amp; SprÃƒÆ’Ã‚Â¡vce zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­</cz>
-        <da>SÃƒÆ’Ã‚Â¦sonbetinget afgrÃƒÆ’Ã‚Â¸destress &amp; vandingsstyring</da>
+        <cz>Seasonal Crop Stress &amp; SprÃƒÂ¡vce zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­</cz>
+        <da>SÃƒÂ¦sonbetinget afgrÃƒÂ¸destress &amp; vandingsstyring</da>
     </title>
 
     <description>
@@ -19,133 +19,133 @@
 Each field tracks a soil moisture percentage (0-100%) that rises with rain and falls through evapotranspiration driven by temperature, season, and soil type. When moisture drops below crop-specific thresholds during critical growth windows, yield stress accumulates and reduces your harvest at season's end.
 
 FEATURES:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Per-field soil moisture simulation driven by real weather
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Seasonal & temperature-adjusted evapotranspiration
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Soil type modifiers: sandy drains fast, clay holds moisture
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Crop-specific critical growth windows (wheat, corn, barley, canola, and more)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Yield reduction at harvest ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â up to 60% loss at maximum stress
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Field moisture HUD overlay with 5-day forecast (press Shift+M to toggle)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Center-pivot and drip irrigation placeables with water pump infrastructure
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigation scheduling dialog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â set active days and hourly window (Shift+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Crop Consultant dialog with risk summary and recommendations (Shift+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optional integration with FS25_NPCFavor (Alex Chen, Agronomist NPC)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optional integration with FS25_UsedPlus (used equipment marketplace)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Full save/load persistence of all field and irrigation state
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug console commands (type csHelp in developer console)
+Ã¢â‚¬Â¢ Per-field soil moisture simulation driven by real weather
+Ã¢â‚¬Â¢ Seasonal & temperature-adjusted evapotranspiration
+Ã¢â‚¬Â¢ Soil type modifiers: sandy drains fast, clay holds moisture
+Ã¢â‚¬Â¢ Crop-specific critical growth windows (wheat, corn, barley, canola, and more)
+Ã¢â‚¬Â¢ Yield reduction at harvest Ã¢â‚¬â€ up to 60% loss at maximum stress
+Ã¢â‚¬Â¢ Field moisture HUD overlay with 5-day forecast (press Shift+M to toggle)
+Ã¢â‚¬Â¢ Center-pivot and drip irrigation placeables with water pump infrastructure
+Ã¢â‚¬Â¢ Irrigation scheduling dialog Ã¢â‚¬â€ set active days and hourly window (Shift+I)
+Ã¢â‚¬Â¢ Crop Consultant dialog with risk summary and recommendations (Shift+C)
+Ã¢â‚¬Â¢ Optional integration with FS25_NPCFavor (Alex Chen, Agronomist NPC)
+Ã¢â‚¬Â¢ Optional integration with FS25_UsedPlus (used equipment marketplace)
+Ã¢â‚¬Â¢ Full save/load persistence of all field and irrigation state
+Ã¢â‚¬Â¢ Debug console commands (type csHelp in developer console)
         ]]></en>
-        <de><![CDATA[FÃƒÆ’Ã‚Â¼gt Bodenfeuchteverfolgung, Pflanzenstresssimulation und BewÃƒÆ’Ã‚Â¤sserungsmanagement zu Farming Simulator 25 hinzu.
+        <de><![CDATA[FÃƒÂ¼gt Bodenfeuchteverfolgung, Pflanzenstresssimulation und BewÃƒÂ¤sserungsmanagement zu Farming Simulator 25 hinzu.
 
-Jedes Feld verfolgt einen Bodenfeuchteanteil (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %), der mit Regen steigt und durch Evapotranspiration (Temperatur, Jahreszeit, Bodentyp) sinkt. Wenn die Feuchte in kritischen Wachstumsphasen unter kultururspezifische Schwellenwerte fÃƒÆ’Ã‚Â¤llt, akkumuliert sich Trockenstress und reduziert den Ernteertrag am Saisonende.
+Jedes Feld verfolgt einen Bodenfeuchteanteil (0Ã¢â‚¬â€œ100 %), der mit Regen steigt und durch Evapotranspiration (Temperatur, Jahreszeit, Bodentyp) sinkt. Wenn die Feuchte in kritischen Wachstumsphasen unter kultururspezifische Schwellenwerte fÃƒÂ¤llt, akkumuliert sich Trockenstress und reduziert den Ernteertrag am Saisonende.
 
 FUNKTIONEN:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodenfeuchte-Simulation pro Feld, gesteuert durch das Spielwetter
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Saisonale und temperaturbeeinflusste Evapotranspiration
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodentyp-Modifikatoren: Sandig trocknet schnell aus, Tonig hÃƒÆ’Ã‚Â¤lt Feuchte
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Kultuurspezifische kritische Wachstumsphasen (Weizen, Mais, Gerste, Raps u. v. m.)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Ertragsreduzierung bei der Ernte ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â bis zu 60 % Verlust bei maximalem Stress
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodenfeuchte-HUD-Overlay mit 5-Tage-Prognose (Shift+M zum Ein-/Ausblenden)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ KreisbewÃƒÆ’Ã‚Â¤sserung und TrÃƒÆ’Ã‚Â¶pfchenbewÃƒÆ’Ã‚Â¤sserung mit Wasserpumpen-Infrastruktur
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ BewÃƒÆ’Ã‚Â¤sserungszeitplan-Dialog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Aktivtage und Zeitfenster einstellen (Shift+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Pflanzenbergungs-Dialog mit RisikoÃƒÆ’Ã‚Â¼bersicht und Empfehlungen (Shift+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionale Integration mit FS25_NPCFavor (Alex Chen, Agrarberater-NPC)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionale Integration mit FS25_UsedPlus (Gebrauchtmarkt fÃƒÆ’Ã‚Â¼r Landmaschinen)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VollstÃƒÆ’Ã‚Â¤ndige Speicherung aller Feld- und BewÃƒÆ’Ã‚Â¤sserungsdaten
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-Konsolenbefehle (csHelp in der Entwicklerkonsole eingeben)
+Ã¢â‚¬Â¢ Bodenfeuchte-Simulation pro Feld, gesteuert durch das Spielwetter
+Ã¢â‚¬Â¢ Saisonale und temperaturbeeinflusste Evapotranspiration
+Ã¢â‚¬Â¢ Bodentyp-Modifikatoren: Sandig trocknet schnell aus, Tonig hÃƒÂ¤lt Feuchte
+Ã¢â‚¬Â¢ Kultuurspezifische kritische Wachstumsphasen (Weizen, Mais, Gerste, Raps u. v. m.)
+Ã¢â‚¬Â¢ Ertragsreduzierung bei der Ernte Ã¢â‚¬â€ bis zu 60 % Verlust bei maximalem Stress
+Ã¢â‚¬Â¢ Bodenfeuchte-HUD-Overlay mit 5-Tage-Prognose (Shift+M zum Ein-/Ausblenden)
+Ã¢â‚¬Â¢ KreisbewÃƒÂ¤sserung und TrÃƒÂ¶pfchenbewÃƒÂ¤sserung mit Wasserpumpen-Infrastruktur
+Ã¢â‚¬Â¢ BewÃƒÂ¤sserungszeitplan-Dialog Ã¢â‚¬â€ Aktivtage und Zeitfenster einstellen (Shift+I)
+Ã¢â‚¬Â¢ Pflanzenbergungs-Dialog mit RisikoÃƒÂ¼bersicht und Empfehlungen (Shift+C)
+Ã¢â‚¬Â¢ Optionale Integration mit FS25_NPCFavor (Alex Chen, Agrarberater-NPC)
+Ã¢â‚¬Â¢ Optionale Integration mit FS25_UsedPlus (Gebrauchtmarkt fÃƒÂ¼r Landmaschinen)
+Ã¢â‚¬Â¢ VollstÃƒÂ¤ndige Speicherung aller Feld- und BewÃƒÂ¤sserungsdaten
+Ã¢â‚¬Â¢ Debug-Konsolenbefehle (csHelp in der Entwicklerkonsole eingeben)
         ]]></de>
-        <fr><![CDATA[Ajoute un suivi de l'humiditÃƒÆ’Ã‚Â© du sol, une simulation du stress hydrique et un gestionnaire d'irrigation ÃƒÆ’Ã‚Â  Farming Simulator 25.
+        <fr><![CDATA[Ajoute un suivi de l'humiditÃƒÂ© du sol, une simulation du stress hydrique et un gestionnaire d'irrigation ÃƒÂ  Farming Simulator 25.
 
-Chaque parcelle suit un pourcentage d'humiditÃƒÆ’Ã‚Â© du sol (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) qui monte avec les pluies et descend par ÃƒÆ’Ã‚Â©vapotranspiration selon la tempÃƒÆ’Ã‚Â©rature, la saison et le type de sol. Lorsque l'humiditÃƒÆ’Ã‚Â© passe sous les seuils propres ÃƒÆ’Ã‚Â  chaque culture pendant les pÃƒÆ’Ã‚Â©riodes critiques de croissance, le stress hydrique s'accumule et rÃƒÆ’Ã‚Â©duit le rendement en fin de saison.
+Chaque parcelle suit un pourcentage d'humiditÃƒÂ© du sol (0Ã¢â‚¬â€œ100 %) qui monte avec les pluies et descend par ÃƒÂ©vapotranspiration selon la tempÃƒÂ©rature, la saison et le type de sol. Lorsque l'humiditÃƒÂ© passe sous les seuils propres ÃƒÂ  chaque culture pendant les pÃƒÂ©riodes critiques de croissance, le stress hydrique s'accumule et rÃƒÂ©duit le rendement en fin de saison.
 
-FONCTIONNALITÃƒÆ’Ã¢â‚¬Â°S :
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulation d'humiditÃƒÆ’Ã‚Â© du sol par parcelle, pilotÃƒÆ’Ã‚Â©e par la mÃƒÆ’Ã‚Â©tÃƒÆ’Ã‚Â©o en temps rÃƒÆ’Ã‚Â©el
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ÃƒÆ’Ã¢â‚¬Â°vapotranspiration ajustÃƒÆ’Ã‚Â©e ÃƒÆ’Ã‚Â  la saison et ÃƒÆ’Ã‚Â  la tempÃƒÆ’Ã‚Â©rature
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Modificateurs de type de sol : Sableux sÃƒÆ’Ã‚Â¨che vite, Argileux retient l'humiditÃƒÆ’Ã‚Â©
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒÆ’Ã‚Â©riodes critiques de croissance propres ÃƒÆ’Ã‚Â  chaque culture (blÃƒÆ’Ã‚Â©, maÃƒÆ’Ã‚Â¯s, orge, colza, etc.)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ RÃƒÆ’Ã‚Â©duction de rendement ÃƒÆ’Ã‚Â  la rÃƒÆ’Ã‚Â©colte ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â jusqu'ÃƒÆ’Ã‚Â  60 % de perte au stress maximal
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Overlay HUD d'humiditÃƒÆ’Ã‚Â© du sol avec prÃƒÆ’Ã‚Â©visions 5 jours (Maj+M pour afficher/masquer)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Pivot central et goutte-ÃƒÆ’Ã‚Â -goutte avec infrastructure de pompe ÃƒÆ’Ã‚Â  eau
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Programme d'irrigation ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â dÃƒÆ’Ã‚Â©finissez les jours actifs et la plage horaire (Maj+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialogue Conseiller cultural avec rÃƒÆ’Ã‚Â©sumÃƒÆ’Ã‚Â© des risques et recommandations (Maj+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ IntÃƒÆ’Ã‚Â©gration optionnelle avec FS25_NPCFavor (Alex Chen, agronome PNJ)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ IntÃƒÆ’Ã‚Â©gration optionnelle avec FS25_UsedPlus (marchÃƒÆ’Ã‚Â© de matÃƒÆ’Ã‚Â©riel d'occasion)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Sauvegarde complÃƒÆ’Ã‚Â¨te de l'ÃƒÆ’Ã‚Â©tat des parcelles et des systÃƒÆ’Ã‚Â¨mes d'irrigation
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Commandes de dÃƒÆ’Ã‚Â©bogage en console (taper csHelp dans la console dÃƒÆ’Ã‚Â©veloppeur)
+FONCTIONNALITÃƒâ€°S :
+Ã¢â‚¬Â¢ Simulation d'humiditÃƒÂ© du sol par parcelle, pilotÃƒÂ©e par la mÃƒÂ©tÃƒÂ©o en temps rÃƒÂ©el
+Ã¢â‚¬Â¢ Ãƒâ€°vapotranspiration ajustÃƒÂ©e ÃƒÂ  la saison et ÃƒÂ  la tempÃƒÂ©rature
+Ã¢â‚¬Â¢ Modificateurs de type de sol : Sableux sÃƒÂ¨che vite, Argileux retient l'humiditÃƒÂ©
+Ã¢â‚¬Â¢ PÃƒÂ©riodes critiques de croissance propres ÃƒÂ  chaque culture (blÃƒÂ©, maÃƒÂ¯s, orge, colza, etc.)
+Ã¢â‚¬Â¢ RÃƒÂ©duction de rendement ÃƒÂ  la rÃƒÂ©colte Ã¢â‚¬â€ jusqu'ÃƒÂ  60 % de perte au stress maximal
+Ã¢â‚¬Â¢ Overlay HUD d'humiditÃƒÂ© du sol avec prÃƒÂ©visions 5 jours (Maj+M pour afficher/masquer)
+Ã¢â‚¬Â¢ Pivot central et goutte-ÃƒÂ -goutte avec infrastructure de pompe ÃƒÂ  eau
+Ã¢â‚¬Â¢ Programme d'irrigation Ã¢â‚¬â€ dÃƒÂ©finissez les jours actifs et la plage horaire (Maj+I)
+Ã¢â‚¬Â¢ Dialogue Conseiller cultural avec rÃƒÂ©sumÃƒÂ© des risques et recommandations (Maj+C)
+Ã¢â‚¬Â¢ IntÃƒÂ©gration optionnelle avec FS25_NPCFavor (Alex Chen, agronome PNJ)
+Ã¢â‚¬Â¢ IntÃƒÂ©gration optionnelle avec FS25_UsedPlus (marchÃƒÂ© de matÃƒÂ©riel d'occasion)
+Ã¢â‚¬Â¢ Sauvegarde complÃƒÂ¨te de l'ÃƒÂ©tat des parcelles et des systÃƒÂ¨mes d'irrigation
+Ã¢â‚¬Â¢ Commandes de dÃƒÂ©bogage en console (taper csHelp dans la console dÃƒÂ©veloppeur)
         ]]></fr>
-        <it><![CDATA[Aggiunge il monitoraggio dell'umiditÃƒÆ’Ã‚Â  del terreno, la simulazione dello stress da siccitÃƒÆ’Ã‚Â  e la gestione dell'irrigazione a Farming Simulator 25.
+        <it><![CDATA[Aggiunge il monitoraggio dell'umiditÃƒÂ  del terreno, la simulazione dello stress da siccitÃƒÂ  e la gestione dell'irrigazione a Farming Simulator 25.
 
-Ogni campo tiene traccia di una percentuale di umiditÃƒÆ’Ã‚Â  del terreno (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) che sale con la pioggia e scende per evapotraspirazione in base a temperatura, stagione e tipo di terreno. Quando l'umiditÃƒÆ’Ã‚Â  scende sotto le soglie specifiche della coltura nelle finestre critiche di crescita, lo stress da siccitÃƒÆ’Ã‚Â  si accumula e riduce la resa al raccolto.
+Ogni campo tiene traccia di una percentuale di umiditÃƒÂ  del terreno (0Ã¢â‚¬â€œ100 %) che sale con la pioggia e scende per evapotraspirazione in base a temperatura, stagione e tipo di terreno. Quando l'umiditÃƒÂ  scende sotto le soglie specifiche della coltura nelle finestre critiche di crescita, lo stress da siccitÃƒÂ  si accumula e riduce la resa al raccolto.
 
-FUNZIONALITÃƒÆ’Ã¢â€šÂ¬:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulazione dell'umiditÃƒÆ’Ã‚Â  del terreno per campo, guidata dal meteo di gioco
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Evapotraspirazione stagionale e influenzata dalla temperatura
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Modificatori per tipo di terreno: Sabbioso si asciuga rapidamente, Argilloso trattiene l'umiditÃƒÆ’Ã‚Â 
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Finestre critiche di crescita specifiche per coltura (grano, mais, orzo, colza e altro)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Riduzione della resa al raccolto ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â fino al 60 % di perdita allo stress massimo
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Overlay HUD dell'umiditÃƒÆ’Ã‚Â  del terreno con previsioni a 5 giorni (Maiusc+M per mostrare/nascondere)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigazione a perno e a goccia con infrastruttura pompa dell'acqua
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Programma irrigazione ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â imposta i giorni attivi e la finestra oraria (Maiusc+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialogo Consulente colturale con riepilogo dei rischi e raccomandazioni (Maiusc+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Integrazione opzionale con FS25_NPCFavor (Alex Chen, agronomo PNG)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Integrazione opzionale con FS25_UsedPlus (mercato attrezzature usate)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Salvataggio completo dello stato dei campi e dei sistemi di irrigazione
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Comandi di debug in console (digitare csHelp nella console sviluppatore)
+FUNZIONALITÃƒâ‚¬:
+Ã¢â‚¬Â¢ Simulazione dell'umiditÃƒÂ  del terreno per campo, guidata dal meteo di gioco
+Ã¢â‚¬Â¢ Evapotraspirazione stagionale e influenzata dalla temperatura
+Ã¢â‚¬Â¢ Modificatori per tipo di terreno: Sabbioso si asciuga rapidamente, Argilloso trattiene l'umiditÃƒÂ 
+Ã¢â‚¬Â¢ Finestre critiche di crescita specifiche per coltura (grano, mais, orzo, colza e altro)
+Ã¢â‚¬Â¢ Riduzione della resa al raccolto Ã¢â‚¬â€ fino al 60 % di perdita allo stress massimo
+Ã¢â‚¬Â¢ Overlay HUD dell'umiditÃƒÂ  del terreno con previsioni a 5 giorni (Maiusc+M per mostrare/nascondere)
+Ã¢â‚¬Â¢ Irrigazione a perno e a goccia con infrastruttura pompa dell'acqua
+Ã¢â‚¬Â¢ Programma irrigazione Ã¢â‚¬â€ imposta i giorni attivi e la finestra oraria (Maiusc+I)
+Ã¢â‚¬Â¢ Dialogo Consulente colturale con riepilogo dei rischi e raccomandazioni (Maiusc+C)
+Ã¢â‚¬Â¢ Integrazione opzionale con FS25_NPCFavor (Alex Chen, agronomo PNG)
+Ã¢â‚¬Â¢ Integrazione opzionale con FS25_UsedPlus (mercato attrezzature usate)
+Ã¢â‚¬Â¢ Salvataggio completo dello stato dei campi e dei sistemi di irrigazione
+Ã¢â‚¬Â¢ Comandi di debug in console (digitare csHelp nella console sviluppatore)
         ]]></it>
         <nl><![CDATA[Voegt bodemvochtmonitoring, gewassstresssimulatie en irrigatiebeheer toe aan Farming Simulator 25.
 
-Elk veld houdt een bodemvochtpercentage bij (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100 %) dat stijgt bij regen en daalt door evapotranspiratie op basis van temperatuur, seizoen en bodemtype. Als de vochtigheid tijdens kritieke groeivensters onder gewasspecifieke drempelwaarden zakt, accumuleert droogtestress en verlaagt de oogstopbrengst aan het einde van het seizoen.
+Elk veld houdt een bodemvochtpercentage bij (0Ã¢â‚¬â€œ100 %) dat stijgt bij regen en daalt door evapotranspiratie op basis van temperatuur, seizoen en bodemtype. Als de vochtigheid tijdens kritieke groeivensters onder gewasspecifieke drempelwaarden zakt, accumuleert droogtestress en verlaagt de oogstopbrengst aan het einde van het seizoen.
 
 FUNCTIES:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodemvochtsimulatie per veld, aangestuurd door het spelweer
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Seizoens- en temperatuurgecorrigeerde evapotranspiratie
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Bodemtype-modifiers: Zandig droogt snel, Kleiig houdt vochtigheid vast
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Gewasspecifieke kritieke groeivensters (tarwe, maÃƒÆ’Ã‚Â¯s, gerst, koolzaad en meer)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Opbrengstreductie bij oogst ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â tot 60 % verlies bij maximale stress
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ HUD-overlay bodemvochtigheid met 5-dagenprognose (Shift+M om in/uit te schakelen)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Cirkelberegening en druppelbevloeiing met waterpomp-infrastructuur
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Irrigatieschema-dialoog ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â stel actieve dagen en tijdvenster in (Shift+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Gewasadviseur-dialoog met risicosamenvatting en aanbevelingen (Shift+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionele integratie met FS25_NPCFavor (Alex Chen, agronoom-NPC)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Optionele integratie met FS25_UsedPlus (marktplaats voor gebruikte machines)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Volledige opslag van veld- en irrigatiestatus
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-consoleopdrachten (typ csHelp in de ontwikkelaarsconsole)
+Ã¢â‚¬Â¢ Bodemvochtsimulatie per veld, aangestuurd door het spelweer
+Ã¢â‚¬Â¢ Seizoens- en temperatuurgecorrigeerde evapotranspiratie
+Ã¢â‚¬Â¢ Bodemtype-modifiers: Zandig droogt snel, Kleiig houdt vochtigheid vast
+Ã¢â‚¬Â¢ Gewasspecifieke kritieke groeivensters (tarwe, maÃƒÂ¯s, gerst, koolzaad en meer)
+Ã¢â‚¬Â¢ Opbrengstreductie bij oogst Ã¢â‚¬â€ tot 60 % verlies bij maximale stress
+Ã¢â‚¬Â¢ HUD-overlay bodemvochtigheid met 5-dagenprognose (Shift+M om in/uit te schakelen)
+Ã¢â‚¬Â¢ Cirkelberegening en druppelbevloeiing met waterpomp-infrastructuur
+Ã¢â‚¬Â¢ Irrigatieschema-dialoog Ã¢â‚¬â€ stel actieve dagen en tijdvenster in (Shift+I)
+Ã¢â‚¬Â¢ Gewasadviseur-dialoog met risicosamenvatting en aanbevelingen (Shift+C)
+Ã¢â‚¬Â¢ Optionele integratie met FS25_NPCFavor (Alex Chen, agronoom-NPC)
+Ã¢â‚¬Â¢ Optionele integratie met FS25_UsedPlus (marktplaats voor gebruikte machines)
+Ã¢â‚¬Â¢ Volledige opslag van veld- en irrigatiestatus
+Ã¢â‚¬Â¢ Debug-consoleopdrachten (typ csHelp in de ontwikkelaarsconsole)
         ]]></nl>
-        <cz><![CDATA[PÃƒâ€¦Ã¢â€žÂ¢idÃƒÆ’Ã‚Â¡vÃƒÆ’Ã‚Â¡ sledovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ vlhkosti pÃƒâ€¦Ã‚Â¯dy, simulaci stresu plodin a sprÃƒÆ’Ã‚Â¡vu zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ do Farming Simulator 25.
+        <cz><![CDATA[PÃ…â„¢idÃƒÂ¡vÃƒÂ¡ sledovÃƒÂ¡nÃƒÂ­ vlhkosti pÃ…Â¯dy, simulaci stresu plodin a sprÃƒÂ¡vu zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ do Farming Simulator 25.
             
-KaÃƒâ€¦Ã‚Â¾dÃƒÆ’Ã‚Â© pole sleduje procento vlhkosti pÃƒâ€¦Ã‚Â¯dy (0-100%), kterÃƒÆ’Ã‚Â© stoupÃƒÆ’Ã‚Â¡ s deÃƒâ€¦Ã‚Â¡tÃƒâ€žÃ¢â‚¬Âºm a klesÃƒÆ’Ã‚Â¡ evapotranspiracÃƒÆ’Ã‚Â­ Ãƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­zenou teplotou, roÃƒâ€žÃ‚ÂnÃƒÆ’Ã‚Â­m obdobÃƒÆ’Ã‚Â­m a typem pÃƒâ€¦Ã‚Â¯dy. KdyÃƒâ€¦Ã‚Â¾ vlhkost klesne pod prahovÃƒÆ’Ã‚Â© hodnoty specifickÃƒÆ’Ã‚Â© pro danou plodinu bÃƒâ€žÃ¢â‚¬Âºhem kritickÃƒÆ’Ã‚Â½ch rÃƒâ€¦Ã‚Â¯stovÃƒÆ’Ã‚Â½ch oken, hromadÃƒÆ’Ã‚Â­ se stres vÃƒÆ’Ã‚Â½nosu a sniÃƒâ€¦Ã‚Â¾uje vaÃƒâ€¦Ã‚Â¡i sklizeÃƒâ€¦Ã‹â€  na konci sezÃƒÆ’Ã‚Â³ny.
+KaÃ…Â¾dÃƒÂ© pole sleduje procento vlhkosti pÃ…Â¯dy (0-100%), kterÃƒÂ© stoupÃƒÂ¡ s deÃ…Â¡tÃ„â€ºm a klesÃƒÂ¡ evapotranspiracÃƒÂ­ Ã…â„¢ÃƒÂ­zenou teplotou, roÃ„ÂnÃƒÂ­m obdobÃƒÂ­m a typem pÃ…Â¯dy. KdyÃ…Â¾ vlhkost klesne pod prahovÃƒÂ© hodnoty specifickÃƒÂ© pro danou plodinu bÃ„â€ºhem kritickÃƒÂ½ch rÃ…Â¯stovÃƒÂ½ch oken, hromadÃƒÂ­ se stres vÃƒÂ½nosu a sniÃ…Â¾uje vaÃ…Â¡i sklizeÃ…Ë† na konci sezÃƒÂ³ny.
 
 FUNKCE:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulace vlhkosti pÃƒâ€¦Ã‚Â¯dy pro kaÃƒâ€¦Ã‚Â¾dÃƒÆ’Ã‚Â© pole Ãƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­zenÃƒÆ’Ã‚Â¡ reÃƒÆ’Ã‚Â¡lnÃƒÆ’Ã‚Â½m poÃƒâ€žÃ‚ÂasÃƒÆ’Ã‚Â­m
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SezÃƒÆ’Ã‚Â³nnÃƒâ€žÃ¢â‚¬Âº a teplotnÃƒâ€žÃ¢â‚¬Âº upravenÃƒÆ’Ã‚Â¡ evapotranspirace
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ModifikÃƒÆ’Ã‚Â¡tory typu pÃƒâ€¦Ã‚Â¯dy: pÃƒÆ’Ã‚Â­sÃƒâ€žÃ‚ÂitÃƒÆ’Ã‚Â¡ odvÃƒÆ’Ã‚Â¡dÃƒÆ’Ã‚Â­ rychle, jÃƒÆ’Ã‚Â­lovitÃƒÆ’Ã‚Â¡ drÃƒâ€¦Ã‚Â¾ÃƒÆ’Ã‚Â­ vlhkost
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ KritickÃƒÆ’Ã‚Â¡ rÃƒâ€¦Ã‚Â¯stovÃƒÆ’Ã‚Â¡ okna specifickÃƒÆ’Ã‚Â¡ pro plodiny (pÃƒâ€¦Ã‚Â¡enice, kukuÃƒâ€¦Ã¢â€žÂ¢ice, jeÃƒâ€žÃ‚Âmen, Ãƒâ€¦Ã¢â€žÂ¢epka a dalÃƒâ€¦Ã‚Â¡ÃƒÆ’Ã‚Â­)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SnÃƒÆ’Ã‚Â­Ãƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â­ vÃƒÆ’Ã‚Â½nosu pÃƒâ€¦Ã¢â€žÂ¢i sklizni ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â aÃƒâ€¦Ã‚Â¾ 60% ztrÃƒÆ’Ã‚Â¡ta pÃƒâ€¦Ã¢â€žÂ¢i maximÃƒÆ’Ã‚Â¡lnÃƒÆ’Ã‚Â­m stresu
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒâ€¦Ã¢â€žÂ¢ekrytÃƒÆ’Ã‚Â­ HUD vlhkosti pole s 5dennÃƒÆ’Ã‚Â­ pÃƒâ€¦Ã¢â€žÂ¢edpovÃƒâ€žÃ¢â‚¬ÂºdÃƒÆ’Ã‚Â­ (stisknÃƒâ€žÃ¢â‚¬Âºte Shift+M pro pÃƒâ€¦Ã¢â€žÂ¢epnutÃƒÆ’Ã‚Â­)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ UmÃƒÆ’Ã‚Â­stitelnÃƒÆ’Ã‚Â© stÃƒâ€¦Ã¢â€žÂ¢edovÃƒÆ’Ã‚Â© pivoty a kapkovÃƒÆ’Ã‚Â© zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ s infrastrukturou vodnÃƒÆ’Ã‚Â­ pumpy
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog plÃƒÆ’Ã‚Â¡novÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­ ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â nastavte aktivnÃƒÆ’Ã‚Â­ dny a hodinovÃƒÆ’Ã‚Â© okno (Shift+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog poradce pro plodiny s pÃƒâ€¦Ã¢â€žÂ¢ehledem rizik a doporuÃƒâ€žÃ‚ÂenÃƒÆ’Ã‚Â­mi (Shift+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VolitelnÃƒÆ’Ã‚Â¡ integrace s FS25_NPCFavor (Alex Chen, NPC agronom)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ VolitelnÃƒÆ’Ã‚Â¡ integrace s FS25_UsedPlus (trÃƒâ€¦Ã‚Â¾iÃƒâ€¦Ã‚Â¡tÃƒâ€žÃ¢â‚¬Âº pouÃƒâ€¦Ã‚Â¾itÃƒÆ’Ã‚Â©ho vybavenÃƒÆ’Ã‚Â­)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ ÃƒÆ’Ã…Â¡plnÃƒÆ’Ã‚Â¡ persistence uloÃƒâ€¦Ã‚Â¾enÃƒÆ’Ã‚Â­/naÃƒâ€žÃ‚ÂtenÃƒÆ’Ã‚Â­ vÃƒâ€¦Ã‚Â¡ech stavÃƒâ€¦Ã‚Â¯ polÃƒÆ’Ã‚Â­ a zavlaÃƒâ€¦Ã‚Â¾ovÃƒÆ’Ã‚Â¡nÃƒÆ’Ã‚Â­
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ PÃƒâ€¦Ã¢â€žÂ¢ÃƒÆ’Ã‚Â­kazy ladicÃƒÆ’Ã‚Â­ konzole (napiÃƒâ€¦Ã‚Â¡te csHelp do vÃƒÆ’Ã‚Â½vojÃƒÆ’Ã‚Â¡Ãƒâ€¦Ã¢â€žÂ¢skÃƒÆ’Ã‚Â© konzole)
+Ã¢â‚¬Â¢ Simulace vlhkosti pÃ…Â¯dy pro kaÃ…Â¾dÃƒÂ© pole Ã…â„¢ÃƒÂ­zenÃƒÂ¡ reÃƒÂ¡lnÃƒÂ½m poÃ„ÂasÃƒÂ­m
+Ã¢â‚¬Â¢ SezÃƒÂ³nnÃ„â€º a teplotnÃ„â€º upravenÃƒÂ¡ evapotranspirace
+Ã¢â‚¬Â¢ ModifikÃƒÂ¡tory typu pÃ…Â¯dy: pÃƒÂ­sÃ„ÂitÃƒÂ¡ odvÃƒÂ¡dÃƒÂ­ rychle, jÃƒÂ­lovitÃƒÂ¡ drÃ…Â¾ÃƒÂ­ vlhkost
+Ã¢â‚¬Â¢ KritickÃƒÂ¡ rÃ…Â¯stovÃƒÂ¡ okna specifickÃƒÂ¡ pro plodiny (pÃ…Â¡enice, kukuÃ…â„¢ice, jeÃ„Âmen, Ã…â„¢epka a dalÃ…Â¡ÃƒÂ­)
+Ã¢â‚¬Â¢ SnÃƒÂ­Ã…Â¾enÃƒÂ­ vÃƒÂ½nosu pÃ…â„¢i sklizni Ã¢â‚¬â€ aÃ…Â¾ 60% ztrÃƒÂ¡ta pÃ…â„¢i maximÃƒÂ¡lnÃƒÂ­m stresu
+Ã¢â‚¬Â¢ PÃ…â„¢ekrytÃƒÂ­ HUD vlhkosti pole s 5dennÃƒÂ­ pÃ…â„¢edpovÃ„â€ºdÃƒÂ­ (stisknÃ„â€ºte Shift+M pro pÃ…â„¢epnutÃƒÂ­)
+Ã¢â‚¬Â¢ UmÃƒÂ­stitelnÃƒÂ© stÃ…â„¢edovÃƒÂ© pivoty a kapkovÃƒÂ© zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ s infrastrukturou vodnÃƒÂ­ pumpy
+Ã¢â‚¬Â¢ Dialog plÃƒÂ¡novÃƒÂ¡nÃƒÂ­ zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­ Ã¢â‚¬â€ nastavte aktivnÃƒÂ­ dny a hodinovÃƒÂ© okno (Shift+I)
+Ã¢â‚¬Â¢ Dialog poradce pro plodiny s pÃ…â„¢ehledem rizik a doporuÃ„ÂenÃƒÂ­mi (Shift+C)
+Ã¢â‚¬Â¢ VolitelnÃƒÂ¡ integrace s FS25_NPCFavor (Alex Chen, NPC agronom)
+Ã¢â‚¬Â¢ VolitelnÃƒÂ¡ integrace s FS25_UsedPlus (trÃ…Â¾iÃ…Â¡tÃ„â€º pouÃ…Â¾itÃƒÂ©ho vybavenÃƒÂ­)
+Ã¢â‚¬Â¢ ÃƒÅ¡plnÃƒÂ¡ persistence uloÃ…Â¾enÃƒÂ­/naÃ„ÂtenÃƒÂ­ vÃ…Â¡ech stavÃ…Â¯ polÃƒÂ­ a zavlaÃ…Â¾ovÃƒÂ¡nÃƒÂ­
+Ã¢â‚¬Â¢ PÃ…â„¢ÃƒÂ­kazy ladicÃƒÂ­ konzole (napiÃ…Â¡te csHelp do vÃƒÂ½vojÃƒÂ¡Ã…â„¢skÃƒÂ© konzole)
         ]]></cz>
-        <da><![CDATA[TilfÃƒÆ’Ã‚Â¸jer overvÃƒÆ’Ã‚Â¥gning af jordfugtighed, simulering af afgrÃƒÆ’Ã‚Â¸destress og styring af vanding til Farming Simulator 25.
+        <da><![CDATA[TilfÃƒÂ¸jer overvÃƒÂ¥gning af jordfugtighed, simulering af afgrÃƒÂ¸destress og styring af vanding til Farming Simulator 25.
 
-Hvert felt overvÃƒÆ’Ã‚Â¥ger procentdelen af jordfugtighed (0ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“100%), som stiger med regn og falder gennem evapotranspiration, der styres af temperatur, ÃƒÆ’Ã‚Â¥rstid og jordtype. NÃƒÆ’Ã‚Â¥r fugtigheden falder under afgrÃƒÆ’Ã‚Â¸despecifikke tÃƒÆ’Ã‚Â¦rskelvÃƒÆ’Ã‚Â¦rdier i kritiske vÃƒÆ’Ã‚Â¦kstperioder, opbygges udbyttestress, som reducerer din hÃƒÆ’Ã‚Â¸st ved sÃƒÆ’Ã‚Â¦sonens afslutning.
+Hvert felt overvÃƒÂ¥ger procentdelen af jordfugtighed (0Ã¢â‚¬â€œ100%), som stiger med regn og falder gennem evapotranspiration, der styres af temperatur, ÃƒÂ¥rstid og jordtype. NÃƒÂ¥r fugtigheden falder under afgrÃƒÂ¸despecifikke tÃƒÂ¦rskelvÃƒÂ¦rdier i kritiske vÃƒÂ¦kstperioder, opbygges udbyttestress, som reducerer din hÃƒÂ¸st ved sÃƒÂ¦sonens afslutning.
 
 FUNKTIONER:
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Simulering af jordfugtighed for hvert felt baseret pÃƒÆ’Ã‚Â¥ realt vejr
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ SÃƒÆ’Ã‚Â¦son- og temperaturjusteret evapotranspiration
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Jordtype-modifikatorer: sandjord drÃƒÆ’Ã‚Â¦ner hurtigt, lerjord holder pÃƒÆ’Ã‚Â¥ fugt
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Kritiske vÃƒÆ’Ã‚Â¦kstperioder specifikke for afgrÃƒÆ’Ã‚Â¸der (hvede, majs, byg, raps og flere)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Udbyttereduktion ved hÃƒÆ’Ã‚Â¸st ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â op til 60% tab ved maksimal stress
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ HUD-overlay for markfugtighed med 5-dages vejrudsigt (tryk Shift+M for at skifte)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Placerbare center pivot- og drypvandingssystemer med vandpumpeinfrastruktur
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Dialog til planlÃƒÆ’Ã‚Â¦gning af vanding ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â angiv aktive dage og tidsvindue (Shift+I)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ AfgrÃƒÆ’Ã‚Â¸derÃƒÆ’Ã‚Â¥dgiver-dialog med risikovurdering og anbefalinger (Shift+C)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Valgfri integration med FS25_NPCFavor (Alex Chen, NPC agronom)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Valgfri integration med FS25_UsedPlus (marked for brugt udstyr)
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Fuld persistens ved gem/indlÃƒÆ’Ã‚Â¦s af alle mark- og vandingsstatusser
-ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¢ Debug-konsolkommandoer (skriv csHelp i udviklerkonsollen)
+Ã¢â‚¬Â¢ Simulering af jordfugtighed for hvert felt baseret pÃƒÂ¥ realt vejr
+Ã¢â‚¬Â¢ SÃƒÂ¦son- og temperaturjusteret evapotranspiration
+Ã¢â‚¬Â¢ Jordtype-modifikatorer: sandjord drÃƒÂ¦ner hurtigt, lerjord holder pÃƒÂ¥ fugt
+Ã¢â‚¬Â¢ Kritiske vÃƒÂ¦kstperioder specifikke for afgrÃƒÂ¸der (hvede, majs, byg, raps og flere)
+Ã¢â‚¬Â¢ Udbyttereduktion ved hÃƒÂ¸st Ã¢â‚¬â€ op til 60% tab ved maksimal stress
+Ã¢â‚¬Â¢ HUD-overlay for markfugtighed med 5-dages vejrudsigt (tryk Shift+M for at skifte)
+Ã¢â‚¬Â¢ Placerbare center pivot- og drypvandingssystemer med vandpumpeinfrastruktur
+Ã¢â‚¬Â¢ Dialog til planlÃƒÂ¦gning af vanding Ã¢â‚¬â€ angiv aktive dage og tidsvindue (Shift+I)
+Ã¢â‚¬Â¢ AfgrÃƒÂ¸derÃƒÂ¥dgiver-dialog med risikovurdering og anbefalinger (Shift+C)
+Ã¢â‚¬Â¢ Valgfri integration med FS25_NPCFavor (Alex Chen, NPC agronom)
+Ã¢â‚¬Â¢ Valgfri integration med FS25_UsedPlus (marked for brugt udstyr)
+Ã¢â‚¬Â¢ Fuld persistens ved gem/indlÃƒÂ¦s af alle mark- og vandingsstatusser
+Ã¢â‚¬Â¢ Debug-konsolkommandoer (skriv csHelp i udviklerkonsollen)
         ]]></da>
     </description>
 
@@ -183,7 +183,7 @@ FUNKTIONER:
     </inputBinding>
 
     <!--
-        All strings ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â including input action descriptions (input_CS_*) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â
+        All strings Ã¢â‚¬â€ including input action descriptions (input_CS_*) Ã¢â‚¬â€
         are defined in the external translation files. No inline l10n block
         is needed and none is used.
         NOTE: FS25 only processes the FIRST <l10n> element. Two separate
@@ -211,7 +211,7 @@ FUNKTIONER:
         <specialization name="RWSM53ChangeObjectByDistance" className="RWSM53ChangeObjectByDistance" filename="src/vendor/rwsm/changeObjectByDistance.lua"/>
         <specialization name="RWSM53AutoReel" className="RWSM53AutoReel" filename="src/vendor/rwsm/rainstarAutoReel.lua"/>
         <specialization name="RWSM118RainstarParkingBrake" className="RWSM118RainstarParkingBrake" filename="src/vendor/rwsm/rainstarParkingBrake.lua"/>
-        <!-- BUILD 19:27 - suite-owned visible EMPâ†”Rainstar supply hose (not COBD / not SPS). -->
+        <!-- BUILD 19:27 - suite-owned visible EMP↔Rainstar supply hose (not COBD / not SPS). -->
         <specialization name="ScsPumpHoseConnection" className="ScsPumpHoseConnection" filename="src/ScsPumpHoseConnection.lua"/>
         <!-- BUILD 22:25 - the EMP pump powers the reel, so no tractor is required to spray. -->
         <specialization name="ScsRainstarPumpPower" className="ScsRainstarPumpPower" filename="src/ScsRainstarPumpPower.lua"/>
@@ -266,12 +266,12 @@ FUNKTIONER:
     </storeItems>
 
     <!--
-        In-game help pages accessible from the pause menu ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Help.
+        In-game help pages accessible from the pause menu Ã¢â€ â€™ Help.
         Four categories: Overview, Settings, Tips & Tricks, Mod Information.
     -->
     <helpLines>
 
-        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 1: Overview ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
+        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 1: Overview Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
         <category title="$l10n_helpLine_cs_cat_overview">
 
             <page title="$l10n_helpLine_cs_p1_title" iconSliceId="icon_crops">
@@ -335,7 +335,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 2: Settings ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
+        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 2: Settings Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
         <category title="$l10n_helpLine_cs_cat_settings">
 
             <page title="$l10n_helpLine_cs_s1_title" iconSliceId="icon_crops">
@@ -362,7 +362,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 3: Tips & Tricks ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
+        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 3: Tips & Tricks Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
         <category title="$l10n_helpLine_cs_cat_tips">
 
             <page title="$l10n_helpLine_cs_p4_title" iconSliceId="icon_crops">
@@ -400,7 +400,7 @@ FUNKTIONER:
 
         </category>
 
-        <!-- ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Category 4: Mod Information ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ -->
+        <!-- Ã¢â€â‚¬Ã¢â€â‚¬ Category 4: Mod Information Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬ -->
         <category title="$l10n_helpLine_cs_cat_info">
 
             <page title="$l10n_helpLine_cs_i1_title" iconSliceId="icon_info">

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -209,18 +209,30 @@
 
                         <!-- Card 2 of 3 (BUILD 12:59): Selected + Next now live INSIDE the
                              PRODUCTS card, so the card owns the whole middle column. -->
-                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="540px 20px"
+                        <!-- GO 21:06 (BUILD 21:01): PRODUCTS was inheriting 560 from
+                             RF_EscCardFrame, so its right edge sat at 220 + 560 = 780 against
+                             ROTATION at 850: a dark 70px canyon down the middle of a three-card
+                             family. The inline 620 lands the right edge on 840, leaving 10px of
+                             air, and TREATMENT already ends at 210 against PRODUCTS at 220, so
+                             both gutters read as the same gap. Family rhythm, not a kiss.
+                             Bodies follow 540 -> 600 in step so the 10px left inset is kept and
+                             nothing is re-centred; RATE and TOTAL keep their left-anchored
+                             recipe and simply gain trailing air.
+                             This edit is in ALL NINE door copies on purpose. The Esc page is
+                             built by whichever mod loads first, from its own copy, so a change
+                             in Soil alone would be overwritten by whoever won the race. -->
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="540px 36px"
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
                                   textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
                             <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
                                  air with one 1px hairline centred in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="540px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="540px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
                             <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
                             <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
@@ -228,54 +240,54 @@
                                   textAlignment="right" text="RATE"/>
                             <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="540px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
                                  card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="540px 120px">
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="540px 15px" visible="false">
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd1Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow2" position="0px -15px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd2Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd2Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd2Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow3" position="0px -30px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd3Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd3Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd3Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow4" position="0px -45px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd4Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd4Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd4Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow5" position="0px -60px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd5Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd5Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd5Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow6" position="0px -75px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd6Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd6Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd6Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow7" position="0px -90px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd7Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd7Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Rate" position="320px 0px" size="100px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd7Total" position="430px 0px" size="110px 15px"/>
                                 </GuiElement>
-                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="540px 15px" visible="false">
+                                <GuiElement profile="RF_ProductRow" id="treatProdRow8" position="0px -105px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd8Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd8Name" position="44px 0px" size="270px 15px"/>
                                     <Text profile="RF_ProductCellDenseRight" id="treatProd8Rate" position="320px 0px" size="100px 15px"/>
@@ -341,58 +353,80 @@
                     <!-- Worker Costs page bodies only (page chrome = left sibling band). -->
                     <GuiElement profile="RF_WcPageShell" id="wcPageShell" visible="false">
                         <!-- Dashboard -->
-                        <GuiElement profile="RF_WcPage" id="wcPageDashboard" visible="true">
-                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="0px 0px" size="1140px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="0px -200px" size="1140px 280px"
+                        <!-- Dashboard is the only WC page that gets the white card (Ash 15:35 #2):
+                             Wages/Workers/About carry MTOs and their own chrome. Framed on
+                             wcPageDashboard itself, not a new inner shell, so nothing double-frames.
+                             Body cells inset 10px L/R and 8px down; worker names still 280 tall and
+                             end at -488 of 500, so 12px of bottom air and no clip. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="wcPageDashboard" visible="true">
+                            <Text profile="RF_TreatTargetLine" id="wcDashStatus" position="10px -8px" size="1120px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashMode" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWage" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashRate" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashWorkers" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashEstimate" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="wcDashCountdown" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="wcDashWorkerNames" position="10px -208px" size="1120px 280px"
                                   textMaxNumLines="12" textVerticalAlignment="top" text=""/>
                         </GuiElement>
 
                         <!-- Wages: tight label+option rows; summary/help/Reset UNDER stack (no 760 side column). -->
+                        <!-- Two cards, not one: settings stack up, summary/help/Reset below, 16px of
+                             clear air between the strokes. The page itself stays unframed - a frame on
+                             RF_WcPage would be the mega-shell over the MTOs George vetoed. Wrappers carry
+                             handleFocus=false so nothing between the player and an option can take a click,
+                             and the MTOs are still found by getDescendantById, which does not care how deep
+                             they sit. Card B trims one internal gap by 8px, which is exactly what the two
+                             strokes plus their air cost, so wcBtnWageReset lands back on -536 and the page
+                             stays 580 tall. Nothing grew to make room. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWages" size="1140px 580px" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="0px 8px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="220px 0px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="0px -44px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="220px -52px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="0px -96px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="220px -104px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="0px -148px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="220px -156px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="0px -200px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="220px -208px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="0px -252px" size="200px 22px" text=""/>
-                            <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="220px -260px"
-                                             disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
-                            <!-- Summary band under last option (~-260); full width; not overlapping options. -->
-                            <Text profile="RF_SectionTitle" id="wcWageBigRate" position="0px -340px" size="1140px 36px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="0px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -384px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcWageHelpBody" position="0px -420px" size="1140px 100px"
-                                  textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                            <Button profile="buttonActivate" id="wcBtnWageReset" position="0px -536px" size="200px 36px"
-                                    text="Reset" onClick="onClickWcWageReset"/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardA" position="0px 0px" size="1140px 326px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblEnabled" position="10px -10px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptEnabled" position="230px -18px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblMode" position="10px -62px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptCostMode" position="230px -70px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblLevel" position="10px -114px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptWageLevel" position="230px -122px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblNotify" position="10px -166px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptNotifications" position="230px -174px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblDebug" position="10px -218px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptDebugMode" position="230px -226px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageLblSalary" position="10px -270px" size="200px 22px" text=""/>
+                                <MultiTextOption profile="RF_WcWageOption" id="wcOptMonthlySalary" position="230px -278px"
+                                                 disableButtonsOnSingleText="false" onClick="onClickWcWageOption"/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWagesCardB" position="0px -342px" size="1140px 238px" handleFocus="false">
+                                <Text profile="RF_SectionTitle" id="wcWageBigRate" position="10px -6px" size="1120px 36px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWageRateLabel" position="10px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcWagePayInterval" position="580px -50px" size="550px 22px" text=""/>
+                                <Text profile="RF_HintText" id="wcWageHelpBody" position="10px -86px" size="1120px 100px"
+                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
+                                <Button profile="buttonActivate" id="wcBtnWageReset" position="10px -194px" size="200px 36px"
+                                        text="Reset" onClick="onClickWcWageReset"/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- Workers -->
+                        <!-- Same family as Wages: stats card, 16px of air, then the worker list card.
+                             wcStatsWorkerList stays fixed Text rows, no SmoothList. -->
                         <GuiElement profile="RF_WcPage" id="wcPageWorkers" visible="false">
-                            <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="wcStatsWorkerList" position="0px -160px" size="1140px 320px"
-                                  textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardA" position="0px 0px" size="1140px 136px" handleFocus="false">
+                                <Text profile="RF_TreatTargetLine" id="wcStatsMode" position="10px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsWage" position="580px -10px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsInterval" position="10px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCount" position="580px -58px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsCostPer" position="10px -106px" size="550px 22px" text=""/>
+                                <Text profile="RF_TreatTargetLine" id="wcStatsTotal" position="580px -106px" size="550px 22px" text=""/>
+                            </GuiElement>
+                            <GuiElement profile="RF_EscCardFrameWide" id="wcWorkersCardB" position="0px -152px" size="1140px 338px" handleFocus="false">
+                                <Text profile="RF_HintText" id="wcStatsWorkerList" position="10px -10px" size="1120px 320px"
+                                      textMaxNumLines="14" textVerticalAlignment="top" text=""/>
+                            </GuiElement>
                         </GuiElement>
 
                         <!-- About page retired 2026-08-02: copy lives in wcSideInfoShell. Keep shell for nil-safe ids. -->
@@ -417,61 +451,84 @@
                          Text-only; no onClick. Visible only for framework module ids.
                          George 2026-08-05: shell 0/-20 (X flush + B1 blurb-48 clearance); titles hidden; rows +36. -->
                     <GuiElement profile="RF_WcPageShell" id="rfFrameworkGlanceShell" visible="false" position="0px 0px">
-                        <GuiElement id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="0px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="0px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="0px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="0px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px 0px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -48px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -96px" size="560px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -144px" size="560px 22px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHint" position="0px -200px" size="1140px 120px"
+                        <!-- Income / Tax / Depot status glance. 580 was taller than the shell (520);
+                             the card is sized to its content instead: hint ends at -328, so 340
+                             leaves 12px of bottom air inside the stroke. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwStatusBlock" visible="true" position="0px 0px" size="1140px 340px">
+                            <Text profile="RF_SectionTitle" id="rfFwStatusTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine1" position="10px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine2" position="10px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine3" position="10px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine4" position="10px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine5" position="580px -8px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine6" position="580px -56px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine7" position="580px -104px" size="550px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwLine8" position="580px -152px" size="550px 22px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwHint" position="10px -208px" size="1120px 120px"
                                   textMaxNumLines="4" textVerticalAlignment="top" text=""/>
                         </GuiElement>
-                        <GuiElement id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 580px">
-                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="0px 0px" size="1140px 24px" text="" visible="false"/>
-                            <Text profile="RF_ColHeader" id="rfFwColA" position="0px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColB" position="300px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColC" position="600px -32px" size="220px 22px" text=""/>
-                            <Text profile="RF_ColHeader" id="rfFwColD" position="840px -32px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="0px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="300px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="600px -60px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="840px -60px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="0px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="300px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="600px -88px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="840px -88px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="0px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="300px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="600px -116px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="840px -116px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="0px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="300px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="600px -144px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="840px -144px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="0px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="300px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="600px -172px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="840px -172px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="0px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="300px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="600px -200px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="840px -200px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="0px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="300px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="600px -228px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="840px -228px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="0px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="300px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="600px -256px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="840px -256px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="0px -292px" size="1140px 20px" text=""/>
-                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="0px -60px" size="1140px 44px"
+                        <!-- Dairy / NPC Favor table glance. Content runs to -416 (hint under the rows),
+                             so 428 gives the same 12px of bottom air. Only one of the two blocks is
+                             ever visible (setVis is an either/or), so no card is ever naked beside
+                             another - Ash 15:35 #1 sibling framing has nothing to bite on here. -->
+                        <GuiElement profile="RF_EscCardFrameWide" id="rfFwTableBlock" visible="false" position="0px 0px" size="1140px 428px">
+                            <Text profile="RF_SectionTitle" id="rfFwTableTitle" position="10px -8px" size="1120px 24px" text="" visible="false"/>
+                            <!-- Excel sheet: the outer border is rfFwTableBlock's own hasFrame; these 11 hairlines
+                                 are the inner grid. RF_EscCardRule is already blank.png + soft grey 0.55, so they
+                                 take it with an inline size rather than one profile per orientation. Declared
+                                 before the cells so text paints over them. Per-cell hasFrame would have been 144
+                                 frame rects for the same picture. -->
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
+                            <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="0px -328px" size="1140px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                         </GuiElement>
                     </GuiElement>
@@ -710,23 +767,23 @@
                         <Bitmap profile="RF_TreatmentBoxBg"/>
 
                         <!-- Page A — Prices -->
-                        <GuiElement id="mdPricesBand" visible="true" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdPricesBand" visible="true" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdGraphTitle" position="10px -6px" size="700px 22px" text=""/>
-                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea"/>
-            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="40px -96px" size="720px 40px"
+                            <GuiElement profile="RF_MdGraphArea" id="mdGraphArea" position="30px -28px"/>
+            <Text profile="RF_EmptyHint" id="mdGraphEmptyHint" position="30px -86px" size="720px 40px"
                   visible="false" text=""/>
-            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="380px 22px"
+            <Text profile="RF_TreatSelected" id="mdDetailCommodity" position="770px -32px" size="350px 22px"
                   textAlignment="left" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="380px 20px" text=""/>
-            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="380px 20px" text=""/>
-            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="380px 44px"
+            <Text profile="RF_TreatTargetLine" id="mdDetailPrice" position="770px -64px" size="350px 20px" text=""/>
+            <Text profile="RF_TreatTargetLine" id="mdDetailPressure" position="770px -92px" size="350px 20px" text=""/>
+            <Text profile="RF_HintText" id="mdDetailEmpty" position="770px -64px" size="350px 44px"
                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtn" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page B — Events (fixed Text rows; no SmoothList thrash). -->
-                        <GuiElement id="mdEventsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdEventsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdEventsTitle" position="10px -6px" size="700px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColName" position="10px -36px" size="420px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdEvColIntensity" position="450px -36px" size="220px 20px" text=""/>
@@ -752,12 +809,12 @@
                             <Text profile="RF_TreatTargetLine" id="mdEvMore" position="10px -240px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdEventsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnEvents" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
 
                         <!-- Page C — Contracts (read-only fixed rows). -->
-                        <GuiElement id="mdContractsBand" visible="false" position="0px 0px" size="100% 100%">
+                        <GuiElement profile="RF_EscCardFrameWide" id="mdContractsBand" visible="false" position="10px -10px" size="1130px 344px">
                             <Text profile="RF_SectionTitle" id="mdContractsTitle" position="10px -6px" size="900px 22px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColCrop" position="10px -36px" size="280px 20px" text=""/>
                             <Text profile="RF_ColHeader" id="mdCtColQty" position="300px -36px" size="220px 20px" text=""/>
@@ -786,7 +843,7 @@
                             <Text profile="RF_TreatTargetLine" id="mdCtMore" position="10px -212px" size="1100px 20px" text=""/>
                             <Text profile="RF_HintText" id="mdContractsEmpty" position="10px -64px" size="1100px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="360px 36px"
+            <Button profile="buttonActivate" id="mdOpenMarketBtnContracts" position="770px -280px" size="350px 36px"
                     onClick="onClickMdOpenMarket"/>
                         </GuiElement>
                     </GuiElement>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -12,9 +12,13 @@
     <GuiElement profile="RF_PageRoot" id="rfPageRoot">
         <GuiElement profile="fs25_subCategorySelectorTabbedContainer" id="rfContentHost" absoluteSizeOffset="0px 0px">
 
-            <!-- BUILD 22:25: Map glass shell restored (463 + notch). Flat RF_SideColUnderlay retired. -->
-            <ThreePartBitmap profile="fs25_subCategoryContainerBg" id="rfSideGlass">
-                <Bitmap profile="fs25_subCategoryContainerArrow"/>
+            <!-- Round 2 D2: opaque column fill painted FIRST (x 0..404, full height, behind nest/cards). -->
+            <Bitmap profile="RF_SideColUnderlay"/>
+
+            <!-- LEFT nest glass hidden (round 3): sidebar is one flat RF_SideColUnderlay tone.
+                 Element kept in tree for structure; no Lua re-shows it. -->
+            <ThreePartBitmap profile="RF_SubCategoryContainerBg" visible="false">
+                <Bitmap profile="fs25_subCategoryContainerArrow" visible="false"/>
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
@@ -31,7 +35,7 @@
                 <ThreePartBitmap profile="fs25_lineSeparatorTop" id="rfSideMidSeparator"
                                  position="8px -130px" width="380px" visible="false"/>
 
-                <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; glass-back InfoBoxBg). -->
+                <!-- Soil/CS left info (George: inside rfFilterBox, BEFORE moduleList; Text + blank.png). -->
                 <GuiElement profile="RF_SideInfoShell" id="rfSideInfoShell" visible="false" handleFocus="false">
                     <Bitmap profile="RF_InfoBoxBg" handleFocus="false"/>
                     <Text profile="RF_SideInfoBody" id="rfSideInfoBody" position="8px -8px" size="368px 644px"
@@ -42,15 +46,14 @@
                     <Text profile="fs25_textGrey" id="wcSideVersion" visible="false" text=""/>
                     <Bitmap profile="fs25_subCategoryStartClipper" name="rfModListStart"/>
                     <Bitmap profile="fs25_subCategoryStopClipper" name="rfModListEnd"/>
-                    <!-- Hang fence: GuiElement parent. Map-family RF_MapList* clones (~56px radio rows). -->
-                    <SmoothList id="moduleList" profile="RF_MapList"
+                    <SmoothList id="moduleList" profile="fs25_subCategoryList"
                                 startClipperElementName="rfModListStart"
                                 endClipperElementName="rfModListEnd">
-                        <ListItem profile="RF_MapListItem" onClick="onClickModuleRow">
-                            <Bitmap profile="RF_MapListItemIconBg" name="iconBg"/>
-                            <Bitmap profile="RF_MapListColorTemplate" name="colorTemplate"/>
-                            <Bitmap profile="RF_MapListItemIcon" name="icon"/>
-                            <Text profile="RF_MapListItemName" name="name"/>
+                        <!-- Compact rows (34px) so Soil stays clickable under taller side shell; not vanilla 100px items. -->
+                        <ListItem profile="RF_ModuleListRow" onClick="onClickModuleRow">
+                            <Bitmap profile="RF_ModuleRowBg" name="alternating"/>
+                            <Text profile="RF_ModuleItemText" name="moduleRowTitle"/>
+                            <Text profile="RF_ModuleItemTag" name="moduleRowTag"/>
                         </ListItem>
                     </SmoothList>
                     <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
@@ -603,13 +606,7 @@
                         <!-- Pivot (red): full-width bottom band. Dial+status left; remotes across width.
                              Children stay inside 1130×240 (strip clipChildren=true). Prefer 80×32. -->
                         <GuiElement profile="RF_EscCardFrame" id="csPivotCard" position="10px -264px" size="1130px 240px">
-                            <Text profile="RF_ProductsTitle" id="csPivotTitle" position="10px -4px" size="560px 18px" text=""/>
-                            <!-- Multi-pivot switcher (George GO: detail card only; no SmoothList thrash). -->
-                            <MultiTextOption profile="RF_CsPivotSwitcher" id="csPivotSwitcher"
-                                             position="580px -2px" size="540px 28px"
-                                             disableButtonsOnSingleText="false"
-                                             visible="false"
-                                             onClick="onClickCsPivotSwitcher"/>
+                            <Text profile="RF_ProductsTitle" id="csPivotTitle" position="10px -4px" size="1110px 18px" text=""/>
                             <!-- Left band: dial + status. -->
                             <Bitmap profile="RF_CsPivotDialFace" id="csPivotDialFace" position="10px -28px" size="92px 92px"/>
                             <!-- BUILD 16:44d (Vera F1): inline size overrides the profile via loadFromXML, so the


### PR DESCRIPTION
## Summary
- Esc-only shared-door freeze: widen Soil PRODUCTS card to 620x248 so PRODUCTS–ROTATION gutters match the 10px family (TREATMENT/ROTATION footprints unchanged).
- Tax only: Status densify FAILFIX (literal GuiUtils reassert every onShow; densify gone).
- Branched clean from live `development`. No `.local/share-staging`, no zip, no gameplay ride-alongs.

## Test plan
- [ ] Esc → RF → Soil: even gaps between the three bottom cards
- [ ] Esc → RF → Tax: Status lines inside the white frame
- [ ] Other RF Esc pages unchanged in behaviour
- [ ] No UTF-8 BOM / UTF-16 on touched files

Replaces the earlier oversized Esc WIP PRs (Sasha CHANGES_REQUESTED on Soil/SCS for deleted shipped APIs / undisclosed pump activatable).