### PR TITLE
fix: drop Rainstar control icon names the engine atlas does not have

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.95</version>
+    <version>1.2.5.96</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/vehicles/irrigatorPlay/Rainstar.xml
+++ b/vehicles/irrigatorPlay/Rainstar.xml
@@ -281,13 +281,13 @@
 			</movingTool>
 			
 			<movingTool node="Chassi_vis" playSound="true" >
-                <controls axis="AXIS_FRONTLOADER_TOOL" invertAxis="false" mouseSpeedFactor="1" iconName="ICON_DRUM"/>
+                <controls axis="AXIS_FRONTLOADER_TOOL" invertAxis="false" mouseSpeedFactor="1"/>
 				<rotation rotationAxis="2" rotSpeed="80" rotAcceleration="50" rotMax="180" startRot="90" rotMin="0"/>
                 <componentJoint index="1" />
             </movingTool>
 			
 			<movingTool node="workAreaWidth" playSound="false" >
-                <controls axis="AXIS_FRONTLOADER_TOOL2" invertAxis="false" mouseSpeedFactor="1" iconName="ICON_WWIDTH"/>
+                <controls axis="AXIS_FRONTLOADER_TOOL2" invertAxis="false" mouseSpeedFactor="1"/>
 				<translation transSpeed="3" transAcceleration="70" transMax="87" transMin="55" translationAxis="1"/>
             </movingTool>
         </movingTools>


### PR DESCRIPTION
## Summary
- Remove `iconName=ICON_DRUM` and `ICON_WWIDTH` from Rainstar.xml. `iconName` is optional.
- Carries Tyson's moisture-cells fix already on development (1.2.5.95). Version 1.2.5.96.

## Test plan
- [ ] Load with Rainstar: no `FS25_SeasonalCropStressICON_` warnings
- [ ] Rainstar axis controls still work