### PR TITLE
feat(hud): base-game HUD theme, independent forecast pane, width resizing and factory layout defaults

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -102,19 +102,14 @@ source(modDir .. "src/CropStressManager.lua")
 -- g_inputBinding:registerActionEvent directly in loadMission00Finished
 -- is not inside the player input context and silently does nothing.
 -- ============================================================
+-- BUILD 04:34 (Wizard ruling, supersedes the BUILD 22:13 removal): the moisture HUD
+-- callbacks are restored WITH their surface - CropStressManager constructs the real
+-- HUDOverlay again instead of the noop stub, which is what made these rows
+-- lit-but-dead in the first place (PB-H05). The 22:13 principle stands satisfied the
+-- other way around: the actions now drive a HUD that exists.
 local function csToggleHUDCallback(_, _, inputValue)
     if (inputValue or 0) <= 0 then return end
     if g_cropStressManager ~= nil then g_cropStressManager:onToggleHUD() end
-end
-
-local function csOpenIrrigationCallback(_, _, inputValue)
-    if (inputValue or 0) <= 0 then return end
-    if g_cropStressManager ~= nil then g_cropStressManager:onOpenIrrigationDialog() end
-end
-
-local function csOpenConsultantCallback(_, _, inputValue)
-    if (inputValue or 0) <= 0 then return end
-    if g_cropStressManager ~= nil then g_cropStressManager:onOpenConsultantDialog() end
 end
 
 local function csEditHUDCallback(_, _, inputValue)
@@ -127,6 +122,16 @@ local function csEditHUDCallback(_, _, inputValue)
             hud:enterEditMode()
         end
     end
+end
+
+local function csOpenIrrigationCallback(_, _, inputValue)
+    if (inputValue or 0) <= 0 then return end
+    if g_cropStressManager ~= nil then g_cropStressManager:onOpenIrrigationDialog() end
+end
+
+local function csOpenConsultantCallback(_, _, inputValue)
+    if (inputValue or 0) <= 0 then return end
+    if g_cropStressManager ~= nil then g_cropStressManager:onOpenConsultantDialog() end
 end
 
 local function csOpenSettingsCallback(_, _, inputValue)
@@ -173,9 +178,10 @@ end
 
 -- ============================================================
 -- VEHICLE INPUT HOOK
