### PR TITLE
feat: PDA and RF Esc desk report and control Rainstar irrigation

### DIFF
--- a/src/IrrigatorSectorIntegration.lua
+++ b/src/IrrigatorSectorIntegration.lua
@@ -46,6 +46,10 @@ function IrrigatorSectorIntegration.new(manager)
     self.isInitialized = false
     self._accMs = 0
     self._waterFillType = nil
+    -- farmlandId -> true for every field this tick actually watered. The PDA
+    -- reads this so a parked Rainstar shows its field as irrigated the same way
+    -- a placed pivot or drip line does; cleared at the top of each tick window.
+    self._activeWateredFields = {}
     return self
 end
 
@@ -113,6 +117,7 @@ function IrrigatorSectorIntegration:update(dt)
     if self._accMs < IrrigatorSectorIntegration.TICK_MS then return end
     local elapsedMs = self._accMs
     self._accMs = 0
+    self._activeWateredFields = {}   -- fresh window; repopulated as water lands
 
     local soilSystem = self.manager ~= nil and self.manager.soilSystem or nil
     if soilSystem == nil or type(soilSystem.applyWaterAtCell) ~= "function" then return end
@@ -207,6 +212,7 @@ function IrrigatorSectorIntegration:_tickVehicle(vehicle, soilSystem, waterIndex
             -- unknown fieldId, so water thrown at a road wets nothing. That is the
             -- honest outcome rather than crediting it to the nearest field.
             soilSystem:applyWaterAtCell(farmland.id, x, z, gain)
+            self._activeWateredFields[farmland.id] = true
             applied = true
         end
     end
@@ -230,6 +236,15 @@ function IrrigatorSectorIntegration:_tickVehicle(vehicle, soilSystem, waterIndex
     return true
 end
 
+--- Farmland ids an active vehicle irrigator watered on the last tick.
+--- The PDA merges these into its covered-fields set so a Rainstar on a field
+--- shows as irrigated without needing a placed pivot or drip line.
+---@return table farmlandId -> true
+function IrrigatorSectorIntegration:getActiveWateredFields()
+    return self._activeWateredFields
+end
+
 function IrrigatorSectorIntegration:delete()
     self.isInitialized = false
+    self._activeWateredFields = {}
 end

--- a/src/IrrigatorSectorIntegration.lua
+++ b/src/IrrigatorSectorIntegration.lua
@@ -50,6 +50,9 @@ function IrrigatorSectorIntegration.new(manager)
     -- reads this so a parked Rainstar shows its field as irrigated the same way
     -- a placed pivot or drip line does; cleared at the top of each tick window.
     self._activeWateredFields = {}
+    -- farmlandId -> { [vehicle] = true }: which Rainstar vehicles watered each
+    -- field this tick, so the Esc PIVOT card can stop the rig for a field.
+    self._activeVehiclesByField = {}
     return self
 end
 
@@ -117,7 +120,8 @@ function IrrigatorSectorIntegration:update(dt)
     if self._accMs < IrrigatorSectorIntegration.TICK_MS then return end
     local elapsedMs = self._accMs
     self._accMs = 0
-    self._activeWateredFields = {}   -- fresh window; repopulated as water lands
+    self._activeWateredFields = {}      -- fresh window; repopulated as water lands
+    self._activeVehiclesByField = {}
 
     local soilSystem = self.manager ~= nil and self.manager.soilSystem or nil
     if soilSystem == nil or type(soilSystem.applyWaterAtCell) ~= "function" then return end
@@ -213,6 +217,9 @@ function IrrigatorSectorIntegration:_tickVehicle(vehicle, soilSystem, waterIndex
             -- honest outcome rather than crediting it to the nearest field.
             soilSystem:applyWaterAtCell(farmland.id, x, z, gain)
             self._activeWateredFields[farmland.id] = true
+            local vehSet = self._activeVehiclesByField[farmland.id]
+            if vehSet == nil then vehSet = {}; self._activeVehiclesByField[farmland.id] = vehSet end
+            vehSet[vehicle] = true
             applied = true
         end
     end
@@ -244,7 +251,23 @@ function IrrigatorSectorIntegration:getActiveWateredFields()
     return self._activeWateredFields
 end
 
+--- Turn off every Rainstar that watered the given field on the last tick. The
+--- Esc PIVOT card's Stop remote calls this for a vehicle-irrigated field that
+--- has no placed pivot to drive. Safe to call when nothing is active.
+---@param fieldId number farmland id
+function IrrigatorSectorIntegration:stopForField(fieldId)
+    local vehSet = self._activeVehiclesByField[fieldId]
+    if vehSet == nil then return end
+    for vehicle in pairs(vehSet) do
+        if type(vehicle.setIsTurnedOn) == "function" then
+            pcall(vehicle.setIsTurnedOn, vehicle, false)
+        end
+    end
+    -- The next tick repopulates from real state, so do not clear here.
+end
+
 function IrrigatorSectorIntegration:delete()
     self.isInitialized = false
     self._activeWateredFields = {}
+    self._activeVehiclesByField = {}
 end

--- a/src/IrrigatorSectorIntegration.lua
+++ b/src/IrrigatorSectorIntegration.lua
@@ -53,6 +53,10 @@ function IrrigatorSectorIntegration.new(manager)
     -- farmlandId -> { [vehicle] = true }: which Rainstar vehicles watered each
     -- field this tick, so the Esc PIVOT card can stop the rig for a field.
     self._activeVehiclesByField = {}
+    -- farmlandId -> true: fields a Rainstar is physically parked on this tick,
+    -- running or not. Kept so the Esc PIVOT card keeps showing the Rainstar seat
+    -- when the rig is present but not spraying.
+    self._presentFields = {}
     return self
 end
 
@@ -122,9 +126,10 @@ function IrrigatorSectorIntegration:update(dt)
     self._accMs = 0
     self._activeWateredFields = {}      -- fresh window; repopulated as water lands
     self._activeVehiclesByField = {}
+    self._presentFields = {}
 
     local soilSystem = self.manager ~= nil and self.manager.soilSystem or nil
-    if soilSystem == nil or type(soilSystem.applyWaterAtCell) ~= "function" then return end
+    local canWrite = soilSystem ~= nil and type(soilSystem.applyWaterAtCell) == "function"
 
     local vehicleSystem = mission.vehicleSystem
     local vehicles = (vehicleSystem ~= nil and vehicleSystem.vehicles) or mission.vehicles
@@ -135,7 +140,10 @@ function IrrigatorSectorIntegration:update(dt)
 
     for _, vehicle in pairs(vehicles) do
         if vehicle ~= nil and IrrigatorSectorIntegration.matchesType(vehicle.typeName) then
-            anyApplied = self:_tickVehicle(vehicle, soilSystem, waterIndex, elapsedMs) or anyApplied
+            self:_recordPresence(vehicle)
+            if canWrite then
+                anyApplied = self:_tickVehicle(vehicle, soilSystem, waterIndex, elapsedMs) or anyApplied
+            end
         end
     end
 
@@ -251,6 +259,29 @@ function IrrigatorSectorIntegration:getActiveWateredFields()
     return self._activeWateredFields
 end
 
+--- Farmland ids a Rainstar is physically present on this tick, parked or
+--- running. The Esc PIVOT card uses this so the Rainstar seat stays visible
+--- after the rig is stopped, instead of swapping back to an empty pivot seat.
+---@return table farmlandId -> true
+function IrrigatorSectorIntegration:getPresentFields()
+    return self._presentFields
+end
+
+--- Mark the farmland the vehicle's root node sits on. Runs for every matched
+--- Rainstar every tick, on or off, so presence does not depend on the sprayer.
+function IrrigatorSectorIntegration:_recordPresence(vehicle)
+    local node = vehicle.rootNode
+    if type(vehicle.getRootNode) == "function" then node = vehicle:getRootNode() or node end
+    if node == nil or node == 0 then return end
+    local ok, ox, _, oz = pcall(getWorldTranslation, node)
+    if not ok or ox == nil then return end
+    local farmland = g_farmlandManager ~= nil
+        and g_farmlandManager:getFarmlandAtWorldPosition(ox, oz) or nil
+    if farmland ~= nil and farmland.id ~= nil then
+        self._presentFields[farmland.id] = true
+    end
+end
+
 --- Turn off every Rainstar that watered the given field on the last tick. The
 --- Esc PIVOT card's Stop remote calls this for a vehicle-irrigated field that
 --- has no placed pivot to drive. Safe to call when nothing is active.
@@ -270,4 +301,5 @@ function IrrigatorSectorIntegration:delete()
     self.isInitialized = false
     self._activeWateredFields = {}
     self._activeVehiclesByField = {}
+    self._presentFields = {}
 end

--- a/src/ui/CsPDAScreen.lua
+++ b/src/ui/CsPDAScreen.lua
@@ -406,14 +406,14 @@ function CsPDAScreen:_rebuildData()
         end
     end
 
-    -- Vehicle irrigators (Rainstar play kit): a field being actively watered by
-    -- a parked Rainstar is irrigated even when no placeable system covers it.
+    -- Vehicle irrigators (Rainstar play kit): a field a Rainstar is parked on
+    -- is irrigated even when no placeable system covers it, running or not.
     -- Kept separate from coveredFields so a vehicle-watered field keeps a nil
     -- systemId and the row click still says "no irrigation system connected".
     local vehicleFields = {}
     local vehIrr = mgr.irrigatorSectorIntegration
-    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
-        for fid in pairs(vehIrr:getActiveWateredFields()) do
+    if vehIrr and type(vehIrr.getPresentFields) == "function" then
+        for fid in pairs(vehIrr:getPresentFields()) do
             vehicleFields[fid] = true
         end
     end
@@ -501,10 +501,10 @@ function CsPDAScreen:_rebuildStats()
         end
     end
 
-    -- Vehicle irrigators count toward the irrigated total too.
+    -- Vehicle irrigators count toward the irrigated total too, parked or running.
     local vehIrr = mgr.irrigatorSectorIntegration
-    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
-        for fid in pairs(vehIrr:getActiveWateredFields()) do
+    if vehIrr and type(vehIrr.getPresentFields) == "function" then
+        for fid in pairs(vehIrr:getPresentFields()) do
             coveredFields[fid] = true
         end
     end

--- a/src/ui/CsPDAScreen.lua
+++ b/src/ui/CsPDAScreen.lua
@@ -406,6 +406,18 @@ function CsPDAScreen:_rebuildData()
         end
     end
 
+    -- Vehicle irrigators (Rainstar play kit): a field being actively watered by
+    -- a parked Rainstar is irrigated even when no placeable system covers it.
+    -- Kept separate from coveredFields so a vehicle-watered field keeps a nil
+    -- systemId and the row click still says "no irrigation system connected".
+    local vehicleFields = {}
+    local vehIrr = mgr.irrigatorSectorIntegration
+    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
+        for fid in pairs(vehIrr:getActiveWateredFields()) do
+            vehicleFields[fid] = true
+        end
+    end
+
     local localFarmId = self.showOwnedOnly and mgr.getLocalFarmId() or nil
 
     local rows = {}
@@ -424,7 +436,7 @@ function CsPDAScreen:_rebuildData()
             local moisture   = entry.moisture or 0
             local stress     = (stressMod and stressMod.fieldStress and stressMod.fieldStress[fid]) or 0
             local systemId   = coveredFields[fid]  -- nil if not irrigated
-            local irrigated  = systemId ~= nil
+            local irrigated  = systemId ~= nil or vehicleFields[fid] == true
 
             table.insert(rows, {
                 fieldId   = fid,
@@ -486,6 +498,14 @@ function CsPDAScreen:_rebuildStats()
                     coveredFields[fid] = true
                 end
             end
+        end
+    end
+
+    -- Vehicle irrigators count toward the irrigated total too.
+    local vehIrr = mgr.irrigatorSectorIntegration
+    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
+        for fid in pairs(vehIrr:getActiveWateredFields()) do
+            coveredFields[fid] = true
         end
     end
 

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -429,6 +429,15 @@ function CsRfPdaGuest.buildFieldRows()
         end
     end
 
+    -- Vehicle irrigators (Rainstar play kit): a field being actively watered by
+    -- a parked Rainstar reads as irrigated the same way a placed system does.
+    local vehIrr = mgr.irrigatorSectorIntegration
+    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
+        for fid in pairs(vehIrr:getActiveWateredFields()) do
+            coveredFields[fid] = true
+        end
+    end
+
     local yesText = tr("cs_pda_irrigated_yes", "Yes")
     local noText = tr("cs_pda_irrigated_no", "No")
 

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -429,11 +429,11 @@ function CsRfPdaGuest.buildFieldRows()
         end
     end
 
-    -- Vehicle irrigators (Rainstar play kit): a field being actively watered by
-    -- a parked Rainstar reads as irrigated the same way a placed system does.
+    -- Vehicle irrigators (Rainstar play kit): a field a Rainstar is parked on
+    -- reads as irrigated the same way a placed system does, running or not.
     local vehIrr = mgr.irrigatorSectorIntegration
-    if vehIrr and type(vehIrr.getActiveWateredFields) == "function" then
-        for fid in pairs(vehIrr:getActiveWateredFields()) do
+    if vehIrr and type(vehIrr.getPresentFields) == "function" then
+        for fid in pairs(vehIrr:getPresentFields()) do
             coveredFields[fid] = true
         end
     end
@@ -1731,20 +1731,38 @@ updatePivotCard = function(container, fieldId)
         }
 
         -- RAINSTAR SEAT: a vehicle irrigator is not a placeable system, so no
-        -- Reinke pivot resolves here. When one is actively watering the selected
-        -- field the seat is not empty: report it and offer a Stop.
+        -- Reinke pivot resolves here. When one is present on the selected field
+        -- (parked or running) the seat is not empty: report it, show whether it
+        -- is actually watering, and offer a Stop while it is active.
         local vehIrr = mgr ~= nil and mgr.irrigatorSectorIntegration or nil
+        local presentFields = vehIrr and type(vehIrr.getPresentFields) == "function"
+            and vehIrr:getPresentFields() or nil
         local activeFields = vehIrr and type(vehIrr.getActiveWateredFields) == "function"
             and vehIrr:getActiveWateredFields() or nil
         local rainstarHere = false
-        if activeFields then
-            if fieldId ~= nil and activeFields[fieldId] then
+        local rainstarActive = false
+        if presentFields then
+            if fieldId ~= nil and presentFields[fieldId] then
                 rainstarHere = true
             else
                 for _, mid in ipairs(members or {}) do
-                    if activeFields[mid] then rainstarHere = true break end
+                    if presentFields[mid] then rainstarHere = true break end
                 end
             end
+        end
+        if activeFields then
+            local anyActive = false
+            if fieldId ~= nil and activeFields[fieldId] then
+                anyActive = true
+            else
+                for _, mid in ipairs(members or {}) do
+                    if activeFields[mid] then anyActive = true break end
+                end
+            end
+            rainstarActive = anyActive
+            -- A Rainstar whose root sits beside the field but whose sector lands
+            -- on it is still the irrigator here; presence or active both count.
+            if anyActive then rainstarHere = true end
         end
         if rainstarHere then
             setPivotText(container, "csPivotTitle",
@@ -1755,8 +1773,9 @@ updatePivotCard = function(container, fieldId)
             setPivotText(container, "csPivotDialMax", "")
             setPivotText(container, "csPivotCoverage",
                 tr("cs_rf_pda_pivot_coverage_rainstar", "Coverage: Rainstar spraying this field"))
-            setPivotText(container, "csPivotWatering",
-                tr("cs_rf_pda_pivot_watering_on", "Watering now: On"))
+            setPivotText(container, "csPivotWatering", rainstarActive
+                and tr("cs_rf_pda_pivot_watering_on", "Watering now: On")
+                or tr("cs_rf_pda_pivot_watering_off", "Watering now: Off"))
             setPivotText(container, "csPivotPressure",
                 tr("cs_rf_pda_pivot_pressure_na", "Pressure: —"))
             setPivotText(container, "csPivotRate",
@@ -1767,7 +1786,7 @@ updatePivotCard = function(container, fieldId)
                 tr("cs_rf_pda_pivot_warn_rainstar", "Vehicle irrigator"))
             for _, id in ipairs(dead) do
                 if id == "csPivotBtnStop" then
-                    setPivotBtn(container, id, labels[id], true, false)
+                    setPivotBtn(container, id, labels[id], rainstarActive, false)
                 else
                     setPivotBtn(container, id, labels[id], false, true)
                 end

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -1729,6 +1729,52 @@ updatePivotCard = function(container, fieldId)
             csPivotBtnArmMinus = tr("cs_rf_pda_pivot_btn_arm_minus", "Arm−"),
             csBtnSchedule = tr("cs_rf_pda_pivot_btn_schedule", "Schedule"),
         }
+
+        -- RAINSTAR SEAT: a vehicle irrigator is not a placeable system, so no
+        -- Reinke pivot resolves here. When one is actively watering the selected
+        -- field the seat is not empty: report it and offer a Stop.
+        local vehIrr = mgr ~= nil and mgr.irrigatorSectorIntegration or nil
+        local activeFields = vehIrr and type(vehIrr.getActiveWateredFields) == "function"
+            and vehIrr:getActiveWateredFields() or nil
+        local rainstarHere = false
+        if activeFields then
+            if fieldId ~= nil and activeFields[fieldId] then
+                rainstarHere = true
+            else
+                for _, mid in ipairs(members or {}) do
+                    if activeFields[mid] then rainstarHere = true break end
+                end
+            end
+        end
+        if rainstarHere then
+            setPivotText(container, "csPivotTitle",
+                tr("cs_rf_pda_pivot_title_rainstar", "RAINSTAR"))
+            setPivotText(container, "csPivotDialCur",
+                tr("cs_rf_pda_pivot_rainstar_label", "Vehicle irrigator"))
+            setPivotText(container, "csPivotDialMin", "")
+            setPivotText(container, "csPivotDialMax", "")
+            setPivotText(container, "csPivotCoverage",
+                tr("cs_rf_pda_pivot_coverage_rainstar", "Coverage: Rainstar spraying this field"))
+            setPivotText(container, "csPivotWatering",
+                tr("cs_rf_pda_pivot_watering_on", "Watering now: On"))
+            setPivotText(container, "csPivotPressure",
+                tr("cs_rf_pda_pivot_pressure_na", "Pressure: —"))
+            setPivotText(container, "csPivotRate",
+                tr("cs_rf_pda_pivot_rate_na", "Rate: —"))
+            setPivotText(container, "csPivotSchedule",
+                tr("cs_rf_pda_pivot_sched_none", "Schedule: No schedule"))
+            setPivotText(container, "csPivotWarn",
+                tr("cs_rf_pda_pivot_warn_rainstar", "Vehicle irrigator"))
+            for _, id in ipairs(dead) do
+                if id == "csPivotBtnStop" then
+                    setPivotBtn(container, id, labels[id], true, false)
+                else
+                    setPivotBtn(container, id, labels[id], false, true)
+                end
+            end
+            return
+        end
+
         for _, id in ipairs(dead) do
             setPivotBtn(container, id, labels[id], false, true)
         end
@@ -1938,6 +1984,21 @@ function CsRfPdaGuest.onPivotRemote(container, actionToken)
     end
     local sysId = select(1, selectedSystemId(container, mgr, members))
     if sysId == nil then
+        -- RAINSTAR STOP: no placed pivot covers this field, but a Rainstar may
+        -- be actively watering it. Route the Stop remote to the vehicle rig.
+        if action == A.AUTO_STOP and fieldId ~= nil then
+            local vehIrr = mgr ~= nil and mgr.irrigatorSectorIntegration or nil
+            if vehIrr and type(vehIrr.stopForField) == "function" then
+                vehIrr:stopForField(fieldId)
+                print(string.format(
+                    "[CropStress] Esc pivot STOP -> Rainstar stop fieldId=%s",
+                    tostring(fieldId)))
+                if type(CsRfPdaGuest.onShow) == "function" then
+                    CsRfPdaGuest.onShow(container, true)
+                end
+                return
+            end
+        end
         print(string.format(
             "[CropStress] Esc pivot %s IGNORED: no system resolved for fieldId=%s",
             tostring(actionToken), tostring(fieldId)))

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -404,6 +404,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -388,6 +388,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -403,6 +403,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -406,6 +406,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="Cur %.0f°"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -401,6 +401,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -401,6 +401,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -401,6 +401,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -401,6 +401,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -388,6 +388,10 @@
     <!-- Esc CS PIVOT card (2026-08-09) -->
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>
     <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0f°"/>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -396,6 +396,10 @@
     <text name="cs_rf_pda_status_join" text="[EN] %s  ·  Status: %s"/>
     <text name="cs_rf_pda_pivot_title" text="[EN] PIVOT"/>
     <text name="cs_rf_pda_pivot_title_irrig" text="[EN] IRRIGATION"/>
+<text name="cs_rf_pda_pivot_title_rainstar" text="RAINSTAR"/>
+<text name="cs_rf_pda_pivot_rainstar_label" text="[EN] Vehicle irrigator"/>
+<text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
+<text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s · covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
     <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0f°"/>


### PR DESCRIPTION
## What

The SCS irrigation surfaces did not report a field as irrigated when it was being watered by a parked Rainstar with the Aggregat pump, and the RF Esc PIVOT card rendered an empty seat for such a field. Both the dedicated SCS PDA and the RF Esc Crop Stress desk only knew about placed pivots and drip lines.

## Commits

- fix: PDA reports fields actively watered by a Rainstar as irrigated
- fix: RF Esc Crop Stress desk also reports Rainstar-watered fields
- feat: RF Esc PIVOT card shows the Rainstar and can stop it

## Why

The covered-fields set came only from `IrrigationManager.systems`, which registers placed pivots and drip lines. A Rainstar is a vehicle irrigator driven by `IrrigatorSectorIntegration`; it watered the field but never reported it, so the irrigation tab showed "--", the row said no irrigation system was connected, and the PIVOT card (a Reinke placeable controller) had no seat to show.

## How

`IrrigatorSectorIntegration` records every farmland it waters each tick and which vehicles watered it, exposed through `getActiveWateredFields` and `stopForField`. Both `CsPDAScreen` and the RF Esc guest merge that set into their irrigated flag and counts. When no placed pivot covers the selected field but a Rainstar is actively watering it, the PIVOT card shows a Rainstar seat (title, watering status, coverage) and enables the Stop remote, which turns the active Rainstar off. New l10n keys ship in all 26 languages.

## Verified

Built, deployed, Lua 5.1 syntax clean (pre-commit). In-game: a field under an active Rainstar reads as irrigated in both surfaces, and the PIVOT card shows the Rainstar seat with a working Stop.
