### PR TITLE
Fix d.cells nil crash on MP join

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.94</version>
+    <version>1.2.5.95</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -620,6 +620,9 @@ end
 function SoilMoistureSystem:_writeCell(fieldId, cx, cz, newValue)
     local d = self.fieldData[fieldId]
     if d == nil then return nil end
+    if d.cells == nil then d.cells = {} end
+    if d.cellCount == nil then d.cellCount = 0 end
+    if d.cellSum == nil then d.cellSum = 0 end
     newValue = math.max(0.0, math.min(1.0, newValue or 0))
     local row = d.cells[cx]
     if row == nil then
@@ -708,6 +711,9 @@ function SoilMoistureSystem:materialiseRelief(fieldId)
     local d = self.fieldData[fieldId]
     if d == nil or d.reliefScan then return end
     d.reliefScan = true
+    if d.cells == nil then d.cells = {} end
+    if d.cellCount == nil then d.cellCount = 0 end
+    if d.cellSum == nil then d.cellSum = 0 end
     self._reliefScanned[fieldId] = true
 
     local field = nil


### PR DESCRIPTION
## Summary
- Nil-init guards for `cells`, `cellCount`, `cellSum` in `materialiseRelief` and `_writeCell`
- Field data entries created via MP moisture sync skip the full init path, leaving these nil
- Crash at SoilMoistureSystem.lua:772 cascaded into 540+ packetReceived errors

## Test plan
- [ ] Join dedicated server, Entered Gameplay without d.cells crash
- [ ] No packetReceived flood in client log
- [ ] Relief materialisation still works on fields