--- Register CS_TOGGLE_HUD and CS_EDIT_HUD in the vehicle input context so
--- Shift+M and Shift+H work while driving (PlayerInputComponent context is
+-- Register CS_TOGGLE_HUD, CS_EDIT_HUD and CS_OPEN_SETTINGS in the vehicle input
+-- context so the HUD keys work while driving (PlayerInputComponent context is
 -- on-foot only; vehicles require a separate registration via Vehicle).
+-- BUILD 04:34: the two moisture HUD actions are back with their restored HUD.
 -- ============================================================
 do
     if Vehicle ~= nil and type(Vehicle.registerActionEvents) == "function" then
@@ -301,6 +307,14 @@ end)
 -- drawStack, so the two paths can never diverge.
 FSBaseMission.draw = Utils.appendedFunction(FSBaseMission.draw, function(self)
     if CropStressMasterHUDBridge ~= nil and CropStressMasterHUDBridge.active then return end
+    -- BUILD 21:53 (PB-H03, George TASK 21:39): the suite hide-all must govern this
+    -- fallback too. When MasterHUD is present but the bridge registration failed or
+    -- has not run yet, this hook is the path that draws - and before this gate it
+    -- drew straight through the player's hide-all. Registered draws are gated inside
+    -- MasterHUD itself; this closes the only RF-side leak. MasterHUD absent means
+    -- there is no suite hide state to honor and the gate passes through.
+    local suiteHud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if suiteHud ~= nil and suiteHud.hudsHidden == true then return end
     if CropStressMasterHUDBridge ~= nil then
         CropStressMasterHUDBridge.drawStack()
     elseif g_csManager ~= nil then

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -162,6 +162,12 @@ FUNKTIONER:
     </extraSourceFiles>
 
     <actions>
+        <!-- BUILD 04:34 (Wizard ruling, supersedes the BUILD 22:13 removal):
+             CS_TOGGLE_HUD and CS_EDIT_HUD are restored WITH their HUD - the manager
+             constructs the real HUDOverlay again, so these rows drive a live surface.
+             No default bindings per Input Convention Rule 1 (no Function keys, the
+             player assigns in Controls). input_CS_* texts already ship in all 26
+             translation files. -->
         <action name="CS_TOGGLE_HUD"/>
         <action name="CS_OPEN_IRRIGATION"/>
         <action name="CS_OPEN_CONSULTANT"/>
@@ -172,10 +178,17 @@ FUNKTIONER:
     </actions>
 
     <inputBinding>
-        <actionBinding action="CS_TOGGLE_HUD" />
+        <!-- BUILD 06:43 (Sam DESIGN 06:42): seat-locked non-Function defaults so a
+             fresh save can drive the Moisture HUD out of the box - Alt+M toggles,
+             Shift+Alt+M edits/moves. The other actions stay player-assigned. -->
+        <actionBinding action="CS_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_m" />
+        </actionBinding>
         <actionBinding action="CS_OPEN_IRRIGATION" />
         <actionBinding action="CS_OPEN_CONSULTANT" />
-        <actionBinding action="CS_EDIT_HUD" />
+        <actionBinding action="CS_EDIT_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_lalt KEY_m" />
+        </actionBinding>
         <actionBinding action="CS_OPEN_SETTINGS" />
         <actionBinding action="RWSM53_REEL_TOGGLE">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_n" axisComponent="+" inputComponent="+" index="1"/>

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -181,12 +181,15 @@ function CropStressManager.new()
     self.soilMoistureSystem = self.soilSystem   -- FarmTablet compatibility alias
     self.stressModifier     = CropStressModifier.new(self)
     self.irrigationManager  = IrrigationManager.new(self)       -- Phase 2 stub
-    -- HUD removed: monitoring moved to the PDA screen (CsPDAScreen).
-    self.hudOverlay = {
-        initialize=function()end, update=function()end, draw=function()end,
-        delete=function()end, toggle=function()end, onMouseEvent=function()end,
-        isVisible=false, panelX=0, panelY=0,
-    }
+    -- BUILD 04:34 (Wizard Motherbarn 2026-08-21 02:10Z): the real HUD is BACK. The
+    -- noop stub that replaced it ("HUD removed: monitoring moved to the PDA screen")
+    -- left CS_TOGGLE_HUD / CS_EDIT_HUD driving nothing, which cascaded into the
+    -- lit-but-dead rows of PB-H05 and their brief removal at BUILD 22:13 - both now
+    -- superseded by Wizard's ruling: the actions open a moisture HUD, so a moisture
+    -- HUD must exist to open. CsPDAScreen keeps the PDA monitoring unchanged; this
+    -- HUD is the on-world glance beside it, hidden until toggled (isVisible=false in
+    -- new, then synced from settings.hudVisible below).
+    self.hudOverlay = HUDOverlay.new(self)
     self.consultant         = CropConsultant.new(self)
     self.moistureMapOverlay = CsMoistureMapOverlay ~= nil and CsMoistureMapOverlay.new(self) or nil
     self.npcIntegration     = NPCIntegration.new(self)

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -485,6 +485,19 @@ function CropStressManager:applySettings()
     -- Push persisted HUD position (client-local display preference, not synced to MP)
     self.hudOverlay.panelX = self.settings.hudPanelX
     self.hudOverlay.panelY = self.settings.hudPanelY
+    -- Forecast pane home: -1 sentinel = docked to the panel (leave nil), >= 0 = absolute
+    if self.settings.hudForecastX ~= nil and self.settings.hudForecastX >= 0
+    and self.settings.hudForecastY ~= nil and self.settings.hudForecastY >= 0 then
+        self.hudOverlay.forecastX = self.settings.hudForecastX
+        self.hudOverlay.forecastY = self.settings.hudForecastY
+    else
+        self.hudOverlay.forecastX = nil
+        self.hudOverlay.forecastY = nil
+    end
+    -- Scale + per-pane width multipliers (Wizard 2026-08-21 width wave)
+    self.hudOverlay.scale             = self.settings.hudScale         or self.hudOverlay.scale
+    self.hudOverlay.widthMult         = self.settings.hudWidthMult     or self.hudOverlay.widthMult
+    self.hudOverlay.forecastWidthMult = self.settings.hudForecastWMult or self.hudOverlay.forecastWidthMult
 
     csLog("Settings applied to all subsystems")
 end

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -23,39 +23,52 @@
 -- All values are normalized screen fractions (0.0–1.0).
 -- ============================================================
 
-HUDOverlay = {}
+-- BUILD 17:57 + ATTN 18:02 (Wizard hot-reload law, FS25-HotReload-Guide.md Part 1):
+-- reuse the existing class table on Ctrl+R reload so updated methods land on the
+-- table live metatables already reference, instead of orphaning it.
+HUDOverlay = HUDOverlay or {}
 HUDOverlay.__index = HUDOverlay
 
 -- ── Main panel layout ──────────────────────────────────────
--- BUILD 06:43 (Sam DESIGN 06:42): fresh-save home is middle-LEFT (0.02, 0.45) in
--- the suite's staggered default layout - clear of the vanilla minimap corner the
--- old (0.010, 0.175) default crowded. A saved layout still wins (settings
+-- BUILD 15:47 (Sam DESIGN 15:46): fresh-save home is LEFT at (0.010, 0.180), panel
+-- narrowed to 0.160 wide, rows capped at 4 - top edge 0.312, under Favors at 0.370.
+-- The 5-day forecast strip moved from BELOW the panel to its RIGHT (see the
+-- FORECAST constants and the draw call). A saved layout still wins (settings
 -- hudPanelX/Y override these on load; their DEFAULTS mirror these values).
-HUDOverlay.PANEL_X          = 0.02
-HUDOverlay.PANEL_Y          = 0.45
-HUDOverlay.PANEL_W          = 0.230
+HUDOverlay.PANEL_X          = 0.010
+HUDOverlay.PANEL_Y          = 0.180
+HUDOverlay.PANEL_W          = 0.160
 HUDOverlay.ROW_H            = 0.024
 HUDOverlay.HEADER_H         = 0.028
 HUDOverlay.PADDING          = 0.004
-HUDOverlay.BAR_W            = 0.080
+-- BUILD 15:47: bar narrowed with the panel (was 0.080 in the 0.230-wide layout) so
+-- the row label keeps proportional room; drawFieldRow also clips the label so it
+-- can never run under the bar in the narrow layout.
+HUDOverlay.BAR_W            = 0.055
 HUDOverlay.BAR_H            = 0.012
 HUDOverlay.TEXT_SIZE         = 0.013
 HUDOverlay.HEADER_TEXT_SIZE  = 0.014
-HUDOverlay.MAX_FIELDS        = 6
+-- BUILD 14:39 (Sam DESIGN 14:20): 6 -> 4 visible rows so the panel's box tops out
+-- at ~0.320 in the suite layout. Every consumer (row paint, panel height, scroll
+-- clamps) derives from this one constant, and scrolling still reaches the rest.
+HUDOverlay.MAX_FIELDS        = 4
 
 -- ── Forecast strip layout ──────────────────────────────────
--- Layout sections from bottom to top:
---   PADDING | PCT_ROW | BAR_AREA | PADDING | LABEL_ROW | PADDING | HEADER
--- Total = 0.004+0.018+0.032+0.004+0.014+0.004+0.022 = 0.098 → 0.100
-HUDOverlay.FORECAST_H        = 0.100   -- total height of the forecast panel
-HUDOverlay.FORECAST_HEADER_H = 0.022
-HUDOverlay.FORECAST_BAR_AREA = 0.032   -- height of vertical bars
-HUDOverlay.FORECAST_ROW_H    = 0.018   -- pct text row below bars
-HUDOverlay.FORECAST_LABEL_H  = 0.014   -- day label row above bars
+-- BUILD 15:47 (Sam DESIGN 15:46): the strip renders to the RIGHT of the main panel
+-- (bottom-aligned with it, so at factory it sits at 0.180/0.180 with its top edge
+-- at 0.260 - it never draws below py). It now has its OWN width (it used to borrow
+-- PANEL_W), and the interior compressed to fit Sam's 0.100 x 0.080 box:
+--   PADDING | PCT_ROW | BAR_AREA | PADDING | LABEL | HEADER  ≈ 0.080
+HUDOverlay.FORECAST_W        = 0.100   -- strip width (no longer PANEL_W)
+HUDOverlay.FORECAST_H        = 0.080   -- total height of the forecast panel
+HUDOverlay.FORECAST_HEADER_H = 0.016
+HUDOverlay.FORECAST_BAR_AREA = 0.026   -- height of vertical bars
+HUDOverlay.FORECAST_ROW_H    = 0.014   -- pct text row below bars
+HUDOverlay.FORECAST_LABEL_H  = 0.012   -- day label row above bars
 HUDOverlay.FORECAST_COLS     = 5
-HUDOverlay.FORECAST_COL_W    = 0.040   -- width per forecast column
+HUDOverlay.FORECAST_COL_W    = 0.018   -- width per forecast column
 HUDOverlay.FORECAST_BAR_H    = 0.010
-HUDOverlay.FORECAST_TEXT_SZ  = 0.011
+HUDOverlay.FORECAST_TEXT_SZ  = 0.009
 
 -- ── Scale & resize ─────────────────────────────────────────
 HUDOverlay.MIN_SCALE          = 0.6
@@ -399,12 +412,15 @@ function HUDOverlay:isPointerOverHUD(posX, posY)
     if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
         return true
     end
-    -- Also include forecast strip
+    -- Also include forecast strip - BUILD 15:47: it sits to the RIGHT of the panel
+    -- now (bottom-aligned), so the hit rect moved with the paint.
     if self.forecastCache ~= nil then
-        local s    = self.scale
-        local stripH = HUDOverlay.FORECAST_H * s + HUDOverlay.PADDING * s
-        if posX >= px and posX <= px + pw
-        and posY >= py - stripH and posY <= py then
+        local s      = self.scale
+        local pad    = HUDOverlay.PADDING * s
+        local stripW = HUDOverlay.FORECAST_W * s
+        local stripH = HUDOverlay.FORECAST_H * s
+        if posX >= px + pw and posX <= px + pw + pad + stripW
+        and posY >= py and posY <= py + stripH then
             return true
         end
     end
@@ -736,9 +752,12 @@ function HUDOverlay:draw()
         end
     end
 
-    -- Forecast strip BELOW the main panel
+    -- BUILD 15:47 (Sam DESIGN 15:46): forecast strip to the RIGHT of the main panel,
+    -- bottom-aligned with it - at factory that is (0.180, 0.180), top edge 0.260,
+    -- and it never draws below py. The relative form keeps the strip attached when
+    -- the player drags the panel.
     if self.forecastCache ~= nil then
-        self:drawForecastStrip(px, py - HUDOverlay.FORECAST_H * s - pad)
+        self:drawForecastStrip(px + panelW + pad, py)
     end
 
     -- Drop shadow
@@ -874,6 +893,13 @@ function HUDOverlay:drawFieldRow(row, px, rowY, s)
     local cropLabel = row.cropName or "?"
     local stageStr  = row.growthStage and (" S" .. tostring(row.growthStage)) or ""
     local label     = string.format("F%d · %s%s", row.fieldId, cropLabel, stageStr)
+    -- BUILD 15:47: in the 0.160-wide layout the label column holds ~13 glyphs before
+    -- the bar; clip so a long crop name can never run under it. The cap is in
+    -- characters, which is scale-stable (text and space both scale with s), and the
+    -- stress "!" is appended AFTER the clip so it always survives.
+    if string.len(label) > 13 then
+        label = string.sub(label, 1, 13)
+    end
     local stressStr = (row.inStressWindow and stress > 0.15) and " !" or ""
 
     setTextColor(unpack(HUDOverlay.COLOR_TEXT))
@@ -935,7 +961,8 @@ function HUDOverlay:drawForecastStrip(px, py)
     local fieldId     = self.forecastCache.fieldId
     local fH          = HUDOverlay.FORECAST_H * s
     local pad         = HUDOverlay.PADDING * s
-    local panelW      = HUDOverlay.PANEL_W * s
+    -- BUILD 15:47: the strip has its own width now; it no longer borrows PANEL_W.
+    local panelW      = HUDOverlay.FORECAST_W * s
     local textSz      = HUDOverlay.FORECAST_TEXT_SZ * s
 
     -- Drop shadow
@@ -1366,3 +1393,16 @@ function HUDOverlay:delete()
     self.isInitialized   = false
 end
 
+
+-- =========================================================
+-- BUILD 17:57 + ATTN 18:02 (hot-reload guide Part 2): force-patch the live
+-- instance after a Ctrl+R reload - g_cropStressManager or mission.cropStressManager; holds .hudOverlay.
+local __hrMgr = g_cropStressManager or (g_currentMission ~= nil and g_currentMission.cropStressManager or nil)
+if __hrMgr ~= nil and __hrMgr.hudOverlay ~= nil then
+    local inst = __hrMgr.hudOverlay
+    for k, v in pairs(HUDOverlay) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
+end

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -29,14 +29,21 @@
 HUDOverlay = HUDOverlay or {}
 HUDOverlay.__index = HUDOverlay
 
+local function getHUDRenderer()
+    local masterHUD = (g_currentMission and g_currentMission.masterHUD) or g_masterHUD
+    return masterHUD and masterHUD.renderer or nil
+end
+
 -- ── Main panel layout ──────────────────────────────────────
 -- BUILD 15:47 (Sam DESIGN 15:46): fresh-save home is LEFT at (0.010, 0.180), panel
 -- narrowed to 0.160 wide, rows capped at 4 - top edge 0.312, under Favors at 0.370.
 -- The 5-day forecast strip moved from BELOW the panel to its RIGHT (see the
 -- FORECAST constants and the draw call). A saved layout still wins (settings
 -- hudPanelX/Y override these on load; their DEFAULTS mirror these values).
-HUDOverlay.PANEL_X          = 0.010
-HUDOverlay.PANEL_Y          = 0.180
+-- Wizard 2026-08-21: factory home is the suite layout Wizard arranged in-game
+-- (must match CropStressSettings DEFAULTS hudPanelX/Y).
+HUDOverlay.PANEL_X          = 0.012604
+HUDOverlay.PANEL_Y          = 0.236481
 HUDOverlay.PANEL_W          = 0.160
 HUDOverlay.ROW_H            = 0.024
 HUDOverlay.HEADER_H         = 0.028
@@ -44,8 +51,16 @@ HUDOverlay.PADDING          = 0.004
 -- BUILD 15:47: bar narrowed with the panel (was 0.080 in the 0.230-wide layout) so
 -- the row label keeps proportional room; drawFieldRow also clips the label so it
 -- can never run under the bar in the narrow layout.
-HUDOverlay.BAR_W            = 0.055
-HUDOverlay.BAR_H            = 0.012
+-- Wizard 2026-08-21 (overlap repair): narrowed again to 0.045 and the row's right
+-- side now reserves explicit columns INSIDE the panel: bar | pct text | scroll
+-- gutter. The pct text used to start at panelW - pad (the panel's right edge) and
+-- painted straight over whatever sat to the right - the forecast strip at factory
+-- dock - and the blue scroll thumb painted over the pct/bar column. Both live in
+-- reserved space now, so nothing crosses the panel border.
+HUDOverlay.BAR_W            = 0.045
+HUDOverlay.BAR_H            = 0.005556 -- 6 px at 1080p, base fill-level height
+HUDOverlay.PCT_W            = 0.024   -- reserved width for the row's "NN%" text
+HUDOverlay.SCROLL_GUTTER_W  = 0.010   -- reserved gutter for the scroll indicator
 HUDOverlay.TEXT_SIZE         = 0.013
 HUDOverlay.HEADER_TEXT_SIZE  = 0.014
 -- BUILD 14:39 (Sam DESIGN 14:20): 6 -> 4 visible rows so the panel's box tops out
@@ -74,6 +89,16 @@ HUDOverlay.FORECAST_TEXT_SZ  = 0.009
 HUDOverlay.MIN_SCALE          = 0.6
 HUDOverlay.MAX_SCALE          = 1.6
 HUDOverlay.RESIZE_HANDLE_SIZE = 0.008
+
+-- ── Width (edge-drag) ──────────────────────────────────────
+-- Wizard 2026-08-21: NPCFavor/Workplace pattern - dragging the left/right edge
+-- adjusts a width multiplier, independent of the corner-scale. The fields pane
+-- floor is higher than Workplace's 0.5 because its right side carries fixed
+-- columns (bar + pct + scroll gutter, ~0.083 of the 0.160 base) that must fit.
+HUDOverlay.MIN_WIDTH_MULT = 0.75
+HUDOverlay.MAX_WIDTH_MULT = 2.0
+HUDOverlay.EDGE_BAND_W    = 0.008   -- hit band centred on each edge
+HUDOverlay.EDGE_SENS      = 3.0     -- mouse dx -> width multiplier (Workplace value)
 
 -- ── Selection highlight ────────────────────────────────────
 -- A thin colored border is drawn on the selected row
@@ -142,9 +167,16 @@ function HUDOverlay.new(manager)
     self.panelY         = HUDOverlay.PANEL_Y
     self.lastResolution = {g_screenWidth or 1920, g_screenHeight or 1080}
 
+    -- Forecast pane position. nil,nil = docked to the panel's right edge (factory).
+    -- Once the player drags the strip in edit mode it becomes an absolute position,
+    -- persisted separately (settings hudForecastX/Y; -1 sentinel = still docked).
+    self.forecastX      = nil
+    self.forecastY      = nil
+
     -- Edit mode / drag state (mirrors NPCFavorHUD pattern)
     self.editMode       = false
     self.dragging       = false
+    self.dragTarget     = nil   -- "panel" | "forecast" while dragging
     self.dragOffsetX    = 0
     self.dragOffsetY    = 0
 
@@ -156,6 +188,15 @@ function HUDOverlay.new(manager)
     self.resizeStartScale = 1.0
     self.hoverCorner      = nil
     self.animTimer        = 0
+
+    -- Width state (edge-drag, NPCFavor/Workplace pattern). One multiplier per
+    -- pane - the forecast strip widens independently of the fields pane.
+    self.widthMult          = 1.0
+    self.forecastWidthMult  = 1.0
+    self.edgeDragging       = nil   -- nil | "left" | "right"
+    self.edgeTarget         = nil   -- "panel" | "forecast" while edge-dragging
+    self.edgeDragStartX     = 0
+    self.edgeDragStartWidth = 1.0
 
     -- Camera freeze state (NPCFavor pattern)
     self.savedCamRotX     = nil
@@ -234,7 +275,7 @@ function HUDOverlay:update(dt)
             self:exitEditMode()
         end
         -- Hover detection for corner handles
-        if not self.dragging and not self.resizing then
+        if not self.dragging and not self.resizing and self.edgeDragging == nil then
             if g_inputBinding and g_inputBinding.mousePosXLast and g_inputBinding.mousePosYLast then
                 self.hoverCorner = self:hitTestCorner(g_inputBinding.mousePosXLast, g_inputBinding.mousePosYLast)
             else
@@ -355,8 +396,9 @@ function HUDOverlay:isPlayerInVehicle()
 end
 
 function HUDOverlay:enterEditMode()
-    self.editMode = true
-    self.dragging = false
+    self.editMode   = true
+    self.dragging   = false
+    self.dragTarget = nil
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(true)
     end
@@ -377,28 +419,50 @@ function HUDOverlay:enterEditMode()
     csLog("HUD edit mode ON — drag to move, corners to resize (inVehicle=" .. tostring(self:isPlayerInVehicle()) .. ")")
 end
 
+-- One writer for every layout persist site (drag end, edit exit, hide mid-edit).
+-- The forecast pane saves -1,-1 while docked; an absolute position once dragged.
+function HUDOverlay:persistLayout()
+    if self.manager == nil or self.manager.settings == nil then return end
+    self.manager.settings.hudPanelX        = self.panelX
+    self.manager.settings.hudPanelY        = self.panelY
+    self.manager.settings.hudScale         = self.scale
+    self.manager.settings.hudWidthMult     = self.widthMult
+    self.manager.settings.hudForecastX     = self.forecastX or -1
+    self.manager.settings.hudForecastY     = self.forecastY or -1
+    self.manager.settings.hudForecastWMult = self.forecastWidthMult
+end
+
 function HUDOverlay:exitEditMode()
-    self.editMode    = false
-    self.dragging    = false
-    self.resizing    = false
-    self.hoverCorner = nil
+    self.editMode     = false
+    self.dragging     = false
+    self.dragTarget   = nil
+    self.resizing     = false
+    self.edgeDragging = nil
+    self.edgeTarget   = nil
+    self.hoverCorner  = nil
     self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = nil, nil, nil
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(false)
     end
-    if self.manager ~= nil and self.manager.settings ~= nil then
-        self.manager.settings.hudPanelX = self.panelX
-        self.manager.settings.hudPanelY = self.panelY
-        self.manager.settings.hudScale  = self.scale
-    end
+    self:persistLayout()
     csLog("HUD edit mode OFF — position saved")
 end
 
 -- ── Geometry helpers ──────────────────────────────────────
 
+-- ONE width source per pane. Every consumer (rect, rows, scroll gutter, hit
+-- tests, chrome) reads these so an edge-drag reshapes everything together.
+function HUDOverlay:getPanelW()
+    return HUDOverlay.PANEL_W * (self.widthMult or 1.0) * self.scale
+end
+
+function HUDOverlay:getForecastW()
+    return HUDOverlay.FORECAST_W * (self.forecastWidthMult or 1.0) * self.scale
+end
+
 function HUDOverlay:getHUDRect()
     local s      = self.scale
-    local panelW = HUDOverlay.PANEL_W * s
+    local panelW = self:getPanelW()
     -- Use max(actual rows, 1) so hit-testing uses the same height the panel visually renders at.
     -- Previously, if displayRows was empty, numRows=0 forced calcPanelHeight(1) which is correct,
     -- but the real draw path passes max(numRows,1) as well. Keep consistent so dragging always works.
@@ -407,24 +471,40 @@ function HUDOverlay:getHUDRect()
     return self.panelX, self.panelY, panelW, panelH
 end
 
-function HUDOverlay:isPointerOverHUD(posX, posY)
+-- Forecast pane rect. Docked to the panel's right edge until the player has
+-- dragged it (forecastX/Y nil), absolute afterwards. The strip is a real pane
+-- now: its own drag target, its own persisted home.
+function HUDOverlay:getForecastRect()
+    local s = self.scale
+    local w = self:getForecastW()
+    local h = HUDOverlay.FORECAST_H * s
+    if self.forecastX ~= nil and self.forecastY ~= nil then
+        return self.forecastX, self.forecastY, w, h
+    end
     local px, py, pw, ph = self:getHUDRect()
-    if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
-        return true
-    end
-    -- Also include forecast strip - BUILD 15:47: it sits to the RIGHT of the panel
-    -- now (bottom-aligned), so the hit rect moved with the paint.
-    if self.forecastCache ~= nil then
-        local s      = self.scale
-        local pad    = HUDOverlay.PADDING * s
-        local stripW = HUDOverlay.FORECAST_W * s
-        local stripH = HUDOverlay.FORECAST_H * s
-        if posX >= px + pw and posX <= px + pw + pad + stripW
-        and posY >= py and posY <= py + stripH then
-            return true
-        end
-    end
-    return false
+    return px + pw + HUDOverlay.PADDING * s, py, w, h
+end
+
+-- The forecast pane participates in hit tests when it paints: with a selected
+-- field's cache, or as the edit-mode placeholder (so it can be placed even
+-- before a field is selected).
+function HUDOverlay:isForecastShown()
+    return self.forecastCache ~= nil or self.editMode
+end
+
+function HUDOverlay:isPointerOverPanel(posX, posY)
+    local px, py, pw, ph = self:getHUDRect()
+    return posX >= px and posX <= px + pw and posY >= py and posY <= py + ph
+end
+
+function HUDOverlay:isPointerOverForecast(posX, posY)
+    if not self:isForecastShown() then return false end
+    local fx, fy, fw, fh = self:getForecastRect()
+    return posX >= fx and posX <= fx + fw and posY >= fy and posY <= fy + fh
+end
+
+function HUDOverlay:isPointerOverHUD(posX, posY)
+    return self:isPointerOverPanel(posX, posY) or self:isPointerOverForecast(posX, posY)
 end
 
 function HUDOverlay:getResizeHandleRects()
@@ -449,10 +529,37 @@ function HUDOverlay:hitTestCorner(posX, posY)
     return nil
 end
 
+-- Left/right edge bands on both panes (NPCFavor/Workplace width pattern).
+-- Returns pane ("panel"|"forecast") and edge ("left"|"right"), or nil.
+function HUDOverlay:hitTestEdge(posX, posY)
+    local band = HUDOverlay.EDGE_BAND_W
+    local px, py, pw, ph = self:getHUDRect()
+    if posY >= py and posY <= py + ph then
+        if posX >= px - band / 2 and posX <= px + band / 2 then return "panel", "left" end
+        if posX >= px + pw - band / 2 and posX <= px + pw + band / 2 then return "panel", "right" end
+    end
+    if self:isForecastShown() then
+        local fx, fy, fw, fh = self:getForecastRect()
+        if posY >= fy and posY <= fy + fh then
+            if posX >= fx - band / 2 and posX <= fx + band / 2 then return "forecast", "left" end
+            if posX >= fx + fw - band / 2 and posX <= fx + fw + band / 2 then return "forecast", "right" end
+        end
+    end
+    return nil, nil
+end
+
 function HUDOverlay:clampPosition()
     local px, py, pw, ph = self:getHUDRect()
     self.panelX = math.max(0.01, math.min(1.0 - pw - 0.01, self.panelX))
     self.panelY = math.max(ph + 0.01, math.min(0.99, self.panelY))
+    -- Undocked forecast pane clamps on-screen independently.
+    if self.forecastX ~= nil and self.forecastY ~= nil then
+        local s  = self.scale
+        local fw = self:getForecastW()
+        local fh = HUDOverlay.FORECAST_H * s
+        self.forecastX = math.max(0.01, math.min(1.0 - fw - 0.01, self.forecastX))
+        self.forecastY = math.max(0.01, math.min(1.0 - fh - 0.01, self.forecastY))
+    end
 end
 
 -- ============================================================
@@ -461,7 +568,7 @@ end
 -- ============================================================
 function HUDOverlay:selectRowAtPosition(mx, my)
     local s       = self.scale
-    local panelW  = HUDOverlay.PANEL_W * s
+    local panelW  = self:getPanelW()
     local rowH    = HUDOverlay.ROW_H * s
     local headerH = HUDOverlay.HEADER_H * s
     local numRows = math.min(#self.displayRows, HUDOverlay.MAX_FIELDS)
@@ -601,13 +708,46 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
             self.resizeStartScale = self.scale
             csLog("HUD resize started — corner=" .. corner)
             -- Fall through so resize block below runs immediately
-        elseif self:isPointerOverHUD(posX, posY) then
+        elseif select(1, self:hitTestEdge(posX, posY)) ~= nil then
+            -- Left/right edge: width-only drag (NPCFavor/Workplace pattern).
+            local pane, edge = self:hitTestEdge(posX, posY)
+            self.edgeTarget         = pane
+            self.edgeDragging       = edge
+            self.dragging           = false
+            self.resizing           = false
+            self.lmbDownOnHUD       = false
+            self.edgeDragStartX     = posX
+            self.edgeDragStartWidth = ((pane == "forecast") and self.forecastWidthMult or self.widthMult) or 1.0
+            if pane == "forecast" and self.forecastX == nil then
+                -- Undock first so the pane widens in place instead of the dock
+                -- point sliding with the fields pane mid-drag.
+                local fx, fy = self:getForecastRect()
+                self.forecastX, self.forecastY = fx, fy
+            end
+            csLog("HUD width drag started — " .. pane .. "/" .. edge)
+        elseif self:isPointerOverPanel(posX, posY) then
             self.dragging    = true
+            self.dragTarget  = "panel"
             self.resizing    = false
             self.lmbDownOnHUD = true   -- may become a row-select if released without moving
             self.dragOffsetX = posX - self.panelX
             self.dragOffsetY = posY - self.panelY
             csLog(string.format("HUD drag started — pos=%.3f,%.3f", self.panelX, self.panelY))
+            -- Fall through so drag block below runs immediately
+        elseif self:isPointerOverForecast(posX, posY) then
+            -- The forecast strip is its own drag target. On first grab, a docked
+            -- strip latches its current docked position as absolute, then moves
+            -- independently of the fields pane from here on.
+            local fx, fy = self:getForecastRect()
+            self.forecastX   = fx
+            self.forecastY   = fy
+            self.dragging    = true
+            self.dragTarget  = "forecast"
+            self.resizing    = false
+            self.lmbDownOnHUD = false  -- forecast is not a row-click candidate
+            self.dragOffsetX = posX - self.forecastX
+            self.dragOffsetY = posY - self.forecastY
+            csLog(string.format("Forecast drag started — pos=%.3f,%.3f", fx, fy))
             -- Fall through so drag block below runs immediately
         end
     end
@@ -616,21 +756,23 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
     if isUp and button == 1 then
         local wasDragging  = self.dragging
         local wasResizing  = self.resizing
+        local wasEdge      = self.edgeDragging ~= nil
         local clickIntent  = self.lmbDownOnHUD
 
         self.dragging     = false
+        self.dragTarget   = nil
         self.resizing     = false
+        self.edgeDragging = nil
+        self.edgeTarget   = nil
         self.lmbDownOnHUD = false
 
-        if wasDragging or wasResizing then
+        if wasDragging or wasResizing or wasEdge then
             self:clampPosition()
-            if self.manager ~= nil and self.manager.settings ~= nil then
-                self.manager.settings.hudPanelX = self.panelX
-                self.manager.settings.hudPanelY = self.panelY
-                self.manager.settings.hudScale  = self.scale
-            end
-            csLog(string.format("HUD repositioned to %.3f,%.3f scale=%.2f",
-                self.panelX, self.panelY, self.scale))
+            self:persistLayout()
+            csLog(string.format("HUD repositioned to %.3f,%.3f scale=%.2f forecast=%s,%s",
+                self.panelX, self.panelY, self.scale,
+                self.forecastX and string.format("%.3f", self.forecastX) or "docked",
+                self.forecastY and string.format("%.3f", self.forecastY) or "docked"))
         elseif clickIntent then
             -- LMB pressed-and-released on HUD body without moving → row select
             self:selectRowAtPosition(posX, posY)
@@ -642,11 +784,18 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
     -- Fires every frame while cursor is unlocked.
     -- Also runs on the isDown event (no early return above) for immediate response.
     if self.dragging then
-        local s      = self.scale
-        local panelW = HUDOverlay.PANEL_W * s
-        local panelH = self:calcPanelHeight(math.max(1, math.min(#self.displayRows, HUDOverlay.MAX_FIELDS)))
-        self.panelX  = math.max(0.01, math.min(1.0 - panelW - 0.01, posX - self.dragOffsetX))
-        self.panelY  = math.max(panelH + 0.01, math.min(0.99, posY - self.dragOffsetY))
+        local s = self.scale
+        if self.dragTarget == "forecast" then
+            local fw = self:getForecastW()
+            local fh = HUDOverlay.FORECAST_H * s
+            self.forecastX = math.max(0.01, math.min(1.0 - fw - 0.01, posX - self.dragOffsetX))
+            self.forecastY = math.max(0.01, math.min(1.0 - fh - 0.01, posY - self.dragOffsetY))
+        else
+            local panelW = self:getPanelW()
+            local panelH = self:calcPanelHeight(math.max(1, math.min(#self.displayRows, HUDOverlay.MAX_FIELDS)))
+            self.panelX  = math.max(0.01, math.min(1.0 - panelW - 0.01, posX - self.dragOffsetX))
+            self.panelY  = math.max(panelH + 0.01, math.min(0.99, posY - self.dragOffsetY))
+        end
     end
 
     if self.resizing then
@@ -660,8 +809,23 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
         self:clampPosition()
     end
 
+    -- Edge width drag (NPCFavor/Workplace pattern): dx scaled by EDGE_SENS,
+    -- left edge inverted so pulling outward always widens.
+    if self.edgeDragging then
+        local dx = posX - self.edgeDragStartX
+        if self.edgeDragging == "left" then dx = -dx end
+        local newMult = self.edgeDragStartWidth + dx * HUDOverlay.EDGE_SENS
+        newMult = math.max(HUDOverlay.MIN_WIDTH_MULT, math.min(HUDOverlay.MAX_WIDTH_MULT, newMult))
+        if self.edgeTarget == "forecast" then
+            self.forecastWidthMult = newMult
+        else
+            self.widthMult = newMult
+        end
+        self:clampPosition()
+    end
+
     -- Hover detection for corner handles (movement events only)
-    if not self.dragging and not self.resizing then
+    if not self.dragging and not self.resizing and self.edgeDragging == nil then
         self.hoverCorner = self:hitTestCorner(posX, posY)
     end
 end
@@ -719,7 +883,7 @@ function HUDOverlay:draw()
     if self.fillOverlay == nil then return end
 
     local s        = self.scale
-    local panelW   = HUDOverlay.PANEL_W * s
+    local panelW   = self:getPanelW()
     local rowH     = HUDOverlay.ROW_H * s
     local headerH  = HUDOverlay.HEADER_H * s
     local pad      = HUDOverlay.PADDING * s
@@ -752,34 +916,65 @@ function HUDOverlay:draw()
         end
     end
 
-    -- BUILD 15:47 (Sam DESIGN 15:46): forecast strip to the RIGHT of the main panel,
-    -- bottom-aligned with it - at factory that is (0.180, 0.180), top edge 0.260,
-    -- and it never draws below py. The relative form keeps the strip attached when
-    -- the player drags the panel.
-    if self.forecastCache ~= nil then
-        self:drawForecastStrip(px + panelW + pad, py)
+    -- Wizard 2026-08-21: the forecast strip is its OWN pane now. Factory dock is
+    -- still the panel's right edge (bottom-aligned), but once dragged in edit mode
+    -- it keeps an absolute home (forecastX/Y, persisted separately). In edit mode
+    -- it paints even with no field selected, as a placeholder, so it can be placed.
+    if self:isForecastShown() then
+        local fx, fy, fw, fh = self:getForecastRect()
+        self:drawForecastStrip(fx, fy)
+        if self.editMode then
+            local pulse = 0.5 + 0.5 * math.sin(self.animTimer * 4)
+            local bw = 0.002
+            local ec = HUDOverlay.COLOR_EDIT_BORDER
+            setOverlayColor(self.fillOverlay, ec[1], ec[2], ec[3], 0.4 + 0.4 * pulse)
+            renderOverlay(self.fillOverlay, fx,           fy + fh - bw, fw, bw)
+            renderOverlay(self.fillOverlay, fx,           fy,           fw, bw)
+            renderOverlay(self.fillOverlay, fx,           fy,           bw, fh)
+            renderOverlay(self.fillOverlay, fx + fw - bw, fy,           bw, fh)
+
+            -- Edge width handles for the forecast pane (same chrome as the
+            -- fields pane, so both panes read as one edit vocabulary).
+            local ehW    = 0.004
+            local inset  = fh * 0.15
+            local ehY    = fy + inset
+            local ehH    = fh - inset * 2
+            local active = {ec[1], math.min(1, ec[2] + 0.20), math.min(1, ec[3] + 0.25), 0.90}
+            local idle   = {ec[1], ec[2], ec[3], 0.65}
+            local onFc   = (self.edgeTarget == "forecast")
+            setOverlayColor(self.fillOverlay, unpack((onFc and self.edgeDragging == "left") and active or idle))
+            renderOverlay(self.fillOverlay, fx - ehW / 2, ehY, ehW, ehH)
+            setOverlayColor(self.fillOverlay, unpack((onFc and self.edgeDragging == "right") and active or idle))
+            renderOverlay(self.fillOverlay, fx + fw - ehW / 2, ehY, ehW, ehH)
+        end
     end
 
-    -- Drop shadow
-    local shadowOff = 0.002 * s
-    setOverlayColor(self.fillOverlay, 0, 0, 0, 0.35)
-    renderOverlay(self.fillOverlay, px + shadowOff, py - shadowOff, panelW, panelH)
+    local renderer = getHUDRenderer()
+    local renderedNativePanel = renderer ~= nil and type(renderer.renderPanel) == "function"
+        and renderer:renderPanel(px, py, panelW, panelH, HUDOverlay.COLOR_BG[4])
 
-    -- Background panel
-    setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_BG))
-    renderOverlay(self.fillOverlay, px, py, panelW, panelH)
+    if not renderedNativePanel then
+        -- Drop shadow
+        local shadowOff = 0.002 * s
+        setOverlayColor(self.fillOverlay, 0, 0, 0, 0.35)
+        renderOverlay(self.fillOverlay, px + shadowOff, py - shadowOff, panelW, panelH)
 
-    -- Permanent subtle border
-    local bwN = 0.001
-    setOverlayColor(self.fillOverlay, 0.30, 0.40, 0.55, 0.50)
-    renderOverlay(self.fillOverlay, px,             py + panelH - bwN, panelW, bwN)
-    renderOverlay(self.fillOverlay, px,             py,                panelW, bwN)
-    renderOverlay(self.fillOverlay, px,             py,                bwN, panelH)
-    renderOverlay(self.fillOverlay, px + panelW - bwN, py,            bwN, panelH)
+        -- Background panel
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_BG))
+        renderOverlay(self.fillOverlay, px, py, panelW, panelH)
 
-    -- Header bar
-    setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_HEADER_BG))
-    renderOverlay(self.fillOverlay, px, py + panelH - headerH, panelW, headerH)
+        -- Permanent subtle border
+        local bwN = 0.001
+        setOverlayColor(self.fillOverlay, 0.30, 0.40, 0.55, 0.50)
+        renderOverlay(self.fillOverlay, px,             py + panelH - bwN, panelW, bwN)
+        renderOverlay(self.fillOverlay, px,             py,                panelW, bwN)
+        renderOverlay(self.fillOverlay, px,             py,                bwN, panelH)
+        renderOverlay(self.fillOverlay, px + panelW - bwN, py,            bwN, panelH)
+
+        -- Header bar
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_HEADER_BG))
+        renderOverlay(self.fillOverlay, px, py + panelH - headerH, panelW, headerH)
+    end
 
     -- Header text + key hint
     setTextColor(unpack(HUDOverlay.COLOR_HEADER_TEXT))
@@ -817,6 +1012,20 @@ function HUDOverlay:draw()
             setOverlayColor(self.fillOverlay, unpack(hc))
             renderOverlay(self.fillOverlay, rect.x, rect.y, rect.w, rect.h)
         end
+
+        -- Left/right edge width handles (Workplace chrome shape, orange family):
+        -- inset vertical bars, lifted while their edge is being dragged.
+        local ehW    = 0.004
+        local inset  = panelH * 0.15
+        local ehY    = py + inset
+        local ehH    = panelH - inset * 2
+        local active = {ec[1], math.min(1, ec[2] + 0.20), math.min(1, ec[3] + 0.25), 0.90}
+        local idle   = {ec[1], ec[2], ec[3], 0.65}
+        local onPanel = (self.edgeTarget == "panel")
+        setOverlayColor(self.fillOverlay, unpack((onPanel and self.edgeDragging == "left") and active or idle))
+        renderOverlay(self.fillOverlay, px - ehW / 2, ehY, ehW, ehH)
+        setOverlayColor(self.fillOverlay, unpack((onPanel and self.edgeDragging == "right") and active or idle))
+        renderOverlay(self.fillOverlay, px + panelW - ehW / 2, ehY, ehW, ehH)
     end
 
     -- Empty state
@@ -856,8 +1065,8 @@ function HUDOverlay:draw()
         local ec = HUDOverlay.COLOR_EDIT_BORDER
         setTextColor(ec[1], math.min(1, ec[2] + 0.20), math.min(1, ec[3] + 0.30), 0.85)
         local editHint = self:isPlayerInVehicle()
-            and "LMB drag  |  Corners scale  |  Edit/Move key to exit"
-            or  "LMB drag/select  |  Corners scale  |  RMB to exit"
+            and "LMB drag  |  Corners scale  |  Edges width  |  Edit/Move key to exit"
+            or  "LMB drag/select  |  Corners scale  |  Edges width  |  RMB to exit"
         renderText(px + pad, py + pad, HUDOverlay.TEXT_SIZE * s * 0.85, editHint)
     elseif self.selectedFieldId == nil then
         setTextColor(unpack(HUDOverlay.COLOR_DIM_TEXT))
@@ -887,18 +1096,24 @@ function HUDOverlay:drawFieldRow(row, px, rowY, s)
     local barW     = HUDOverlay.BAR_W * s
     local barH     = HUDOverlay.BAR_H * s
     local pad      = HUDOverlay.PADDING * s
-    local panelW   = HUDOverlay.PANEL_W * s
+    local panelW   = self:getPanelW()
     local rowH     = HUDOverlay.ROW_H * s
 
     local cropLabel = row.cropName or "?"
     local stageStr  = row.growthStage and (" S" .. tostring(row.growthStage)) or ""
     local label     = string.format("F%d · %s%s", row.fieldId, cropLabel, stageStr)
-    -- BUILD 15:47: in the 0.160-wide layout the label column holds ~13 glyphs before
-    -- the bar; clip so a long crop name can never run under it. The cap is in
-    -- characters, which is scale-stable (text and space both scale with s), and the
+    -- BUILD 15:47: clip so a long crop name can never run under the bar; the
     -- stress "!" is appended AFTER the clip so it always survives.
-    if string.len(label) > 13 then
-        label = string.sub(label, 1, 13)
+    -- Wizard 2026-08-21 (width-mult wave): the cap derives from the actual gap
+    -- between label start and bar start instead of a fixed count, so widening
+    -- the pane with an edge-drag buys longer labels. 0.53 * TEXT_SIZE per glyph
+    -- is the ratio the old fixed caps (13-in-0.090, 10-in-0.070) encoded.
+    local labelStartX = px + pad + HUDOverlay.SELECTED_BORDER_W * s
+    local labelEndX   = px + panelW - pad - HUDOverlay.SCROLL_GUTTER_W * s
+                        - HUDOverlay.PCT_W * s - barW
+    local maxChars = math.max(4, math.floor((labelEndX - labelStartX) / (HUDOverlay.TEXT_SIZE * s * 0.53)))
+    if string.len(label) > maxChars then
+        label = string.sub(label, 1, maxChars)
     end
     local stressStr = (row.inStressWindow and stress > 0.15) and " !" or ""
 
@@ -906,16 +1121,28 @@ function HUDOverlay:drawFieldRow(row, px, rowY, s)
     renderText(px + pad + HUDOverlay.SELECTED_BORDER_W * s, rowY + pad,
         HUDOverlay.TEXT_SIZE * s, label .. stressStr)
 
-    local barX = px + panelW - barW - pad * 2
+    -- Right-side columns, all INSIDE the panel: bar | pct | scroll gutter | pad.
+    -- The pct text used to start at panelW - pad and painted past the panel's
+    -- right edge (over the docked forecast strip); the gutter keeps the blue
+    -- scroll indicator off the pct/bar column.
+    local gutW = HUDOverlay.SCROLL_GUTTER_W * s
+    local pctW = HUDOverlay.PCT_W * s
+    local barX = px + panelW - pad - gutW - pctW - barW
     local barY = rowY + (rowH - barH) * 0.5
-    setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_BAR_BG))
-    renderOverlay(self.fillOverlay, barX, barY, barW, barH)
+    local renderer = getHUDRenderer()
+    local moistureColor = self:getMoistureColor(moisture)
+    local renderedNativeBar = renderer ~= nil and type(renderer.renderProgressBar) == "function"
+        and renderer:renderProgressBar(barX, barY, barW, barH, moisture, moistureColor)
+    if not renderedNativeBar then
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_BAR_BG))
+        renderOverlay(self.fillOverlay, barX, barY, barW, barH)
 
