### PR TITLE
fix(scs): probe every surface for the RealisticWeather handle

### DIFF
--- a/src/WeatherIntegration.lua
+++ b/src/WeatherIntegration.lua
@@ -121,19 +121,49 @@ end
 -- OPTIONAL MOD DETECTION
 -- ============================================================
 function WeatherIntegration:detectOptionalMods()
-    -- FS25_RealisticWeather detection
-    -- This mod exposes g_realisticWeather global with enhanced weather data
-    if getfenv(0)["g_realisticWeather"] ~= nil then
+    -- FS25_RealisticWeather detection. The mod publishes the bare global
+    -- g_realisticWeather (RealisticWeather.lua:109); whether that bare global is
+    -- visible here depends on the engine's mod-environment scoping, so probe every
+    -- surface the handle could live on (_rwHandle) and log which one matched, so a
+    -- csDebug session can confirm the real cross-mod path.
+    if self:_rwHandle() ~= nil then
         self.realisticWeatherActive = true
-        csLog("FS25_RealisticWeather detected — using enhanced weather data")
-    elseif getfenv(0)["g_weatherSystem"] ~= nil then
-        -- NOTE: g_weatherSystem might be a vanilla FS25 global on some builds.
-        -- If the RealisticWeather API methods don't exist on it, getTemperatureFromWeather()
-        -- and getHumidity() will return nil from the RW path and fall through to vanilla
-        -- automatically — so this detection fails safe even if it's a false positive.
-        self.realisticWeatherActive = true
-        csLog("Weather mod detected (g_weatherSystem) — using enhanced weather data")
+        csLog(string.format("FS25_RealisticWeather detected (%s) - using enhanced weather data", self._rwSurface))
     end
+end
+
+-- FS25_RealisticWeather handle resolution. Probes every surface the handle could
+-- live on in order: the bare global, the g_currentMission bridge (the ecosystem's
+-- delegate-when-present shape), then getfenv(0). Falls back to the g_weatherSystem
+-- family the same way. g_weatherSystem may be a vanilla global on some builds, but
+-- the RW-path reads fail safe to vanilla when its API is absent, so a false
+-- positive here is harmless. Records which surface matched on self._rwSurface.
+function WeatherIntegration:_rwHandle()
+    local surface, h
+    h = g_realisticWeather
+    if h ~= nil then surface = "g_realisticWeather" end
+    if h == nil and g_currentMission ~= nil and g_currentMission.realisticWeather ~= nil then
+        h = g_currentMission.realisticWeather
+        surface = "g_currentMission.realisticWeather"
+    end
+    if h == nil and getfenv ~= nil and getfenv(0) ~= nil and getfenv(0).g_realisticWeather ~= nil then
+        h = getfenv(0).g_realisticWeather
+        surface = "getfenv(0).g_realisticWeather"
+    end
+    if h == nil then
+        h = g_weatherSystem
+        if h ~= nil then surface = "g_weatherSystem" end
+    end
+    if h == nil and g_currentMission ~= nil and g_currentMission.weatherSystem ~= nil then
+        h = g_currentMission.weatherSystem
+        surface = "g_currentMission.weatherSystem"
+    end
+    if h == nil and getfenv ~= nil and getfenv(0) ~= nil and getfenv(0).g_weatherSystem ~= nil then
+        h = getfenv(0).g_weatherSystem
+        surface = "getfenv(0).g_weatherSystem"
+    end
+    self._rwSurface = surface or "none"
+    return h
 end
 
 -- Called every in-game hour by CropStressManager:onHourlyTick()
@@ -198,7 +228,7 @@ function WeatherIntegration:getTemperatureFromWeather()
 
     -- Try RealisticWeather first if active.
     if self.realisticWeatherActive then
-        local rw = g_realisticWeather or g_weatherSystem
+        local rw = self:_rwHandle()
         if rw ~= nil then
             local val = nil
             if type(rw.getTemperature) == "function" then
@@ -266,7 +296,7 @@ function WeatherIntegration:getHumidity()
 
     -- Try RealisticWeather first if active.
     if self.realisticWeatherActive then
-        local rw = g_realisticWeather or g_weatherSystem
+        local rw = self:_rwHandle()
         if rw ~= nil then
             local val = nil
             if type(rw.getHumidity) == "function" then
@@ -309,7 +339,7 @@ function WeatherIntegration:getRainFromWeather()
 
     -- Try RealisticWeather first if active
     if self.realisticWeatherActive then
-        local rw = g_realisticWeather or g_weatherSystem
+        local rw = self:_rwHandle()
         if rw ~= nil then
             -- RealisticWeather rain methods - check multiple possible APIs
             if type(rw.getRainIntensity) == "function" then

