### PR TITLE
fix(scs): drop the bogus WOOD_CHIPPER_IDLE sound from the pump turn-on

### DIFF
--- a/vehicles/irrigatorPlay/Aggregat.xml
+++ b/vehicles/irrigatorPlay/Aggregat.xml
@@ -215,9 +215,9 @@
 	     turn-on and nothing offered a turn-on surface. ScsPumpHoseConnection already
 	     accepts turn-on OR motor-started, so the enter+ignition path stays valid. -->
 	<turnOnVehicle turnOffIfNotAllowed="false" >
-        <sounds>
-            <work template="WOOD_CHIPPER_IDLE" linkNode="Aggregat_main" />
-        </sounds>
+        <!-- No work sound here: the kit's own pump idle plays through pumpIdleSound
+             below, and the old WOOD_CHIPPER_IDLE reference was a leftover template
+             the game does not have (load-time error). -->
     </turnOnVehicle>
 	
     <foliageBending>


### PR DESCRIPTION
The irrigator kit's Aggregat.xml referenced sound template WOOD_CHIPPER_IDLE in turnOnVehicle.sounds.work, which the game does not have, so the kit errored at load (found in the RF Dev server log: 'Sound template WOOD_CHIPPER_IDLE was not found'). The kit's own pump idle plays through pumpIdleSound; the turn-on block now carries no sound. One line removed.