-    setOverlayColor(self.fillOverlay, unpack(self:getMoistureColor(moisture)))
-    renderOverlay(self.fillOverlay, barX, barY, barW * moisture, barH)
+        setOverlayColor(self.fillOverlay, unpack(moistureColor))
+        renderOverlay(self.fillOverlay, barX, barY, barW * moisture, barH)
+    end
 
     setTextColor(unpack(HUDOverlay.COLOR_TEXT))
-    renderText(barX + barW + pad, rowY + pad, HUDOverlay.TEXT_SIZE * s,
+    renderText(barX + barW + pad * 0.5, rowY + pad, HUDOverlay.TEXT_SIZE * s * 0.90,
         string.format("%d%%", math.floor(moisture * 100 + 0.5)))
 
     -- SoilFertilizer enrichment: render a compact pressure/needs strip
@@ -954,33 +1181,46 @@ end
 --   py + FORECAST_H                             top edge
 -- ============================================================
 function HUDOverlay:drawForecastStrip(px, py)
-    if self.forecastCache == nil then return end
+    -- Wizard 2026-08-21: with no selected field the strip still paints as an
+    -- empty placeholder in edit mode, so the pane can be found and placed.
+    if self.forecastCache == nil and not self.editMode then return end
 
     local s           = self.scale
-    local projections = self.forecastCache.projections
-    local fieldId     = self.forecastCache.fieldId
+    local cache       = self.forecastCache
+    local projections = cache ~= nil and cache.projections or nil
+    local fieldId     = cache ~= nil and cache.fieldId or nil
+    -- Declared before ANY use. The old code read isApprox in the header suffix
+    -- a dozen lines before its local declaration, so the "~" approximation
+    -- marker on the header could never render (nil at that point).
+    local isApprox    = cache == nil or cache.isApproximate ~= false  -- default true
     local fH          = HUDOverlay.FORECAST_H * s
     local pad         = HUDOverlay.PADDING * s
     -- BUILD 15:47: the strip has its own width now; it no longer borrows PANEL_W.
-    local panelW      = HUDOverlay.FORECAST_W * s
+    local panelW      = self:getForecastW()
     local textSz      = HUDOverlay.FORECAST_TEXT_SZ * s
 
-    -- Drop shadow
-    local shadowOff = 0.002 * s
-    setOverlayColor(self.fillOverlay, 0, 0, 0, 0.30)
-    renderOverlay(self.fillOverlay, px + shadowOff, py - shadowOff, panelW, fH)
+    local renderer = getHUDRenderer()
+    local renderedNativePanel = renderer ~= nil and type(renderer.renderPanel) == "function"
+        and renderer:renderPanel(px, py, panelW, fH, HUDOverlay.COLOR_FORECAST_BG[4])
 
-    -- Background
-    setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_FORECAST_BG))
-    renderOverlay(self.fillOverlay, px, py, panelW, fH)
+    if not renderedNativePanel then
+        -- Drop shadow
+        local shadowOff = 0.002 * s
+        setOverlayColor(self.fillOverlay, 0, 0, 0, 0.30)
+        renderOverlay(self.fillOverlay, px + shadowOff, py - shadowOff, panelW, fH)
 
