### PR TITLE
fix(esc): restore RF_EscCardFrameWide + RF_FwColHeader profiles dropped in the shared-door merge

### DIFF
--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -287,6 +287,17 @@
         <frameBottomColor value="1 1 1 0.85"/>
     </Profile>
 
+    <Profile name="RF_EscCardFrameWide" extends="RF_WcPage">
+        <clipChildren value="false"/>
+        <hasFrame value="true"/>
+        <frameThickness value="1dp 1dp 1dp 1dp"/>
+        <frameLeftColor value="1 1 1 0.85"/>
+        <frameTopColor value="1 1 1 0.85"/>
+        <frameRightColor value="1 1 1 0.85"/>
+        <frameBottomColor value="1 1 1 0.85"/>
+    </Profile>
+
+
     <!-- BUILD 16:44c: dial face is the Reinke panel's own POSITION scale, not invented
          art. Atlas is that mod's textures/ControlDecals.dds (1024x1024); the dial island
          measured at x288 y354 400x400, which keeps 0/90/180/270 whole and excludes the
@@ -647,6 +658,11 @@
     <Profile name="RF_ColHeaderRight" extends="RF_ColHeader">
         <textAlignment value="center"/>
     </Profile>
+
+    <Profile name="RF_FwColHeader" extends="RF_ColHeader">
+        <textAlignment value="left"/>
+    </Profile>
+
 
     <Profile name="RF_SmoothList" extends="emptyPanel" with="anchorStretchingYLeft pivotTopLeft"/>
 


### PR DESCRIPTION
﻿Restores the RF_EscCardFrameWide and RF_FwColHeader GUI profiles that the shared-door esc-freeze merge dropped (the merge shipped RfPdaMenuPage.xml referencing them, but the rfEscProfiles.xml changes were left behind). Without them the wide cards (WorkerCosts/FarmTablet FW/MarketDynamics bands) and FW column headers fall back to the base profile, so the boxed layout renders wrong. The profiles are re-added exactly as they existed on the source branch (verified against 6abc1ce3). Both XML files still well-formed; no encoding changes.