--- a/tools/test/lua/weather_rw_detection_spec_test.lua
+++ b/tools/test/lua/weather_rw_detection_spec_test.lua
@@ -1,0 +1,76 @@
+-- weather_rw_detection_spec_test.lua
+-- SCS / RealisticWeather interop (Discord testing wave 2026-08-23): SCS moisture
+-- did not follow RealisticWeather. The RW detection probed only
+-- getfenv(0)["g_realisticWeather"], the per-mod-scoped read that SCS's own
+-- CLAUDE.md documents as unreliable cross-mod. _rwHandle now probes every surface
+-- (bare global, g_currentMission bridge, getfenv(0)) and records which matched;
+-- detection and the weather reads use the same resolver so they cannot disagree.
+--!load: src/WeatherIntegration.lua
+
+local function newWI()
+  return setmetatable({}, WeatherIntegration)
+end
+
+local function clearRWGlobals()
+  g_realisticWeather = nil
+  g_weatherSystem = nil
+  g_currentMission = g_currentMission or {}
+  g_currentMission.realisticWeather = nil
+  g_currentMission.weatherSystem = nil
+  g_currentMission.weatherGuard = nil
+end
+
+-- 1. NO RW: nil handle, surface "none", detection leaves the flag off.
+do
+  clearRWGlobals()
+  local wi = newWI()
+  T.ok('none.nilHandle', wi:_rwHandle() == nil)
+  T.eq('none.surface', wi._rwSurface, "none")
+  wi:detectOptionalMods()
+  T.ok('none.notActive', wi.realisticWeatherActive ~= true)
+end
+
+-- 2. BARE GLOBAL: g_realisticWeather resolves (the shared-env bench).
+do
+  clearRWGlobals()
+  g_realisticWeather = { getTemperature = function() return 20.0 end }
+  local wi = newWI()
+  T.ok('bare.resolves', wi:_rwHandle() ~= nil)
+  T.eq('bare.surface', wi._rwSurface, "g_realisticWeather")
+  wi:detectOptionalMods()
+  T.eq('bare.active', wi.realisticWeatherActive, true)
+end
+
+-- 3. MISSION BRIDGE: g_currentMission.realisticWeather resolves when the bare
+--    global is invisible (the per-mod-scoped real-world case the probe exists for).
+do
+  clearRWGlobals()
+  g_currentMission.realisticWeather = { getTemperature = function() return 18.0 end }
+  local wi = newWI()
+  T.ok('bridge.resolves', wi:_rwHandle() ~= nil)
+  T.eq('bridge.surface', wi._rwSurface, "g_currentMission.realisticWeather")
+end
+
+-- 4. WEATHERSYSTEM FALLBACK: g_weatherSystem resolves and arms the flag.
+do
+  clearRWGlobals()
+  g_weatherSystem = { getTemperature = function() return 16.0 end }
+  local wi = newWI()
+  T.ok('ws.resolves', wi:_rwHandle() ~= nil)
+  T.eq('ws.surface', wi._rwSurface, "g_weatherSystem")
+  wi:detectOptionalMods()
+  T.eq('ws.active', wi.realisticWeatherActive, true)
+end
+
+-- 5. READS AGREE WITH DETECTION: with the flag on and the handle set, the
+--    temperature read uses the RW path, not the vanilla fallback.
+do
+  clearRWGlobals()
+  g_realisticWeather = { getTemperature = function() return 22.0 end }
+  g_currentMission.environment = { weather = { getCurrentTemperature = function() return 9.0 end } }
+  local wi = newWI()
+  wi:detectOptionalMods()
+  T.eq('read.usesRW', wi:getTemperatureFromWeather(), 22.0)
+end
+
+T.summary()


### PR DESCRIPTION
Follow-up to the Discord testing wave report (nitro + J. Duke FF1-8505): SCS moisture does not follow RealisticWeather.

The RW detection in `WeatherIntegration:detectOptionalMods` probed only `getfenv(0)["g_realisticWeather"]` - the per-mod-scoped global read this repo's own CLAUDE.md documents as unreliable cross-mod (proven with the NPCFavor integration). If that read is invisible, SCS never arms `realisticWeatherActive`, falls back to the vanilla environment, and moisture never follows RW - exactly the report.

**Fix:** a single `_rwHandle()` resolver probes every surface the handle could live on (the bare global, the `g_currentMission` bridge, `getfenv(0)`, and the `g_weatherSystem` family the same way), records which matched on `_rwSurface`, and the detection plus all three weather reads (temperature, humidity, rain) use the same resolver so they cannot disagree. A csDebug session will now log which surface actually resolved, confirming or refuting the cross-mod path.

New `weather_rw_detection_spec_test.lua` at 12 assertions (nil case, bare global, mission bridge, g_weatherSystem fallback, and read-path agreement). Suite: 465 passed, 0 failed, plus one pre-existing load error in `scs039_delegation_test.lua` (its own `worldToPixel` stub gap, unrelated to this change and present on development). Deployed.

The decisive confirmation is still the in-game check: load with RealisticWeather, run `csDebug`, and read the weather line - it should now show "RealisticWeather detected (g_realisticWeather)" and moisture should track RW's rain. Not yet verified in a game session.