-    -- Subtle border
-    local bwN = 0.001
-    setOverlayColor(self.fillOverlay, 0.25, 0.35, 0.50, 0.45)
-    renderOverlay(self.fillOverlay, px,             py + fH - bwN, panelW, bwN)
-    renderOverlay(self.fillOverlay, px,             py,            panelW, bwN)
-    renderOverlay(self.fillOverlay, px,             py,            bwN, fH)
-    renderOverlay(self.fillOverlay, px + panelW - bwN, py,        bwN, fH)
+        -- Background
+        setOverlayColor(self.fillOverlay, unpack(HUDOverlay.COLOR_FORECAST_BG))
+        renderOverlay(self.fillOverlay, px, py, panelW, fH)
+
+        -- Subtle border
+        local bwN = 0.001
+        setOverlayColor(self.fillOverlay, 0.25, 0.35, 0.50, 0.45)
+        renderOverlay(self.fillOverlay, px,             py + fH - bwN, panelW, bwN)
+        renderOverlay(self.fillOverlay, px,             py,            panelW, bwN)
+        renderOverlay(self.fillOverlay, px,             py,            bwN, fH)
+        renderOverlay(self.fillOverlay, px + panelW - bwN, py,        bwN, fH)
+    end
 
     -- Header text (top section, clearly separated from column labels)
     -- ~ suffix indicates all projected values are approximations (no FS25 forecast API)
@@ -989,8 +1229,16 @@ function HUDOverlay:drawForecastStrip(px, py)
     local forecastLabel = (g_i18n ~= nil and g_i18n:getText("cs_hud_forecast")) or "5-Day Forecast"
     if isApprox then forecastLabel = forecastLabel .. " ~" end
     renderText(px + pad, py + fH - HUDOverlay.FORECAST_HEADER_H * s + pad, textSz,
-        string.format("%s — F%d", forecastLabel, fieldId))
+        fieldId ~= nil and string.format("%s — F%d", forecastLabel, fieldId)
+                       or  string.format("%s — click a row", forecastLabel))
     setTextBold(false)
+
+    -- Placeholder mode (edit, no selected field): frame + header only.
+    if cache == nil then
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(1, 1, 1, 1)
+        return
+    end
 
     -- Explicit section anchors (bottom → top): pct | bars | labels | header
     local pctBaseY = py + pad
@@ -999,7 +1247,6 @@ function HUDOverlay:drawForecastStrip(px, py)
     local labelY   = barBaseY + barAreaH + pad
 
     local colLabels  = {"Now", "D+1", "D+2", "D+3", "D+4"}
-    local isApprox   = self.forecastCache.isApproximate ~= false  -- default true
     local currentMoisture = 0
     if self.manager ~= nil and self.manager.soilSystem ~= nil then
         currentMoisture = self.manager:getMoisture(fieldId) or 0
@@ -1017,7 +1264,9 @@ function HUDOverlay:drawForecastStrip(px, py)
     for i = 1, HUDOverlay.FORECAST_COLS do
         local val = displayVals[i] or 0
         local cx  = colStartX + (i - 1) * colGap + pad
-        local bw  = HUDOverlay.FORECAST_COL_W * s - pad
+        -- Bar width derives from the column gap (not the fixed FORECAST_COL_W)
+        -- so an edge-drag widening of the pane stretches the bars with it.
+        local bw  = math.max(0.004, colGap - pad)
 
         -- Day label: "Now" uses normal color; projected days (i>1) use a dimmer
         -- tone when forecast is approximate, signalling reduced certainty.
@@ -1279,13 +1528,11 @@ function HUDOverlay:toggle()
     else
         -- Exit edit mode when hiding — orange border should not persist invisibly
         if self.editMode then
-            self.editMode = false
-            self.dragging = false
+            self.editMode   = false
+            self.dragging   = false
+            self.dragTarget = nil
             -- Persist position so the drag position is saved even if they hid mid-edit
-            if self.manager ~= nil and self.manager.settings ~= nil then
-                self.manager.settings.hudPanelX = self.panelX
-                self.manager.settings.hudPanelY = self.panelY
-            end
+            self:persistLayout()
         end
     end
 
@@ -1351,30 +1598,31 @@ function HUDOverlay:drawScrollIndicator(px, py, s)
     if totalFields <= self.maxVisibleFields then return end
     
     local pad = HUDOverlay.PADDING * s
