### PR TITLE
Hold Crop Stress field remaps until the player has entered

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.77</version>
+    <version>1.2.5.94</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
@@ -218,16 +218,22 @@ FUNKTIONER:
     </specializations>
 
     <vehicleTypes>
-        <!-- className/filename omitted on purpose: TypeManager inherits both from the
-             parent type. The old filename="/scripts/vehicles/Vehicle.lua" was resolved
-             against the mod directory and logged "Can't load resource" once per type. -->
-        <type name="rwsmPlayPump" parent="sprayer">
+        <!-- BUILD 18:55: filename is set explicitly, and the $dataS prefix is the whole
+             point of it. An earlier build removed this attribute because the value then in
+             use was "/scripts/vehicles/Vehicle.lua" with no prefix, which the engine resolved
+             against the MOD directory and logged "Can't load resource" once per type. That
+             removal fixed the wrong half: relying on the parent type to supply the script
+             leaves these three with no filename at all on a joining client.
+             "$dataS/..." points at the game's own copy, so it is neither the old broken
+             mod-relative path nor an omission. className stays absent and is still inherited
+             from the parent type. -->
+        <type name="rwsmPlayPump" parent="sprayer" filename="$dataS/scripts/vehicles/Vehicle.lua">
             <specialization name="motorized"/>
             <specialization name="drivable"/>
             <specialization name="enterable"/>
             <specialization name="ScsPumpHoseConnection"/>
         </type>
-        <type name="rwsmPlayRainstar" parent="sprayer">
+        <type name="rwsmPlayRainstar" parent="sprayer" filename="$dataS/scripts/vehicles/Vehicle.lua">
             <specialization name="RWSM53ChangeObjectByDistance"/>
             <specialization name="RWSM53AutoReel"/>
             <specialization name="RWSM118RainstarParkingBrake"/>
@@ -235,7 +241,7 @@ FUNKTIONER:
         </type>
         <!-- implement_attacherJointControl (vanilla, verified in dataS/vehicleTypes.xml)
              backs the <attacherJointControl> block the XML already carries. -->
-        <type name="rwsmPlaySchiene" parent="implement_attacherJointControl"/>
+        <type name="rwsmPlaySchiene" parent="implement_attacherJointControl" filename="$dataS/scripts/vehicles/Vehicle.lua"/>
     </vehicleTypes>
 
     <placeableSpecializations>

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -522,7 +522,14 @@ function CropStressManager:update(dt)
         -- Read it BEFORE the key is advanced, or it is gone.
         local elapsedHours = CropStressManager.elapsedHoursFrom(self.lastHourKey, hourKey)
         self.lastHourKey = hourKey
-        self:onHourlyTick(elapsedHours)
+        -- BUILD 19:47: nothing hourly runs until the player has actually entered. During a
+        -- long 4x compile this loop was rebuilding a 122-field map every thirty seconds for
+        -- a world nobody was looking at yet, on the same machine that was trying to finish
+        -- loading. The key is still advanced above, so no hours are lost or double counted
+        -- when the gate opens; only the work is held.
+        if g_currentMission ~= nil and g_currentMission.isMissionStarted == true then
+            self:onHourlyTick(elapsedHours)
+        end
     end
 
     -- HUD frame update (handles auto-show, input response)
@@ -550,6 +557,10 @@ end
 function CropStressManager:onHourlyTick(elapsedHours)
     -- Respect the player's master on/off toggle
     if not self.settings.enabled then return end
+
+    -- BUILD 19:47: belt for the caller gate above. This is public and reachable from more
+    -- than the update loop, and the field-map rebuild below is the expensive half.
+    if not (g_currentMission ~= nil and g_currentMission.isMissionStarted == true) then return end
 
     local hours = math.max(1, math.floor(tonumber(elapsedHours) or 1))
 

--- a/src/events/CropStressMoistureInitEvent.lua
+++ b/src/events/CropStressMoistureInitEvent.lua
@@ -28,6 +28,17 @@ CropStressMoistureInitEvent_mt = Class(CropStressMoistureInitEvent, Event)
 
 InitEventClass(CropStressMoistureInitEvent, "CropStressMoistureInitEvent")
 
+--- BUILD 18:55: the engine's EVENT path calls emptyNew() and then readStream on
+--- what it returns, so an event class without one is a nil call the moment its
+--- packet arrives on a joining client. Vanilla shape, matching
+--- CropStressPivotRemoteEvent: construct and return, nothing else.
+--- No field defaults on purpose. readStream fills the instance, and pre-seeding
+--- here would quietly paper over a short or mismatched read instead of failing.
+function CropStressMoistureInitEvent.emptyNew()
+    local self = Event.new(CropStressMoistureInitEvent_mt)
+    return self
+end
+
 -- fieldData   : soilSystem.fieldData   (farmlandId -> {moisture=float, ...})
 -- fieldStress : stressModifier.fieldStress (farmlandId -> float)
 function CropStressMoistureInitEvent.new(fieldData, fieldStress)
