### PR TITLE
docs: record PR #140 MP join fix in ROADMAP and TODO

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,3 +93,6 @@
 ## 2026-08-15 (Wizard): Crop Moisture heat sheet + hose-peer log-flood fix
 - [x] CsMoistureMapOverlay now fills each owned farmland with a sampled tile grid (polygon walk + point-in-polygon ported into SCS, no SoilFertilizer dependency), one ramp feeding both the tiles and the legend, display-only (no density-map writes, HUD thresholds untouched). Merged #138; 1.2.5.77.
 - [x] ScsPumpHoseConnection guards every hose-joint read behind phVehicleAlive (component-root liveness) and drops dead peers on the same frame they die, stopping the client log flood and a stale hose prompt after a sale. Merged #137; 1.2.5.77.
+
+## 2026-08-16 (Tyson): MP join d.cells nil crash fix
+- [x] SoilMoistureSystem.lua: nil-init guards for d.cells, d.cellCount, d.cellSum in both materialiseRelief and _writeCell. Field data entries created via MP moisture sync events before the full structure was built caused cascading packetReceived errors (540+ in 8 seconds). Merged #140; 1.2.5.95.

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,7 @@
 - [x] CRITICAL (house rule): PF integration mode active on detection - RESOLVED. No PF code path remains after 77b3064; nothing left to stand down.
 - [x] SCS-001: created overlay handle in `initialize()`, replaced bare `drawFilledRect` calls (fixed, merged to main).
 - [x] SCS-002 / SCS-003: additional SeasonalCropStress bugs fixed in 2026-07-26 bug sweep, merged to main.
+- [x] MP join d.cells nil crash (PR #140, 2026-08-16): SoilMoistureSystem.lua d.cells/d.cellCount/d.cellSum nil when field data arrives via MP sync events before initFieldData builds the full structure. Nil-init guards in materialiseRelief and _writeCell. Wizard diagnosed the exact bug shape in the ledger.
 
 ## Features / enhancements
 - [x] Release gate (2026-08-04): `ReleaseGate.lua` with the `cs_89_rebuild` and `moisture_coupling` rows, both noted "not built yet; locks when it lands" (Arissani 2026-08-03). F93 ships stable and is not in the registry. `experimentalSystems` opt-in (default false, orthogonal to difficulty) through `CropStressSettings` defaults/load/save/validate, the MP bulk sync (count 10 to 11), the SettingsHub mirror and a settings-panel row. `csRelease` status command. 23 assertions in release_gate_test.lua.


### PR DESCRIPTION
## Summary
- Added the 2026-08-16 MP join d.cells nil crash fix (PR #140) to ROADMAP.md and TODO.md
- The fix was merged but not recorded in either file

## Test plan
- [ ] Docs only, no code changes