-    local panelW = HUDOverlay.PANEL_W * s
+    local panelW = self:getPanelW()
     local numRows = math.min(#self.displayRows, HUDOverlay.MAX_FIELDS)
     local panelH = self:calcPanelHeight(numRows)
     local headerH = HUDOverlay.HEADER_H * s
     
-    -- Draw scroll indicator on the right side of the panel
-    local indicatorX = px + panelW - 0.012 * s
+    -- Wizard 2026-08-21: the indicator lives in the reserved SCROLL_GUTTER_W column
+    -- inside the panel now (drawFieldRow keeps the bar/pct clear of it), and the
+    -- "Scroll: Mouse Wheel" hint text is gone - it painted at py + pad, the exact
+    -- anchor the footer hints already use, so the two overlapped whenever both drew.
+    -- The blue thumb itself is the scroll affordance.
+    local trackW     = 0.006 * s
+    local indicatorX = px + panelW - pad - (HUDOverlay.SCROLL_GUTTER_W * s + trackW) * 0.5
     local indicatorY = py + pad
     local indicatorH = panelH - headerH - pad * 2
-    
+
     -- Background of scroll indicator
     setOverlayColor(self.fillOverlay, 0.20, 0.20, 0.20, 0.60)
-    renderOverlay(self.fillOverlay, indicatorX, indicatorY, 0.008 * s, indicatorH)
-    
+    renderOverlay(self.fillOverlay, indicatorX, indicatorY, trackW, indicatorH)
+
     -- Scroll thumb
     local thumbHeight = math.max(0.010 * s, indicatorH * (self.maxVisibleFields / totalFields))
     local thumbPosition = indicatorY + (indicatorH - thumbHeight) * (self.scrollOffset / math.max(1, totalFields - self.maxVisibleFields))
-    
+
     setOverlayColor(self.fillOverlay, 0.40, 0.80, 1.00, 0.80)
-    renderOverlay(self.fillOverlay, indicatorX, thumbPosition, 0.008 * s, thumbHeight)
-    
-    -- Scroll hint text
-    setTextColor(0.60, 0.80, 1.00, 0.85)
-    renderText(px + pad, py + pad, 0.008 * s, "Scroll: Mouse Wheel")
+    renderOverlay(self.fillOverlay, indicatorX, thumbPosition, trackW, thumbHeight)
 end
 
 -- ============================================================
@@ -1405,4 +1653,10 @@ if __hrMgr ~= nil and __hrMgr.hudOverlay ~= nil then
             inst[k] = v
         end
     end
+    -- Fields new in the width wave that a pre-wave live instance lacks.
+    if inst.widthMult         == nil then inst.widthMult         = 1.0 end
+    if inst.forecastWidthMult == nil then inst.forecastWidthMult = 1.0 end
+    -- Delivery proof in log.txt - silent patch blocks made this session's dropped
+    -- reloads invisible (Wizard 2026-08-21).
+    print("[CropStress] HUDOverlay hot-patched onto live instance")
 end

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -6,9 +6,10 @@
 -- Phase 1: Basic moisture bars with auto-show/auto-hide
 -- Phase 3: +Forecast strip for selected field, +click-based row selection
 --
--- Layout (bottom-left, above minimap):
+-- Layout (bottom-left, above minimap). BUILD 05:40: the header no longer carries a
+-- key glyph - the toggle ships unbound (Rule 1) and Controls is the binding's truth.
 -- ┌─────────────────────────────────────────────┐
--- │  CROP MOISTURE MONITOR               [M]    │
+-- │  CROP MOISTURE MONITOR                      │
 -- │  Field 7 · Wheat S4    ████████░░ 78%  [SEL]│
 -- │  Field 3 · Corn  S5 !  ███░░░░░░░ 32%       │
 -- │  Field 5 · Corn  S3    ██████████ 80%       │
@@ -26,8 +27,12 @@ HUDOverlay = {}
 HUDOverlay.__index = HUDOverlay
 
 -- ── Main panel layout ──────────────────────────────────────
-HUDOverlay.PANEL_X          = 0.010
-HUDOverlay.PANEL_Y          = 0.175
+-- BUILD 06:43 (Sam DESIGN 06:42): fresh-save home is middle-LEFT (0.02, 0.45) in
+-- the suite's staggered default layout - clear of the vanilla minimap corner the
+-- old (0.010, 0.175) default crowded. A saved layout still wins (settings
+-- hudPanelX/Y override these on load; their DEFAULTS mirror these values).
+HUDOverlay.PANEL_X          = 0.02
+HUDOverlay.PANEL_Y          = 0.45
 HUDOverlay.PANEL_W          = 0.230
 HUDOverlay.ROW_H            = 0.024
 HUDOverlay.HEADER_H         = 0.028
@@ -178,6 +183,22 @@ end
 function HUDOverlay:update(dt)
     if not self.isInitialized then return end
     if not self.isVisible then return end
+
+    -- BUILD 04:34: suite hide-all governs this HUD's live state, not only its paint.
+    -- Both draw paths (the MasterHUD self-draw and the gated FSBaseMission fallback)
+    -- already skip while the suite is hidden, but this update ran on regardless - so
+    -- hide-all during edit mode would have kept asserting the cursor and the frozen
+    -- camera for a HUD the player could no longer see. Same rule MasterHUD applies to
+    -- its own edit listeners: entering hide exits edit. The isVisible flag is NOT
+    -- touched - a toggle-on while hidden stays an honest pending state that paints
+    -- the moment the suite is shown again.
+    local suiteHud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if suiteHud ~= nil and suiteHud.hudsHidden == true then
+        if self.editMode then
+            self:exitEditMode()
+        end
+        return
+    end
 
     self.animTimer = self.animTimer + dt
 
@@ -517,7 +538,7 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
     -- In vehicle: RMB is captured by the vehicle camera, so we only allow it
     --   to EXIT edit mode (cursor is visible when in edit mode, suppressing
     --   the vehicle camera, so this is safe). Entering edit mode in a vehicle
-    --   must be done via the CS_EDIT_HUD keybind (Shift+H).
+    --   must be done via the CS_EDIT_HUD keybind (player-assigned; no default ships).
     if isDown and button == 3 then
         if self:isPointerOverHUD(posX, posY) then
             if self.editMode then
@@ -532,7 +553,7 @@ function HUDOverlay:onMouseEvent(posX, posY, isDown, isUp, button)
 
     -- ── LMB without edit mode: row selection while in a vehicle ──────────────
     -- Allows the player to select a field for the forecast panel without
-    -- needing to enter full edit mode (which requires Shift+H in a vehicle).
+    -- needing to enter full edit mode (which requires the CS_EDIT_HUD key in a vehicle).
     if isDown and button == 1 and not self.editMode then
         if self:isPlayerInVehicle() and self:isPointerOverHUD(posX, posY) then
             self.lmbDownOnHUD = true
@@ -746,14 +767,24 @@ function HUDOverlay:draw()
     setTextBold(true)
     renderText(px + pad, py + panelH - headerH + pad, HUDOverlay.HEADER_TEXT_SIZE * s,
         (g_i18n ~= nil and g_i18n:getText("cs_hud_title")) or "CROP MOISTURE")
-    renderText(px + panelW - 0.028 * s, py + panelH - headerH + pad, HUDOverlay.TEXT_SIZE * s, "[M]")
+    -- BUILD 05:40 (PB-H02): the hardcoded "[M]" key glyph is GONE. It claimed a
+    -- binding this action does not ship (Rule 1: no defaults, player assigns), so it
+    -- lied to everyone except a player who happened to bind M. Omitting the glyph is
+    -- the honest state; the Controls row is the binding's one source of truth.
     setTextBold(false)
 
-    -- Edit mode: pulsing border + corner resize handles
+    -- Edit mode: pulsing border + corner resize handles.
+    -- BUILD 05:40 (PB-H01, George TASK 05:22): border and handles draw from
+    -- COLOR_EDIT_BORDER - the orange this file itself declares as "edit mode
+    -- indicator" (:77) - instead of the hardcoded cyan/blue family that ignored it.
+    -- The pulse Brian scored PASS is kept; only the colour was the defect. Handles
+    -- derive from the same constant: idle at reduced alpha, hover lifted toward
+    -- white so the hovered corner still reads brighter, never a different hue.
     if self.editMode then
         local pulse = 0.5 + 0.5 * math.sin(self.animTimer * 4)
         local bw = 0.002
-        setOverlayColor(self.fillOverlay, 0.30, 0.65, 1.00, 0.4 + 0.4 * pulse)
+        local ec = HUDOverlay.COLOR_EDIT_BORDER
+        setOverlayColor(self.fillOverlay, ec[1], ec[2], ec[3], 0.4 + 0.4 * pulse)
         renderOverlay(self.fillOverlay, px,             py + panelH - bw, panelW, bw)
         renderOverlay(self.fillOverlay, px,             py,               panelW, bw)
         renderOverlay(self.fillOverlay, px,             py,               bw, panelH)
@@ -762,8 +793,8 @@ function HUDOverlay:draw()
         local handles = self:getResizeHandleRects()
         for key, rect in pairs(handles) do
             local hc = (self.hoverCorner == key)
-                and {0.50, 0.80, 1.00, 0.90}
-                or  {0.30, 0.55, 0.90, 0.65}
+                and {ec[1], math.min(1, ec[2] + 0.20), math.min(1, ec[3] + 0.25), 0.90}
+                or  {ec[1], ec[2], ec[3], 0.65}
             setOverlayColor(self.fillOverlay, unpack(hc))
             renderOverlay(self.fillOverlay, rect.x, rect.y, rect.w, rect.h)
         end
@@ -795,18 +826,25 @@ function HUDOverlay:draw()
         self:drawFieldRow(row, px, rowY, s)
     end
 
-    -- Footer hint
+    -- Footer hint.
+    -- BUILD 05:40 (PB-H02): the "Shift+H" strings are GONE - that chord was a stale
+    -- fiction from before Rule 1 stripped the defaults, so the footer lied the moment
+    -- it painted. Mouse affordances (LMB/RMB/corners) are real hardware truths and
+    -- stay; the rebindable action is named by its Controls label ("Edit/Move"), never
+    -- by an invented glyph. The edit-hint text colour joins the orange family so the
+    -- edit state reads as one vocabulary.
     if self.editMode then
-        setTextColor(0.60, 0.80, 1.00, 0.85)
+        local ec = HUDOverlay.COLOR_EDIT_BORDER
+        setTextColor(ec[1], math.min(1, ec[2] + 0.20), math.min(1, ec[3] + 0.30), 0.85)
         local editHint = self:isPlayerInVehicle()
-            and "LMB drag  |  Corners scale  |  Shift+H to exit"
+            and "LMB drag  |  Corners scale  |  Edit/Move key to exit"
             or  "LMB drag/select  |  Corners scale  |  RMB to exit"
         renderText(px + pad, py + pad, HUDOverlay.TEXT_SIZE * s * 0.85, editHint)
     elseif self.selectedFieldId == nil then
         setTextColor(unpack(HUDOverlay.COLOR_DIM_TEXT))
         local hintText
         if self:isPlayerInVehicle() then
-            hintText = "Click row to select • Shift+H = move"
+            hintText = "Click row to select • Edit/Move key = move"
         else
             hintText = (g_i18n ~= nil and g_i18n:getText("cs_hud_click_forecast")) or "RMB = select row / edit mode"
         end

--- a/src/integrations/CropStressMasterHUDBridge.lua
+++ b/src/integrations/CropStressMasterHUDBridge.lua
@@ -19,12 +19,14 @@
 -- with the fallback hook so the two paths can never diverge.
 -- =========================================================
 
-CropStressMasterHUDBridge = {}
+-- BUILD 19:38: reload-safe like the HUD classes - the table AND the active flag
+-- survive Ctrl+R, or the hot-reload delivery block at the end could never fire.
+CropStressMasterHUDBridge = CropStressMasterHUDBridge or {}
 
 -- Full-token id per the ecosystem NAMING-CONVENTION (client-local, re-registered
 -- each session, not a save/wire lock key). Confirmed with Claude(A) 2026-07-16.
 CropStressMasterHUDBridge.HUD_ID = "SeasonalCropStress_StressOverlay"
-CropStressMasterHUDBridge.active = false   -- MasterHUD present and we registered
+CropStressMasterHUDBridge.active = CropStressMasterHUDBridge.active or false   -- survives reload; register() re-derives it
 
 -- The full SCS HUD draw. Delegates to the manager's own draw() (settings panel +
 -- moisture/stress overlay, with the same enabled-gating), so the MasterHUD path and
@@ -54,7 +56,44 @@ function CropStressMasterHUDBridge.register(mgr)
     if ok then
         CropStressMasterHUDBridge.active = true
         print("[CropStress] Registered crop-stress HUD with MasterHUD (single draw loop + menu-suspend)")
+        -- BUILD 19:38 (Income bridge pattern): suite layout edit reaches the RF
+        -- Moisture panel - MasterHUD's edit toggle enters/exits HUDOverlay's own
+        -- edit mode (orange border, drag, corners).
+        if hud.registerEditListener ~= nil then
+            hud:registerEditListener(CropStressMasterHUDBridge.HUD_ID, {
+                enter = function()
+                    local m = g_cropStressManager
+                        or (g_currentMission ~= nil and g_currentMission.cropStressManager or nil)
+                    local ho = m ~= nil and m.hudOverlay or nil
+                    if ho ~= nil and ho.enterEditMode ~= nil then ho:enterEditMode() end
+                end,
+                exit = function()
+                    local m = g_cropStressManager
+                        or (g_currentMission ~= nil and g_currentMission.cropStressManager or nil)
+                    local ho = m ~= nil and m.hudOverlay or nil
+                    if ho ~= nil and ho.editMode and ho.exitEditMode ~= nil then ho:exitEditMode() end
+                end,
+            })
+        end
     else
         print(string.format("[CropStress] MasterHUD registration failed: %s (using own draw hook)", tostring(err)))
     end
+end
+
+-- =========================================================
+-- Hot-reload delivery: register() only runs at mission load, so a push of this
+-- file alone would define the new edit listener without ever registering it.
+-- This top-level block re-runs the registration on reload.
+--
+-- BUILD 20:04 aftermath: delivery is NOT gated on .active any more. The 20:04
+-- wave proved the gate can skip silently - the boot-time bridge on this session
+-- predated the edit-listener code, and the gated block left the Moisture panel
+-- with no listener on the live MasterHUD table while Fuel and Soil re-registered
+-- (their register prints appear in log.txt at 20:05:59/20:06:05, CropStress
+-- never printed). register() is idempotent (subscribe and registerEditListener
+-- both replace by id), so firing on every live source pass is safe; on a cold
+-- source pass the mission handle does not exist yet and this stays a no-op.
+local __hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+if __hud ~= nil then
+    pcall(function() CropStressMasterHUDBridge.register() end)
 end

