### PR TITLE
fix: exactFillRootNode syntax + buildFieldMap log spam

### DIFF
--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -447,7 +447,10 @@ function CropStressManager:buildFieldMap()
         end
     end
 
-    csLog(string.format("buildFieldMap: %d fields mapped by fieldId", count))
+    if count ~= (self._lastFieldMapCount or -1) then
+        csLog(string.format("buildFieldMap: %d fields mapped by fieldId", count))
+        self._lastFieldMapCount = count
+    end
     return count
 end
 

--- a/vehicles/irrigatorPlay/Aggregat.xml
+++ b/vehicles/irrigatorPlay/Aggregat.xml
@@ -158,7 +158,9 @@
                         <fillSound template="DEFAULT_REFUEL_SOUND" linkNode="Aggregat_main"/>
                     </fillTrigger>
 					<fillUnit unitTextOverride="$l10n_unit_literShort" showOnHud="false" showInShop="false" fillTypes="WATER" capacity="250000" updateMass="false" startFillLevel="250000" startFillType="WATER" canBeUnloaded="false"/>
-					<fillUnit unitTextOverride="$l10n_unit_literShort" showOnHud="false" showInShop="false" fillTypes="diesel" capacity="450" canBeUnloaded="false" exactFillRootNode="Aggregat_main"/>
+					<fillUnit unitTextOverride="$l10n_unit_literShort" showOnHud="false" showInShop="false" fillTypes="diesel" capacity="450" canBeUnloaded="false">
+						<exactFillRootNode node="Aggregat_main"/>
+					</fillUnit>
                 </fillUnits>
             </fillUnitConfiguration>
         </fillUnitConfigurations>


### PR DESCRIPTION
## Summary
- **Aggregat.xml**: `exactFillRootNode` must be a child element `<exactFillRootNode node="..."/>`, not an attribute on `<fillUnit>`. Confirmed from decompiled `FillUnit.lua` lines 1313-1315 — the engine looks for `key .. ".exactFillRootNode#node"`, ignoring the attribute form silently.
- **CropStressManager**: `buildFieldMap` logged its field count unconditionally on every call, producing ~2 lines/minute on a dedi server. Now only logs when the count changes.

## Test plan
- [ ] Deploy to dedi, check log.txt for `Missing exactFillRootNode` warning — should be gone
- [ ] Check log.txt for `buildFieldMap` spam — should print once on load, then only if a field is bought/sold
- [ ] Verify irrigation pump still accepts diesel refueling (exactFillRootNode enables exact fill targeting)

From dedi test session 2026-08-19.