@@ -107,7 +118,11 @@ function CropStressMoistureInitEvent:run(connection)
     -- be fully populated yet. The field-ready updater installFieldReadyUpdater()
     -- handles the initial enumeration and field map build when fields become
     -- available, so it's safe to skip here.
-    if g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+    -- BUILD 19:47: the moisture numbers above are applied unconditionally, because a join
+    -- packet has to be fully read whenever it lands. Only the field-map walk waits for the
+    -- player to be in; the field-ready updater rebuilds it afterwards either way.
+    if g_currentMission ~= nil and g_currentMission.isMissionStarted == true
+        and g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
         mgr:buildFieldMap()
     end
 

--- a/src/events/CropStressMoistureRowEvent.lua
+++ b/src/events/CropStressMoistureRowEvent.lua
@@ -33,6 +33,17 @@ CropStressMoistureRowEvent_mt = Class(CropStressMoistureRowEvent, Event)
 
 InitEventClass(CropStressMoistureRowEvent, "CropStressMoistureRowEvent")
 
+--- BUILD 18:55: the engine's EVENT path calls emptyNew() and then readStream on
+--- what it returns, so an event class without one is a nil call the moment its
+--- packet arrives on a joining client. Vanilla shape, matching
+--- CropStressPivotRemoteEvent: construct and return, nothing else.
+--- No field defaults on purpose. readStream fills the instance, and pre-seeding
+--- here would quietly paper over a short or mismatched read instead of failing.
+function CropStressMoistureRowEvent.emptyNew()
+    local self = Event.new(CropStressMoistureRowEvent_mt)
+    return self
+end
+
 --- @param rowIndex number  map row (0-based)
 --- @param packed table     run-length pairs from CropStressValueMap.packRow
 function CropStressMoistureRowEvent.new(rowIndex, packed)

--- a/src/events/CropStressSettingsSyncEvent.lua
+++ b/src/events/CropStressSettingsSyncEvent.lua
@@ -24,6 +24,17 @@ CropStressSettingsSyncEvent_mt = Class(CropStressSettingsSyncEvent, Event)
 
 InitEventClass(CropStressSettingsSyncEvent, "CropStressSettingsSyncEvent")
 
+--- BUILD 18:55: the engine's EVENT path calls emptyNew() and then readStream on
+--- what it returns, so an event class without one is a nil call the moment its
+--- packet arrives on a joining client. Vanilla shape, matching
+--- CropStressPivotRemoteEvent: construct and return, nothing else.
+--- No field defaults on purpose. readStream fills the instance, and pre-seeding
+--- here would quietly paper over a short or mismatched read instead of failing.
+function CropStressSettingsSyncEvent.emptyNew()
+    local self = Event.new(CropStressSettingsSyncEvent_mt)
+    return self
+end
+
 -- Event type constants
 CropStressSettingsSyncEvent.TYPE_SINGLE = 1
 CropStressSettingsSyncEvent.TYPE_BULK = 2

--- a/src/integrations/CropStressNetworkSyncBridge.lua
+++ b/src/integrations/CropStressNetworkSyncBridge.lua
@@ -139,7 +139,10 @@ function CropStressNetworkSyncBridge._onReadState(arr)
 
     -- Rebuild field map only when fields are ready; on MP join the field manager
     -- may not yet be populated. The field-ready updater handles initial enumeration.
-    if mgr.buildFieldMap ~= nil and g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
+    -- BUILD 19:47: same shape as the init event. State above is applied every time; the
+    -- map walk is the part that waits for the player to be in.
+    if g_currentMission ~= nil and g_currentMission.isMissionStarted == true
+        and mgr.buildFieldMap ~= nil and g_fieldManager ~= nil and g_fieldManager.fields ~= nil then
         mgr:buildFieldMap()
     end
 end


### PR DESCRIPTION
## Summary
- Construct the three Crop Stress join packets with a vanilla empty event, so the engine can read them.
- Point the three irrigation vehicle types at the game Vehicle script.
- Hold the hourly field-map walk until the player has entered. Moisture numbers still apply on join.
- Keep the rain-outlook helper that was in the clone and never packed.

## Test plan
- [ ] Dedicated join: no Client.lua nil on Crop Stress join sends
- [ ] Dedicated join: no Crop Stress Vehicle.lua miss
- [ ] Pre-Start: no field remap every 30 seconds
- [ ] Start is a separate test; this PR does not claim Start is fixed