--- a/src/settings/CropStressSettings.lua
+++ b/src/settings/CropStressSettings.lua
@@ -36,8 +36,8 @@ local DEFAULTS = {
     debugMode = false,
     -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
     experimentalSystems = false,
-    hudPanelX = 0.010,   -- matches HUDOverlay.PANEL_X
-    hudPanelY = 0.175    -- matches HUDOverlay.PANEL_Y
+    hudPanelX = 0.02,    -- matches HUDOverlay.PANEL_X (BUILD 06:43 middle-left default)
+    hudPanelY = 0.45     -- matches HUDOverlay.PANEL_Y (BUILD 06:43 middle-left default)
 }
 
 -- Difficulty multipliers

--- a/src/settings/CropStressSettings.lua
+++ b/src/settings/CropStressSettings.lua
@@ -19,7 +19,9 @@ end
 -- ============================================================
 -- CROP STRESS SETTINGS CLASS
 -- ============================================================
-CropStressSettings = {}
+-- Wizard hot-reload law Part 1: reuse the existing class table on reload so
+-- updated methods land on the table live metatables already reference.
+CropStressSettings = CropStressSettings or {}
 CropStressSettings.__index = CropStressSettings
 
 -- Default values matching the current hardcoded constants
@@ -36,8 +38,22 @@ local DEFAULTS = {
     debugMode = false,
     -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
     experimentalSystems = false,
-    hudPanelX = 0.01,    -- matches HUDOverlay.PANEL_X (BUILD 15:47 left default)
-    hudPanelY = 0.18     -- matches HUDOverlay.PANEL_Y (BUILD 15:47 left default)
+    -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
+    -- in-game (must match HUDOverlay.PANEL_X/Y). A saved XML still wins on load.
+    hudPanelX = 0.012604,
+    hudPanelY = 0.236481,
+    -- Forecast pane home (Wizard 2026-08-21: strip is independently movable).
+    -- -1 = docked to the fields panel's right edge; the factory home is the
+    -- absolute spot Wizard placed it (just above the fields pane).
+    hudForecastX = 0.136500,
+    hudForecastY = 0.135556,
+    -- Wizard 2026-08-21 width wave: corner-scale and per-pane width multipliers
+    -- (NPCFavor/Workplace pattern) persist too. hudScale was written by the HUD
+    -- since the resize feature shipped but never saved - fixed here. Values are
+    -- the factory suite layout.
+    hudScale         = 1.118898,
+    hudWidthMult     = 1.098438,
+    hudForecastWMult = 1.187500
 }
 
 -- Difficulty multipliers
@@ -90,7 +106,15 @@ local VALIDATION = {
     criticalThreshold = { min = 0.15, max = 0.35 },
     alertCooldown = { min = 4, max = 24 },
     hudPanelX = { min = 0.0,  max = 0.95 },
-    hudPanelY = { min = 0.05, max = 0.95 }
+    hudPanelY = { min = 0.05, max = 0.95 },
+    -- Forecast pane: same screen clamp, but -1 (docked sentinel) passes through
+    -- validate() untouched - see the explicit branch there.
+    hudForecastX = { min = 0.0, max = 0.95 },
+    hudForecastY = { min = 0.0, max = 0.95 },
+    -- Mirror HUDOverlay.MIN/MAX_SCALE and MIN/MAX_WIDTH_MULT
+    hudScale         = { min = 0.6,  max = 1.6 },
+    hudWidthMult     = { min = 0.75, max = 2.0 },
+    hudForecastWMult = { min = 0.75, max = 2.0 }
 }
 
 function CropStressSettings.new()
@@ -161,6 +185,11 @@ function CropStressSettings:load(missionInfo)
     self.experimentalSystems = readBool(xmlFile, "cropStressSettings.experimentalSystems", DEFAULTS.experimentalSystems)
     self.hudPanelX          = xmlFile:getFloat("cropStressSettings.hudPanelX")           or DEFAULTS.hudPanelX
     self.hudPanelY          = xmlFile:getFloat("cropStressSettings.hudPanelY")           or DEFAULTS.hudPanelY
+    self.hudForecastX       = xmlFile:getFloat("cropStressSettings.hudForecastX")        or DEFAULTS.hudForecastX
+    self.hudForecastY       = xmlFile:getFloat("cropStressSettings.hudForecastY")        or DEFAULTS.hudForecastY
+    self.hudScale           = xmlFile:getFloat("cropStressSettings.hudScale")            or DEFAULTS.hudScale
+    self.hudWidthMult       = xmlFile:getFloat("cropStressSettings.hudWidthMult")        or DEFAULTS.hudWidthMult
+    self.hudForecastWMult   = xmlFile:getFloat("cropStressSettings.hudForecastWMult")    or DEFAULTS.hudForecastWMult
 
     -- One-time default migration for the yield cap (Arissani ruling 2026-07-30).
     --
@@ -241,6 +270,11 @@ function CropStressSettings:saveToXMLFile(missionInfo)
     xmlFile:setBool("cropStressSettings.experimentalSystems", self.experimentalSystems)
     xmlFile:setFloat("cropStressSettings.hudPanelX", self.hudPanelX)
     xmlFile:setFloat("cropStressSettings.hudPanelY", self.hudPanelY)
+    xmlFile:setFloat("cropStressSettings.hudForecastX", self.hudForecastX or -1)
+    xmlFile:setFloat("cropStressSettings.hudForecastY", self.hudForecastY or -1)
+    xmlFile:setFloat("cropStressSettings.hudScale", self.hudScale or 1.0)
+    xmlFile:setFloat("cropStressSettings.hudWidthMult", self.hudWidthMult or 1.0)
+    xmlFile:setFloat("cropStressSettings.hudForecastWMult", self.hudForecastWMult or 1.0)
 
     xmlFile:save()
     xmlFile:delete()
@@ -292,6 +326,17 @@ function CropStressSettings:validateSettings()
     -- Clamp HUD panel position
     self.hudPanelX = math.max(VALIDATION.hudPanelX.min, math.min(VALIDATION.hudPanelX.max, self.hudPanelX or DEFAULTS.hudPanelX))
     self.hudPanelY = math.max(VALIDATION.hudPanelY.min, math.min(VALIDATION.hudPanelY.max, self.hudPanelY or DEFAULTS.hudPanelY))
+    -- Forecast pane: -1 is the docked sentinel and passes through untouched;
+    -- anything else clamps on-screen like the main panel.
+    local fx = self.hudForecastX or DEFAULTS.hudForecastX
+    local fy = self.hudForecastY or DEFAULTS.hudForecastY
+    if fx >= 0 then fx = math.max(VALIDATION.hudForecastX.min, math.min(VALIDATION.hudForecastX.max, fx)) else fx = -1 end
+    if fy >= 0 then fy = math.max(VALIDATION.hudForecastY.min, math.min(VALIDATION.hudForecastY.max, fy)) else fy = -1 end
+    self.hudForecastX = fx
+    self.hudForecastY = fy
+    self.hudScale         = math.max(VALIDATION.hudScale.min,         math.min(VALIDATION.hudScale.max,         self.hudScale or DEFAULTS.hudScale))
+    self.hudWidthMult     = math.max(VALIDATION.hudWidthMult.min,     math.min(VALIDATION.hudWidthMult.max,     self.hudWidthMult or DEFAULTS.hudWidthMult))
+    self.hudForecastWMult = math.max(VALIDATION.hudForecastWMult.min, math.min(VALIDATION.hudForecastWMult.max, self.hudForecastWMult or DEFAULTS.hudForecastWMult))
 
     -- Ensure boolean values are actually booleans
     self.enabled = not not self.enabled
@@ -355,4 +400,20 @@ function CropStressSettings:debugPrint()
     csLog("hudPanelX: " .. tostring(self.hudPanelX))
     csLog("hudPanelY: " .. tostring(self.hudPanelY))
     csLog("=========================")
+end
+-- =========================================================
+-- Wizard hot-reload law Part 2: force-patch the live settings instance after a
+-- reload so the new save()/validate() (hudForecastX/Y persistence) apply
+-- mid-session. The instance lives at manager.settings; fields the new code
+-- reads that the old instance lacks are nil-safe (save writes "or -1").
+local __hrMgr = g_cropStressManager or (g_currentMission ~= nil and g_currentMission.cropStressManager or nil)
+if __hrMgr ~= nil and __hrMgr.settings ~= nil then
+    local inst = __hrMgr.settings
+    for k, v in pairs(CropStressSettings) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
+    -- Delivery proof in log.txt (Wizard 2026-08-21).
+    print("[CropStress] CropStressSettings hot-patched onto live instance")
 end

--- a/src/settings/CropStressSettings.lua
+++ b/src/settings/CropStressSettings.lua
@@ -36,8 +36,8 @@ local DEFAULTS = {
     debugMode = false,
     -- Release-gate opt-in (default false), orthogonal to difficulty. See ReleaseGate.lua.
     experimentalSystems = false,
-    hudPanelX = 0.02,    -- matches HUDOverlay.PANEL_X (BUILD 06:43 middle-left default)
-    hudPanelY = 0.45     -- matches HUDOverlay.PANEL_Y (BUILD 06:43 middle-left default)
+    hudPanelX = 0.01,    -- matches HUDOverlay.PANEL_X (BUILD 15:47 left default)
+    hudPanelY = 0.18     -- matches HUDOverlay.PANEL_Y (BUILD 15:47 left default)
 }
 
 -- Difficulty multipliers

--- a/src/ui/CsMapHooks.lua
+++ b/src/ui/CsMapHooks.lua
@@ -592,3 +592,75 @@ if IngameMapElement ~= nil then
 else
     print(LOG_PREFIX .. "WARNING — IngameMapElement not available — map dots will not draw")
 end
+
+-- =========================================================
+-- BUILD 09:19 (PB-12): keep the Growth-map field drawer inside the visible frame.
+-- =========================================================
+-- Twin of the same patch in FS25_SoilFertilizer/src/hooks/SoilMapHooks.lua; the long-form
+-- reasoning lives there. Short version: vanilla InGameMenuMapUtil places the field info
+-- drawer left of the cursor with `posX = posX - fieldInfoBox.size[1]` and never clamps that
+-- to the screen, and getFieldInfoBoxOrientation only flips for right/top overflow, so at the
+-- map's left edge the box runs off-screen and the player reads label tails ("...ds lime")
+-- instead of labels.
+--
+-- Vanilla still chooses the side and the anchor. This appended pass only pulls the finished
+-- box back inside the safe frame when it ended up outside, so away from the edges it is a
+-- no-op and nothing about the normal placement changes.
+--
+-- Soil and Crop Stress both carry it and share one install flag on InGameMenuMapUtil, so
+-- whichever loads first installs and the drawer is fixed whether or not both are present.
+
+local function clampFieldInfoBoxInsideFrame(fieldInfoBox)
+    if fieldInfoBox == nil then
+        return
+    end
+    local ap = fieldInfoBox.absPosition
+    local as = fieldInfoBox.absSize
+    if type(ap) ~= "table" or type(as) ~= "table" then
+        return
+    end
+    local px, py = ap[1], ap[2]
+    local w, h = as[1], as[2]
+    if type(px) ~= "number" or type(py) ~= "number"
+        or type(w) ~= "number" or type(h) ~= "number" then
+        return
+    end
+
+    -- Same margins the vanilla HUD keeps off the screen edge (IngameMap:getMapPosition
+    -- returns g_safeFrameOffsetX, g_safeFrameOffsetY), not a number invented here.
+    local marginX = (type(g_safeFrameOffsetX) == "number") and g_safeFrameOffsetX or 0
+    local marginY = (type(g_safeFrameOffsetY) == "number") and g_safeFrameOffsetY or 0
+
+    -- Left wins if the box cannot satisfy both edges: the left edge is where label text
+    -- starts, and a lost first character is the defect being fixed.
+    local maxX = 1 - marginX - w
+    local newX = px
+    if newX > maxX then newX = maxX end
+    if newX < marginX then newX = marginX end
+
+    local maxY = 1 - marginY - h
+    local newY = py
+    if newY > maxY then newY = maxY end
+    if newY < marginY then newY = marginY end
+
+    if newX ~= px or newY ~= py then
+        if type(fieldInfoBox.setAbsolutePosition) == "function" then
+            fieldInfoBox:setAbsolutePosition(newX, newY)
+        end
+    end
+end
+
+if InGameMenuMapUtil ~= nil
+    and type(InGameMenuMapUtil.updateFieldInfoBoxPosition) == "function"
+    and InGameMenuMapUtil._rfFieldInfoBoxClampInstalled ~= true then
+
+    InGameMenuMapUtil._rfFieldInfoBoxClampInstalled = true
+    InGameMenuMapUtil.updateFieldInfoBoxPosition = Utils.appendedFunction(
+        InGameMenuMapUtil.updateFieldInfoBoxPosition,
+        function(fieldInfoBox)
+            clampFieldInfoBoxInsideFrame(fieldInfoBox)
+        end)
+    print(LOG_PREFIX .. "field info drawer clamped inside the safe frame (PB-12)")
+elseif InGameMenuMapUtil == nil then
+    print(LOG_PREFIX .. "WARNING - InGameMenuMapUtil not available - field info drawer clamp not installed")
+end

--- a/src/ui/RfEscModules.lua
+++ b/src/ui/RfEscModules.lua
@@ -256,6 +256,11 @@ function RfEscModules:registerModule(def)
         -- companions that predate this.
         selectCommodityIndex = def.selectCommodityIndex,
         onLightTick = def.onLightTick,
+        -- Sixth instance, BUILD 14:04 (Brian TEST 10:29): NPC Favor registered onPageStep
+        -- for the shared row pager on BUILD 09:19 and this whitelist ate it, so the live
+        -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
+        -- The register-time warning below did name it, in a log nobody read back.
+        onPageStep = def.onPageStep,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1033,13 +1033,56 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         return
     end
 
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
+    -- BUILD 17:50 (PB-06). The item count decides everything below this line.
+    --
+    -- Before 17:50 this helper forced the arrows enabled and full lime unconditionally,
+    -- which was the fault it fixed: with a single entry the arrow cannot change state, so
+    -- the player saw a bright, clickable-looking arrow that could never act.
+    --
+    -- 17:50 leaned on disableButtonsOnSingleText to express that. BUILD 20:39 takes it back
+    -- off (see the note below the empty-list guard) and drives disabled from here alone.
+    -- Line references throughout are
+    -- .local/ref/FS25-lua-scripting/elements/MultiTextOptionElement.lua unless named
+    -- otherwise. Nothing here is guessed.
+    local texts = sel.texts or {}
+
+    -- BUILD 20:39. An empty text list means "not seeded yet", not "one page", and the two
+    -- must not be treated the same. Every caller below runs this helper both BEFORE and
+    -- AFTER the texts are set, so the early call used to latch the pager disabled from a
+    -- count that was about to change - and if the seeding path then failed or threw, the
+    -- pager stayed disabled for the rest of the session while the arrows below still got
+    -- painted. That is one of the three ways George's TASK 20:38 lime-but-dead read is
+    -- reachable. With no texts there is nothing to page through, so write nothing and let
+    -- the seeded call decide.
+    if #texts == 0 then
+        return
     end
