### PR TITLE
docs: roadmap for moisture map + Rainstar PDA/PIVOT (2026-08-25)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,3 +98,12 @@
 
 ## 2026-08-16 (Tyson): MP join d.cells nil crash fix
 - [x] SoilMoistureSystem.lua: nil-init guards for d.cells, d.cellCount, d.cellSum in both materialiseRelief and _writeCell. Field data entries created via MP moisture sync events before the full structure was built caused cascading packetReceived errors (540+ in 8 seconds). Merged #140; 1.2.5.95.
+
+## 2026-08-25 (Fred): Moisture map renders per-pixel; Rainstar detected and stoppable in the PDA (PRs #157, #158)
+- [x] PR #157 fix/scs-moisture-map-quantisation: applyWaterAtCell accumulates the quantisation remainder per pixel (quantiseDelta, the hourly-path shape) so irrigator water past one raw step lands on the 2m map; seedMapFromStore paints all fields at load (no blank map, no whole-field base-coat on first write); _seedMapRelief paints per-pixel relief variation so fields are not flat averages. 4 commits.
+- [x] PR #158 fix/scs-pda-rainstar-coverage: IrrigatorSectorIntegration tracks presence (getPresentFields) and active watering plus stopForField; CsPDAScreen and the RF Esc Crop Stress desk mark Rainstar-covered fields as irrigated, presence-based like placed pivots; the RF Esc PIVOT card shows a Rainstar seat with watering on/off and a working Stop. 5 commits, new l10n keys in all 26 languages.
+- [x] Built and deployed; Lua syntax clean. In-game verified 2026-08-25: the map shows variation and the wet patch; the PIVOT seat shows and stops the Rainstar and stays after Stop.
+- [~] The relief variation is coarse (8m blocks) to bound load cost; smooth it if the look is too blocky.
+- [~] Wet patch colour bands move slowly at low time scale (a band is about 6% moisture); that is the honest moisture rate, not a regression.
+- [~] cs_grid_concordance is still release-gated; decision pending on making the per-pixel map the default (the in-game layer look ran this session).
+- [~] DMV availability still gated on the CS_PDA_MoistureDisplay bitvector in _pdaCreateOverlays; robustness fix noted, not built.

--- a/TODO.md
+++ b/TODO.md
@@ -104,3 +104,10 @@
 ## Crop Moisture heat sheet + hose log-flood fix (2026-08-15, Wizard)
 - [x] Moisture heat-sheet overlay (#138) and the hose-peer liveness/log-flood fix (#137), both merged; 1.2.5.77.
 - [~] In-game: the heat sheet paints the wet patch where an irrigator just ran; a sold hose partner clears the prompt and the log goes quiet.
+
+## Moisture map + Rainstar UI (2026-08-25, PRs #157 #158)
+- [x] Per-pixel irrigator accumulation, load seeding, relief variation, Rainstar presence detection and the PIVOT Stop all built and deployed.
+- [~] Release cs_grid_concordance (the 2m value map) so the per-pixel map is the default; decision owed by Tyson after the in-game layer look.
+- [~] Smooth the relief variation (currently 8m blocks) if the map reads too blocky.
+- [~] Watch for Arissani's SCS-24 brief and check overlap with the moisture map and Rainstar surfaces.
+- [~] DMV availability robustness: gate _pdaDMVAvailable only on the two DMV overlays, not the display bitvector.


### PR DESCRIPTION
## What

Records the moisture map and Rainstar PDA/PIVOT work (PRs #157 and #158) in the mod's `ROADMAP.md` and `TODO.md`.

## Why

The roadmap and todo were owed for the two fixes that just merged to development: the moisture map now renders per-pixel (irrigator accumulation, load seeding, relief variation) and the Rainstar is detected and stoppable across the SCS PDA and the RF Esc desk.

## Changes

- `ROADMAP.md`: dated Fred section for 2026-08-25 covering both PRs, with the shipped items ticked and the open items flagged.
- `TODO.md`: dated section with the open items, including the `cs_grid_concordance` release decision, relief smoothing, the SCS-24 overlap watch, and the DMV availability robustness fix.

## Verified

Docs only; no code touched. Syntax and build unaffected.