+    local multi = #texts > 1
+
+    -- BUILD 20:39: disableButtonsOnSingleText stays FALSE (Sam feel lock DESIGN 20:00,
+    -- re-stated in BUILD 20:39; the XML declares false on every MTO in this page).
+    -- 17:50 read it as a free engine helper, but it is not free: with it true the engine
+    -- writes setDisabled(#texts <= 1) from inside updateContentElement (:831-833), and
+    -- updateContentElement runs on every setTexts, setState and arrow click. That is a
+    -- second writer on the one flag that decides whether the pager takes input at all,
+    -- firing on the same frame as our own write - "state reset in the same frame", the
+    -- third cause George named. With it false this function is the only writer.
+    -- The single-page focus guard 17:50 wanted from it is not lost: canReceiveFocus (:774)
+    -- also returns false on a disabled element, and one page still sets disabled below.
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false   -- never remove the control, only dim it
+    if sel.setCanChangeState then
+        sel:setCanChangeState(multi)
+    end
+    -- This is the gate that decides whether a click ever reaches the arrows. A disabled
+    -- MTO swallows the whole mouse event before it can descend to its buttons:
+    -- MultiTextOptionElement:mouseEvent wraps its entire body in getIsActive() (:434) and
+    -- GuiElement:getIsActive is "not disabled and visible" (GuiElement.lua:1338-1340).
+    -- The GuiOverlay.setColor tint further down does NOT go through that gate, so a
+    -- disabled pager still paints lime - which is exactly the reported defect: lime arrows,
+    -- dead clicks. Multi-page must therefore end this call with disabled == false.
     if sel.setDisabled then
-        sel:setDisabled(false)
+        sel:setDisabled(not multi)
     end
 
     -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
@@ -1053,11 +1096,22 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     end
 
     -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
-    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    --
+    -- Enabled keeps George's lime. Disabled goes to Samantha's neutral 45% rather than a faded
+    -- lime, so "cannot act" reads as absence of colour instead of a dimmed affordance. The
+    -- brief writes the enabled state as {1,1,1,1}, which would drop the lime this file already
+    -- carries; that is not what PB-06 is about, so the lime stays and the reading is flagged
+    -- in the reply rather than decided silently.
+    local r, g, b, a
+    if multi then
+        r, g, b, a = 0.549, 0.776, 0.247, 1
+    else
+        r, g, b, a = 1, 1, 1, 0.45
+    end
     for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
-            if btn.setDisabled then btn:setDisabled(false) end
+            if btn.setDisabled then btn:setDisabled(not multi) end
             -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
@@ -1073,8 +1127,19 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
 end
 
 --- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+--- BUILD 20:39: also the wrap lock for the left-pane pager. Wrap is engine-native and on
+--- by default (MultiTextOptionElement.lua:55) - onRightButtonClicked rolls #texts -> 1 and
+--- onLeftButtonClicked rolls 1 -> #texts (:670-679 / :721-730) - but XML #wrap and profile
+--- "wrap" can both turn it off (:111 / :141), and with it off the last page clamps and the
+--- arrow reads dead at exactly one end. The ask is explicit that both ends wrap, so state
+--- it rather than inherit it. Set here on the pager only: _ensureMtoArrowsVisible is shared
+--- with the WC wage / About / subnav MTOs, and their wrap is not this token's business.
 function RfPdaMenuPage:_ensureSelectorArrowsVisible()
-    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+    local sel = self.rfPanelSelector
+    if sel ~= nil then
+        sel.wrap = true
+    end
+    self:_ensureMtoArrowsVisible(sel)
 end
 
 --- Stable id list fingerprint for quiet SmoothList reload decisions.
@@ -1114,7 +1179,10 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
             activeIndex = 1
         end
 
-        self:_ensureSelectorArrowsVisible()
+        -- BUILD 20:39: the pre-setTexts ensure call that used to sit here is gone. It fed
+        -- _ensureMtoArrowsVisible the PREVIOUS text count - on first open an empty one - so
+        -- it decided the pager's disabled state from a number that the next line was about
+        -- to replace. The post-setState call below is the one that matters and it stays.
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
@@ -1270,14 +1338,43 @@ function RfPdaMenuPage:_applySelectorState()
 
     local state = self.rfPanelSelector:getState()
     local panel = self._panelCache[state]
-    if panel == nil then return end
+    if panel == nil then
+        -- BUILD 20:39: this is the second half of the defect. The arrow has already moved
+        -- the label and the dots by the time we get here (the engine advances state, then
+        -- raises this callback), so returning empty-handed leaves the page NAME on one
+        -- module and the page CONTENT on another - the "content does not move" read. A
+        -- cache one module older than the MTO texts is enough to hit it. Re-read the
+        -- registry once before giving up.
+        local panels = (type(host.getPanels) == "function") and host:getPanels() or nil
+        if panels ~= nil then
+            self._panelCache = panels
+            panel = panels[state]
+        end
+    end
+    if panel == nil then
+        -- Still nothing at this index: put the pager back on the page that is actually
+        -- showing. An honest snap-back beats a label pointing at a page that never loaded.
+        self:_restoreBrandToActivePanel()
+        return
+    end
 
     if host.activeModuleId ~= panel.id then
         if not self:_allowModuleSelect(panel.id) then
+            -- Refused by the dual-fire debounce. The MTO state has still moved, so snap it
+            -- back or label, dots and content stay disagreeing until the next full refresh.
+            self:_restoreBrandToActivePanel()
             return
         end
         -- Host notify refreshes selector + content (quiet lists).
-        host:selectPanel(panel.id)
+        local switched = host:selectPanel(panel.id)
+        if switched == false then
+            -- Registry refused (module gone or isAvailable false): no notify fires, so
+            -- nothing downstream would ever correct the advanced label. Snap it back.
+            SoilLogger.warning("RfPdaMenuPage: selectPanel %s refused, restoring pager state",
+                tostring(panel.id))
+            self:_restoreBrandToActivePanel()
+            return
+        end
         SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
     else
         self:refreshContent(false)

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -16,17 +16,29 @@
 local MOD_DIR = g_currentModDirectory
 local MOD_NAME = g_currentModName
 
--- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+-- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
+-- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
+-- with the format first (src/utils/Logger.lua: function SoilLogger.info(msg, ...)), and
+-- every call in this file is dot-style. The old stub took (_, fmt, ...) as if colon-called,
+-- so on every non-Soil-hosted door the message landed in the discarded first slot and the
+-- log printed only the leftover arguments - or nothing at all. That is why the host's
+-- [RfEsc] lines have never appeared in a Dairy-door log, and it would have eaten the
+-- selector diagnostics this build ships. pcall on the format so a stray % in a runtime
+-- value can never turn a log line into the only traceback on the page.
 if SoilLogger == nil then
+    local function stubLine(fmt, ...)
+        local ok, text = pcall(string.format, fmt or "", ...)
+        return "[RfEsc] " .. (ok and text or tostring(fmt))
+    end
     SoilLogger = {
-        info = function(_, fmt, ...)
-            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        info = function(fmt, ...)
+            if Logging and Logging.info then Logging.info(stubLine(fmt, ...)) end
         end,
-        warning = function(_, fmt, ...)
-            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        warning = function(fmt, ...)
+            if Logging and Logging.warning then Logging.warning(stubLine(fmt, ...)) end
         end,
-        error = function(_, fmt, ...)
-            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        error = function(fmt, ...)
+            if Logging and Logging.error then Logging.error(stubLine(fmt, ...)) end
         end,
     }
 end
@@ -198,7 +210,9 @@ local function mdResolve(bare, name)
             MdRfPdaGuest = "FS25_MarketDynamics",
             MDMMarketScreenGraph = "FS25_MarketDynamics",
             MDMMarketScreen = "FS25_MarketDynamics",
+            MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
+            NpcRfPdaGuest = "FS25_NPCFavor",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -212,16 +226,69 @@ local function mdResolve(bare, name)
             end
         end
     end
-    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    -- 4. _G. BUILD 14:04 (George TASK 10:53): Vera's live gate read via=mission, which
+    --    means belts 2 and 3 miss on the live engine (g_modEnvironments carries nothing
+    --    there) and getfenv(0) is the per-mod sandbox, not a shared root. _G read from mod
+    --    code resolves through the sandbox chain, so when the engine backs it with the real
+    --    global table this belt sees a publisher's _G write; when the sandbox loops _G onto
+    --    itself it degenerates to the bare lookup and costs one table index.
+    if type(_G) == "table" and _G[name] ~= nil then
+        return _G[name]
+    end
+    -- 5. sandbox root: MarketDynamics publishes here from BUILD 11:43.
     local okEnv, root = pcall(getfenv, 0)
     if okEnv and type(root) == "table" and root[name] ~= nil then
         return root[name]
     end
-    -- 5. mission handle, same publish.
+    -- 6. mission handle, same publish. The one belt Vera's live gate has actually seen
+    --    resolve on a non-MD door (via=mission), so it must stay last-resort-but-present.
     if g_currentMission ~= nil and g_currentMission[name] ~= nil then
         return g_currentMission[name]
     end
     return nil
+end
+
+--- BUILD 14:04 fence for _populateMdCommodityRow: 2dp currency when MDMPriceFormat cannot
+--- be resolved at all. George's constraint on the failed probe is "degrades to 2dp path -
+--- never formatMoney(..., 0)". This is the Vera-F2 pad rule in miniature (formatNumber and
+--- formatMoney both round-then-tostring, so neither ever pads a whole number to .00): split
+--- the digits by hand, let formatNumber group the integer half only, take the locale's own
+--- decimal mark. No x1000, no litre suffix, no animal test - that display policy lives in
+--- MDMPriceFormat and duplicating it here would put two dialects back on screen. This fence
+--- should be unreachable: the Prices rows only paint under a registered MD guest, and
+--- registration publishes MDMPriceFormat to the mission handle every attempt.
+local function mdMoney2(value)
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, 2)
+    end
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        whole = whole + 1
+        frac = frac - 100
+    end
+    local wholeStr = tostring(whole)
+    local separator = "."
+    local symbol = ""
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+    return out
 end
 
 local function tr(key, fallback)
@@ -1283,6 +1350,13 @@ function RfPdaMenuPage:_rebuildDots(count)
 end
 
 function RfPdaMenuPage:onClickRfPanelSelector()
+    -- BUILD 17:08 diagnostic, one line per real selector input (forceEvent is false on
+    -- every internal setState in this file, so this callback only fires for the player).
+    -- If a live test still shows dead arrows AND this line never appears in the log, the
+    -- click is being consumed ABOVE this page (menu-level), which the in-page shield in
+    -- mouseEvent cannot reach - that finding goes to George, not to more host code.
+    SoilLogger.info("RfPdaMenuPage: selector input received, state=%s",
+        tostring(self.rfPanelSelector ~= nil and self.rfPanelSelector:getState() or "?"))
     self:_ensureSelectorArrowsVisible()
     self:_applySelectorState()
 end
@@ -1551,6 +1625,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- BUILD 09:19 (PB-07): the shared row pager is OFF by default, every refresh, for every
+    -- module. Only a guest that implements onPageStep turns it back on, from inside its own
+    -- onShow, which runs after this. That ordering is what stops the pager following the
+    -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
+    -- exist and would never have hidden them.
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+        local btn = self:getDescendantById(id)
+        if btn ~= nil and type(btn.setVisible) == "function" then
+            btn:setVisible(false)
+        end
+    end
     -- Action bar rides the CS module only; the guest decides the two buttons.
     setVis(self.csActionBar, isCs)
     if not isCs then
@@ -2336,6 +2421,136 @@ function RfPdaMenuPage:onClickHelpCs()
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 09:19 (PB-07): shared Table-mode row pager.
+--
+-- rfFwTableBlock is a STATIC eight-row table (rfFwRow1..rfFwRow8) - not a SmoothList - and
+-- four guests paint into it: Income, Dairy, NPC Favor and Fertilizer Depot. When a guest has
+-- more rows than eight it prints "showing 8 of 11" into rfFwMore and the other three rows
+-- were unreachable: no scrollbar, no page control, no route of any kind. Sam's law is that a
+-- list which prints a range must be navigable to the end of that range.
+--
+-- This is a PAGER and deliberately not a SmoothList. George's standing hang lesson is that a
+-- SmoothList nested under the Map-style Bitmap shell in this page can hang the frame, and the
+-- existing csConsultPanel carries the same NO-GO ("George NO-GO on TextElement.new rebuild,
+-- dialog XML nest, or SmoothList"). Two Buttons plus a window offset held by the guest costs
+-- no new list machinery and cannot re-enter the layout.
+--
+-- The host owns only the click. It knows nothing about roster size, page count or labels -
+-- it forwards a step to whichever guest is active and then repaints. A guest that does not
+-- implement onPageStep is simply not pageable and the buttons stay hidden, which is why the
+-- other three Table guests need no change to keep working exactly as before.
+-- ---------------------------------------------------------------------------
+
+--- Forward one page step to the active guest, then repaint the page it just moved.
+---@param delta number -1 for previous page, +1 for next
+---@return boolean moved true when the window moved and a repaint ran
+function RfPdaMenuPage:_rfFwPageStep(delta)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active == nil then
+        return false
+    end
+    local step = active.onPageStep
+    -- BUILD 14:04 (Brian TEST 10:29). This is why the live MORE was a painted no-op: the
+    -- guest registered onPageStep exactly as BUILD 09:19 described, and
+    -- RfEscModules:registerModule silently dropped it - the sixth handler that whitelist
+    -- has eaten (onOpenFullMarket, onOpenConsultant/Schedule/Help, onPivotRemote,
+    -- onLightTick, onMoverChanged before it). The whitelist now carries onPageStep, and
+    -- this belt is the same shape as the 23:51 onLightTick belt directly below in
+    -- refreshContent: if the registry instance was created by a mod still running an old
+    -- RfEscModules copy, reach the guest class itself rather than shipping a dead button
+    -- again. npcFavor is the only pageable guest today, so the belt names it.
+    if type(step) ~= "function" and active.id == "npcFavor" then
+        local npcGuest = (type(mdResolve) == "function")
+                and mdResolve(NpcRfPdaGuest, "NpcRfPdaGuest") or NpcRfPdaGuest
+        if npcGuest ~= nil and type(npcGuest.onPageStep) == "function" then
+            step = npcGuest.onPageStep
+        end
+    end
+    if type(step) ~= "function" then
+        return false
+    end
+    -- The guest owns the clamp/wrap: it is the only side that knows how many rows it has.
+    -- It returns true when the window actually moved, so a click at a hard end does not
+    -- trigger a pointless full repaint.
+    local ok, moved = pcall(step, delta)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: onPageStep failed on %s: %s",
+            tostring(active.id), tostring(moved))
+        return false
+    end
+    if moved == false then
+        return false
+    end
+    -- Soft refresh: same path the module pager uses, so the guest repaints its rows and its
+    -- own footer range without a full enter/rebuild.
+    self:refreshContent(false)
+    return true
+end
+
+function RfPdaMenuPage:onClickRfFwPagePrev()
+    self:_rfFwPageStep(-1)
+end
+
+function RfPdaMenuPage:onClickRfFwPageNext()
+    self:_rfFwPageStep(1)
+end
+
+--- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
+--- "click/Space/>" acceptance. keyEvent walks children first via the superclass
+--- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
+--- control that consumes the key - including the pager Button itself activating on Space -
+--- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
+--- step, and only a step that actually moved marks the event used; on every page without a
+--- pageable guest _rfFwPageStep returns false immediately and the key passes through
+--- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
+--- layout that produced ">" does not matter.
+function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
+    local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
+    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+        used = self:_rfFwPageStep(1) == true
+    end
+    return used
+end
+
+--- BUILD 17:08 (Brian TEST 16:53, George TASK 17:03 GO): click shield for the module
+--- selector. Brian measured both selector arrows hover-highlighting but never advancing,
+--- with no Lua traceback. The engine split that allows exactly that: ButtonElement paints
+--- its hover state regardless of eventUsed (ButtonElement.lua:450-459) but fires its click
+--- only "if not eventUsed" (:469-491), and FocusManager highlight on the MTO is likewise
+--- move-driven (MultiTextOptionElement.lua:465-469). So hover-alive-click-dead means the
+--- CLICK half of the event is being consumed before the selector's walk position - George's
+--- hit-steal read. Event order in this engine is reverse declaration order with no z-index,
+--- and Sam's lock forbids moving any geometry, so the fix is delivery order, not layout:
+--- the page offers every click that lands inside the selector's rect to the selector FIRST,
+--- then runs the normal child walk with the event marked used, so whichever sibling was
+--- eating the click can still clear its own pressed state but can no longer act on it.
+--- Moves are NOT pre-offered - hover behavior is untouched, and a second visit of the MTO
+--- during the normal walk with eventUsed=true only re-computes identical press flags
+--- (:441-446, not eventUsed-gated), so nothing double-fires and no wrapper element is
+--- introduced. Clicks outside the selector rect take the walk exactly as before, so the
+--- module list, FW pager and every guest control keep their ownership.
+function RfPdaMenuPage:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    local used = eventUsed
+    local sel = self.rfPanelSelector
+    if not used and (isDown or isUp) and sel ~= nil
+        and sel.absPosition ~= nil and sel.absSize ~= nil
+        and type(sel.getIsActive) == "function" and sel:getIsActive()
+        and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function"
+        and GuiUtils.checkOverlayOverlap(posX, posY,
+            sel.absPosition[1], sel.absPosition[2], sel.absSize[1], sel.absSize[2], nil) then
+        if sel:mouseEvent(posX, posY, isDown, isUp, button, false) then
+            used = true
+            if not self._selShieldLogged then
+                self._selShieldLogged = true
+                SoilLogger.info("RfPdaMenuPage: selector click shield delivered its first click")
+            end
+        end
+    end
+    return RfPdaMenuPage:superClass().mouseEvent(self, posX, posY, isDown, isUp, button, used) or used
+end
+
 function RfPdaMenuPage:_csPageSel()
     return self.csSubnavSelector
 end
@@ -2786,12 +3001,50 @@ function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
         end
     end
     if nameEl then nameEl:setText(entry.title or "-") end
+    -- BUILD 09:19 (PB-02). This cell is the one Brian read as "£0" and "£1".
+    --
+    -- entry.price is the PER-LITRE engine number. formatMoney(price, 0, ...) rounded it to
+    -- whole currency units and printed no unit at all, so a live 0.00037/l commodity became
+    -- an actionable-looking "£0" and soybean at 0.85/l became "£1". Neither is a zero and
+    -- neither says what it is a price OF.
+    --
+    -- MDMPriceFormat is the single place that decides how a market price is written: the
+    -- x1000 display multiply for bulk goods, the forced two decimals built by hand (Vera F2:
+    -- neither formatMoney nor formatNumber forcePrecision actually pads .00), the locale
+    -- decimal mark, and the " / 1,000L" suffix that animal cargo does NOT get. The full
+    -- Market table and the Esc selected-crop line call the same helper, so all three
+    -- surfaces print one string and not three dialects of it.
+    --
+    -- The nil guard matters on this file specifically: this host is mirrored into all nine
+    -- doors and only the Market Dynamics zip ships MdPriceFormat.lua. On the other eight
+    -- doors MDMPriceFormat is nil UNLESS Market Dynamics is also loaded - and if it is not
+    -- loaded there is no Market page to paint anyway. The fallback keeps the old reading
+    -- instead of erroring.
+    --
+    -- BUILD 10:06, Vera FAIL F1. The bare global was doing less than that comment claimed.
+    -- It is nil not only when Market Dynamics is absent, but whenever Market Dynamics is not
+    -- the mod that WON the door race: FS25 gives every mod its own environment and this
+    -- mirrored file executes inside the host's, so on a Dairy-hosted or Income-hosted suite
+    -- the bare lookup misses a fully loaded MdPriceFormat.lua and the cell silently drops to
+    -- the formatMoney fallback - the exact "GBP 0" reading PB-02 was supposed to have fixed.
+    -- Same failure shape, same cause and same cure as MDMMarketScreenGraph on the Dairy door.
+    -- Resolved through mdResolve, which is that cure: bare first (free when Market Dynamics
+    -- hosts), then the named g_modEnvironments["FS25_MarketDynamics"] entry, then the
+    -- name-independent scan and the getfenv(0) / mission belts.
+    local priceFormat = (type(mdResolve) == "function")
+            and mdResolve(MDMPriceFormat, "MDMPriceFormat") or MDMPriceFormat
     local priceText = "-"
     if entry.price ~= nil then
-        if g_i18n and g_i18n.formatMoney then
-            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        if priceFormat ~= nil and type(priceFormat.price) == "function" then
+            priceText = priceFormat.price(entry.fillTypeIndex, entry.price)
         else
-            priceText = string.format("%.0f", entry.price)
+            -- BUILD 14:04 (Vera FAIL on SUBMIT 10:16). The old branch here was
+            -- formatMoney(entry.price, 0, ...), which is the exact GBP 0 / GBP 1 reading
+            -- this cell has now shipped twice. George's constraint is verbatim "failed
+            -- probe degrades to 2dp path - never formatMoney(..., 0)", so the raw
+            -- per-litre number prints at two decimals or it does not print through
+            -- an engine rounder at all.
+            priceText = mdMoney2(entry.price)
         end
     end
     if priceEl then priceEl:setText(priceText) end

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -22,9 +22,13 @@
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
-                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
-                                 disableButtonsOnSingleText="false"
-                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <!-- BUILD 18:16: rfPanelSelector moved to LAST child of rfFilterBox (see below).
+                     George TASK 18:12 asked for z-order ~10-20 on the selector; this engine has no
+                     z attribute of any kind (GuiElement loads none, and no rfHeaderBg element exists
+                     in this page) - draw AND input priority are declaration order, walked in reverse
+                     for events. Declaring the selector last IS the engine's z-raise: it now receives
+                     events before every sibling in this box and draws above them. Positions are
+                     profile-absolute, so nothing moves a pixel. -->
                 <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
                     <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
                 </BoxLayout>
@@ -60,6 +64,16 @@
                         <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
                     </ThreePartBitmap>
                 </GuiElement>
+
+                <!-- BUILD 18:16 (George TASK 18:12): the module selector is deliberately the LAST
+                     child of rfFilterBox. Events walk children in reverse declaration order, so
+                     last-declared = first offered = this engine's only "z-order raise". Its band
+                     rect (profile-positioned, unchanged) does not overlap any sibling's visible
+                     paint, so drawing on top changes no pixel. The BUILD 17:08 page-level click
+                     shield stays as the guarantee against anything OUTSIDE this box. -->
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
             </Bitmap>
 
             <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
@@ -222,29 +236,43 @@
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
                         <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
+                            <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
+                                 this strip: the sentence that says an apply will scorch the crop was
+                                 cut before its own verb.
+                                 The wrap was not broken. TextElement defaults to LAYOUT_MODE.TRUNCATE
+                                 (TextElement.lua:141) and with textMaxNumLines > 1 that takes the
+                                 limitVerticalLines path (:667-676), wrapping at absSize[1] and then
+                                 chopping characters until the text fits the line budget before adding
+                                 "..." (:679-699). So it wrapped to its two lines exactly as asked and
+                                 the string is simply longer than two lines of 18px across 600px.
+                                 Two allowed 18px lines become three. The 18px comes out of this zone
+                                 rather than out of the table: Selected moves up 2, the hairline and
+                                 the PRODUCTS heading close up, and the eight-row clip drops 4. Row 8
+                                 still ends 4px clear of the card frame (124 + 120 = 244 against 248),
+                                 so nothing is cut mid-glyph and the card does not grow. -->
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -4px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
-                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
-                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -24px" size="600px 54px"
+                                  textAlignment="left" textMaxNumLines="3" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then air with
+                                 one 1px hairline in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -82px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -86px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -106px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -106px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -106px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -106px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -124px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
-                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                 card bottom keeps air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -124px" size="600px 120px">
                                 <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
@@ -312,20 +340,43 @@
                             <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
                             <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
+                            <!-- BUILD 09:19 (PB-05). The WHAT IF effect column lost whole consequences.
+                                 RotationPlannerData.effectText joins at most three items with ", " and
+                                 the set is closed: fatigue "x1.15 depletion", nitrogen "+N", and one of
+                                 "less disease" / "more disease". The worst real string is therefore
+                                 "x1.15 depletion, +N, less disease" at 33 characters, and the painter
+                                 capped the cell at 18 - so even the two-item "x1.15 depletion, +N" (19)
+                                 dropped an item and the player was told about the fatigue but not about
+                                 the disease.
+                                 18 was not arbitrary against the OLD cell: this card's own calibration
+                                 is ~6px per glyph at 17px (crop 92px/16, status 60px/10, effect 110px/18),
+                                 so 110px really does hold about 18. One 17px line cannot hold 33 and the
+                                 card cannot grow - George holds the footprint at 290x248 and it must
+                                 never take width back from PRODUCTS. So the effect cell gains a SECOND
+                                 line at 14px instead, which is the size the PRODUCTS table already uses
+                                 for its own cells (RF_ProductCellDense), and about 22 glyphs a line at
+                                 that size gives ~44 against a bounded worst case of 33.
+                                 Row pitch 22 -> 30 to hold the taller cell; the hairline and the two
+                                 header lines close up by 4-8px to pay for it. Row 3 ends at 240 against
+                                 the 248 frame, so the card keeps its 8px of bottom air. Crop and Status
+                                 stay one 17px line and are unchanged. -->
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -112px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -118px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -136px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -136px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -136px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -152px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -152px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf1Effect" position="170px -152px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -182px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -182px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf2Effect" position="170px -182px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -212px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -212px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf3Effect" position="170px -212px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -526,6 +577,19 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
+                                 Hidden by default and shown ONLY by a guest that implements
+                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
+                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
+                                 on nesting a SmoothList in this page (see csConsultPanel below)
+                                 applies here too, and a window offset held by the guest cannot
+                                 re-enter the layout the way a list rebuild can.
+                                 Parked on the rfFwTableTitle band, which every Table-mode guest
+                                 already hides, so the pager collides with nothing that paints. -->
+                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
+                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -260,6 +260,16 @@
     </Profile>
     <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
         <textAlignment value="right"/>
+    </Profile>
+    <!-- BUILD 09:19 (PB-05): WHAT IF effect cell only. Two lines at the same 14px the
+         PRODUCTS table already uses for its own cells, so a comma-joined consequence is
+         printed whole instead of losing its last item to a one-line 110px column. Top
+         aligned because a two-line cell that centres would not line up with the one-line
+         Crop and Status cells beside it. -->
+    <Profile name="RF_ProductCellEffect" extends="RF_ProductCell">
+        <textSize value="14px"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="top"/>
     </Profile>
     <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="18px"/>


### PR DESCRIPTION
## Summary
- Upgrades SeasonalCropStress HUDs (Moisture monitor and 5-day forecast) to native base-game HUD extension styling with dark plates and light border framing.
- Separates the 5-day forecast strip into an independent pane with its own drag/scale target and persistence.
- Resolves row text clipping and scroll thumb overlap.
- Integrates full width-resizing mechanics (edge bands, width multiplier persistence).
- Sets factory layout defaults: Moisture (0.0126, 0.2365, scale 1.119, width 1.098) and Forecast (0.1365, 0.1356, width 1.188).
- Keybindings: CS_TOGGLE_HUD (LAlt + M), CS_EDIT_HUD (LShift + LAlt + M).

## Test plan
- Verified in-game: Moisture and forecast panes drag, scale, and resize independently.
- Verified persistent layout survives save/load cycles and connects to MasterHUD show/hide.