### PR TITLE
fix: Esc pivot Fit, Door, invert chips, and captions

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.97</version>
+    <version>1.2.5.104</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.96</version>
+    <version>1.2.5.97</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/placeables/reinkeA22/scripts/centerPivot.lua
+++ b/placeables/reinkeA22/scripts/centerPivot.lua
@@ -278,6 +278,9 @@ function ReinkeIrrigationPivot.registerFunctions(placeableType)
     SpecializationUtil.registerFunction(placeableType, "onAngleMinusPressed",       ReinkeIrrigationPivot.onAngleMinusPressed)
     SpecializationUtil.registerFunction(placeableType, "onAutoMaxUpPressed",        ReinkeIrrigationPivot.onAutoMaxUpPressed)
     SpecializationUtil.registerFunction(placeableType, "onAutoMinUpPressed",        ReinkeIrrigationPivot.onAutoMinUpPressed)
+    SpecializationUtil.registerFunction(placeableType, "toggleDoor",               ReinkeIrrigationPivot.toggleDoor)
+    SpecializationUtil.registerFunction(placeableType, "adjustSweepMin",            ReinkeIrrigationPivot.adjustSweepMin)
+    SpecializationUtil.registerFunction(placeableType, "adjustSweepMax",            ReinkeIrrigationPivot.adjustSweepMax)
     SpecializationUtil.registerFunction(placeableType, "stepTargetAngle",           ReinkeIrrigationPivot.stepTargetAngle)
 
     SpecializationUtil.registerFunction(placeableType, "updateDriveShaftAnimation", ReinkeIrrigationPivot.updateDriveShaftAnimation)
@@ -1944,26 +1947,43 @@ end
 -- The door rotates around ControlBoxDoorROT's local Y axis.
 -- Open = -120Â° (Y), Closed = 0Â°.
 -- ============================================================
-function ReinkeIrrigationPivot.onDoorPressed(self)
+--- Flip the control box door. No proximity check: this is the shared flip, used
+--- by the keypad below AFTER its range test and by the Esc card directly.
+---
+--- [BUILD 14:05] CropStressPivotRemoteEvent has always called toggleDoor, and
+--- this spec never had one, so the Esc Door remote did nothing. That single
+--- absence disabled the WHOLE card, because power is gated on doorOpen and
+--- every other remote returns early on "not doorOpen or not powered". One
+--- missing function, every button dead.
+---
+--- Open = -120 deg on local Y (confirmed in GE: open state is (0,-120,0)).
+--- Closed = 0 deg. Animation uses absolute rotation so it is independent of the
+--- i3d baked pose: make sure the Shape is saved at (0,0,0) in GE.
+function ReinkeIrrigationPivot.toggleDoor(self)
     local spec = self[ReinkeIrrigationPivot.SPEC_TABLE_NAME]
-    rInfo(string.format("pivot %d: onDoorPressed FIRED playerInRange=%s doorOpen=%s",
-        self.id or -1, tostring(spec.playerInRange), tostring(spec.doorOpen)))
-    if not spec.playerInRange then return end
+    if spec == nil then return end
     spec.doorOpen = not spec.doorOpen
     if self.isClient then
         sndPlay1(spec.doorOpen and spec.samples.hydraulicOpen or spec.samples.hydraulicClose)
     end
     self:raiseDirtyFlags(spec.dirtyFlag)
-    -- Open = -120Â° on local Y (confirmed in GE: open state is (0,-120,0)).
-    -- Closed = 0Â°.  Animation uses absolute rotation so it is independent of
-    -- the i3d baked pose  -  make sure the Shape is saved at (0,0,0) in GE.
     spec.doorAngleTgt = spec.doorOpen and math.rad(-120) or 0
-    rInfo(string.format("pivot %d: door %s (tgt=%.1fÂ°)",
+    rInfo(string.format("pivot %d: door %s (tgt=%.1f deg)",
         self.id or -1, spec.doorOpen and "OPENING" or "CLOSING",
         math.deg(spec.doorAngleTgt)))
-    -- Immediately refresh F1 hint visibility: show/hide control keys based on door state.
-    -- Door key itself stays visible (player may want to close the box again).
+    -- Refresh F1 hint visibility: show or hide control keys based on door state.
+    -- The door key itself stays visible, the player may want to close the box.
     self:setInteractionHintsVisible(true)
+end
+
+function ReinkeIrrigationPivot.onDoorPressed(self)
+    local spec = self[ReinkeIrrigationPivot.SPEC_TABLE_NAME]
+    rInfo(string.format("pivot %d: onDoorPressed FIRED playerInRange=%s doorOpen=%s",
+        self.id or -1, tostring(spec.playerInRange), tostring(spec.doorOpen)))
+    -- The physical keypad keeps its proximity rule; only the flip is shared, so
+    -- the two routes cannot drift into different door behaviour.
+    if not spec.playerInRange then return end
+    self:toggleDoor()
 end
 
 -- ============================================================
@@ -2096,7 +2116,51 @@ local function clampSweepBounds(minDeg, maxDeg)
 end
 
 -- ============================================================
--- KP 6 — step arm +10° CW (manual mode only; no-op in AUTO)
+-- Esc PDA sweep adjust (BUILD 12:51)
+-- ============================================================
+-- CropStressPivotRemoteEvent has always called adjustSweepMin / adjustSweepMax,
+-- and this vendored spec never registered them, so the Min and Max remotes on
+-- the Esc card were a silent no-op: the event found no function, took its
+-- guarded branch and returned, and the dial marks could not move from the menu.
+--
+-- These are NOT the keypad handlers. The keypad ones bail on playerInRange,
+-- which is correct for a physical panel and wrong from a menu the farmer opens
+-- from anywhere. Door and power honesty is kept, because those model the
+-- machine's own state rather than where the player is standing, and the Esc
+-- chips are already gated on the same two.
+--
+-- The clamp is the SAME clampSweepBounds the keypad uses, so a bound set from
+-- the menu and one set from the panel cannot land on different rules.
+---@param deltaDeg number degrees to add, may be negative
+function ReinkeIrrigationPivot.adjustSweepMin(self, deltaDeg)
+    local spec = self[ReinkeIrrigationPivot.SPEC_TABLE_NAME]
+    if spec == nil then return end
+    if not spec.doorOpen then return end
+    if not spec.masterPower then return end
+    local newMin = (spec.autoMinAngleDeg or 0) + (tonumber(deltaDeg) or 0)
+    spec.autoMinAngleDeg, spec.autoMaxAngleDeg =
+        clampSweepBounds(newMin, spec.autoMaxAngleDeg or 360)
+    self:raiseDirtyFlags(spec.dirtyFlag)
+    rInfo(string.format("pivot %d: Esc MIN %+d -> sweep %.0f to %.0f",
+        self.id or -1, tonumber(deltaDeg) or 0, spec.autoMinAngleDeg, spec.autoMaxAngleDeg))
+end
+
+---@param deltaDeg number degrees to add, may be negative
+function ReinkeIrrigationPivot.adjustSweepMax(self, deltaDeg)
+    local spec = self[ReinkeIrrigationPivot.SPEC_TABLE_NAME]
+    if spec == nil then return end
+    if not spec.doorOpen then return end
+    if not spec.masterPower then return end
+    local newMax = (spec.autoMaxAngleDeg or 360) + (tonumber(deltaDeg) or 0)
+    spec.autoMinAngleDeg, spec.autoMaxAngleDeg =
+        clampSweepBounds(spec.autoMinAngleDeg or 0, newMax)
+    self:raiseDirtyFlags(spec.dirtyFlag)
+    rInfo(string.format("pivot %d: Esc MAX %+d -> sweep %.0f to %.0f",
+        self.id or -1, tonumber(deltaDeg) or 0, spec.autoMinAngleDeg, spec.autoMaxAngleDeg))
+end
+
+-- ============================================================
+-- KP 6 - step arm +10 deg CW (manual mode only; no-op in AUTO)
 -- ============================================================
 function ReinkeIrrigationPivot.onAnglePlusPressed(self)
     local spec = self[ReinkeIrrigationPivot.SPEC_TABLE_NAME]

--- a/src/events/CropStressRainKeyCommandEvent.lua
+++ b/src/events/CropStressRainKeyCommandEvent.lua
@@ -13,11 +13,11 @@ CropStressRainKeyCommandEvent_mt = Class(CropStressRainKeyCommandEvent, Event)
 InitEventClass(CropStressRainKeyCommandEvent, "CropStressRainKeyCommandEvent")
 
 function CropStressRainKeyCommandEvent.emptyNew()
-    return CropStressRainKeyCommandEvent:new()
+    return Event.new(CropStressRainKeyCommandEvent_mt)
 end
 
-function CropStressRainKeyCommandEvent:new(systemId, action, value)
-    local self = setmetatable({}, CropStressRainKeyCommandEvent_mt)
+function CropStressRainKeyCommandEvent.new(systemId, action, value)
+    local self = CropStressRainKeyCommandEvent.emptyNew()
     self.systemId = systemId or 0
     self.action   = action or ""
     self.value    = value

--- a/src/events/CropStressRainKeyResultEvent.lua
+++ b/src/events/CropStressRainKeyResultEvent.lua
@@ -11,11 +11,11 @@ CropStressRainKeyResultEvent_mt = Class(CropStressRainKeyResultEvent, Event)
 InitEventClass(CropStressRainKeyResultEvent, "CropStressRainKeyResultEvent")
 
 function CropStressRainKeyResultEvent.emptyNew()
-    return CropStressRainKeyResultEvent:new()
+    return Event.new(CropStressRainKeyResultEvent_mt)
 end
 
-function CropStressRainKeyResultEvent:new(systemId, accepted, resultCode)
-    local self = setmetatable({}, CropStressRainKeyResultEvent_mt)
+function CropStressRainKeyResultEvent.new(systemId, accepted, resultCode)
+    local self = CropStressRainKeyResultEvent.emptyNew()
     self.systemId   = systemId or 0
     self.accepted   = accepted == true
     self.resultCode = resultCode or "OK"

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -1430,13 +1430,15 @@ end
 --- label is stored on the element rather than written into its TextElement. Two
 --- things must never draw at once: the TextElement label and the chip. Leaving
 --- setText(label) on gave the DOOR-over-SPACE overlap Wizard was looking at.
-local function setPivotBtn(container, id, label, enabled, dead)
+---@param latched boolean|nil  true when this function is currently ON
+local function setPivotBtn(container, id, label, enabled, dead, latched)
     local el = findDescendant(container, id)
     if el == nil then return end
     if el.setVisible then el:setVisible(true) end
     if el.setText then el:setText("") end
     el.rfPivotChipLabel = label
     el.rfPivotChipEnabled = enabled and true or false
+    el.rfPivotChipLatched = latched and true or false
     -- BUILD 15:26: "dead" means there is no system behind this card at all, which
     -- is different from a gated remote on a real pivot. Gated still shows a grey
     -- chip so the farmer can see what is locked; dead paints nothing, because a
@@ -1485,7 +1487,14 @@ local function renderPivotChip(el, overlay)
 
     local enabled = el.rfPivotChipEnabled
     local t, b, ta, ba
-    if enabled then
+    if enabled and el.rfPivotChipLatched then
+        -- [BUILD 18:42] LATCHED: this function is currently ON. A true invert of
+        -- the live chip, text and background swapped, so open reads differently
+        -- from closed at a glance without inventing a third colour that would
+        -- then need its own meaning. Only the live tier inverts: a gated chip
+        -- stays grey, because "locked" must never look like "on".
+        t, b, ta, ba = PIVOT_CHIP_BG, PIVOT_CHIP_TEXT, 1.0, 1.0
+    elseif enabled then
         t, b, ta, ba = PIVOT_CHIP_TEXT, PIVOT_CHIP_BG, 1.0, 1.0
     else
         -- GATED: real pivot, this tier locked (door / power / ownership / autoRotate).
@@ -1800,6 +1809,9 @@ updatePivotCard = function(container, fieldId)
         setPivotText(container, "csPivotWarn",
             tr("cs_rf_pda_pivot_warn_none", "No pivot on this field"))
         setPivotText(container, "csPivotTripLabel", "")
+        setPivotText(container, "csPivotCapMin", "")
+        setPivotText(container, "csPivotCapMax", "")
+        setPivotText(container, "csPivotCapFit", "")
         local dead = {
             "csPivotBtnDoor", "csPivotBtnPower", "csPivotBtnSpray", "csPivotBtnEndGun",
             "csPivotBtnSpeed", "csPivotBtnStart", "csPivotBtnStop",
@@ -2040,13 +2052,25 @@ updatePivotCard = function(container, fieldId)
         end
     end
 
-    setPivotBtn(container, "csPivotBtnDoor", tr("cs_rf_pda_pivot_btn_door", "Door"), doorOk)
-    setPivotBtn(container, "csPivotBtnPower", tr("cs_rf_pda_pivot_btn_power", "Power"), powerOk)
-    setPivotBtn(container, "csPivotBtnSpray", tr("cs_rf_pda_pivot_btn_spray", "Spray"), opsOk)
-    setPivotBtn(container, "csPivotBtnEndGun", tr("cs_rf_pda_pivot_btn_endgun", "End gun"), opsOk)
+    -- [BUILD 18:42] Latch state per chip: what is ON right now. Speed, Min/Max,
+    -- Arm, Schedule, Fit and Trip are deliberately never latched: they are steps
+    -- and actions, not states, so an inverted chip would be claiming a mode that
+    -- does not exist.
+    local sprayOn  = spec ~= nil and spec.isSprayActive == true
+    local endGunOn = spec ~= nil and spec.endGunActive == true
+    local wateringOn = (spec ~= nil and spec.autoRotate == true)
+                       or (spec == nil and sys ~= nil and sys.isActive == true)
+    setPivotBtn(container, "csPivotBtnDoor", tr("cs_rf_pda_pivot_btn_door", "Door"), doorOk, false, doorOpen)
+    setPivotBtn(container, "csPivotBtnPower", tr("cs_rf_pda_pivot_btn_power", "Power"), powerOk, false, powered)
+    setPivotBtn(container, "csPivotBtnSpray", tr("cs_rf_pda_pivot_btn_spray", "Spray"), opsOk, false, sprayOn)
+    setPivotBtn(container, "csPivotBtnEndGun", tr("cs_rf_pda_pivot_btn_endgun", "End gun"), opsOk, false, endGunOn)
     setPivotBtn(container, "csPivotBtnSpeed", speedLabel, opsOk)
-    setPivotBtn(container, "csPivotBtnStart", tr("cs_rf_pda_pivot_btn_start", "Start"), owned and (reinke or sys ~= nil))
-    setPivotBtn(container, "csPivotBtnStop", tr("cs_rf_pda_pivot_btn_stop", "Stop"), owned and (reinke or sys ~= nil))
+    setPivotBtn(container, "csPivotBtnStart", tr("cs_rf_pda_pivot_btn_start", "Start"),
+        owned and (reinke or sys ~= nil), false, wateringOn)
+    -- Stop latches when the machine is stopped, so the pair always shows which
+    -- of the two modes you are actually in rather than leaving both dark.
+    setPivotBtn(container, "csPivotBtnStop", tr("cs_rf_pda_pivot_btn_stop", "Stop"),
+        owned and (reinke or sys ~= nil), false, owned and not wateringOn)
     setPivotBtn(container, "csPivotBtnMinUp", tr("cs_rf_pda_pivot_btn_min_up", "Min+"), opsOk)
     setPivotBtn(container, "csPivotBtnMinDn", tr("cs_rf_pda_pivot_btn_min_dn", "Min-"), opsOk)
     setPivotBtn(container, "csPivotBtnMaxUp", tr("cs_rf_pda_pivot_btn_max_up", "Max+"), opsOk)
@@ -2076,9 +2100,17 @@ updatePivotCard = function(container, fieldId)
         local tripMm = (sys ~= nil and tonumber(sys.rainKeyTripMm)) or 2.5
         setPivotText(container, "csPivotTripLabel",
             string.format(tr("cs_rf_pda_rk_trip_label", "%.1fmm"), tripMm))
+        setPivotText(container, "csPivotCapFit", tr("cs_rf_pda_cap_rain_key", "Rain key"))
     else
         setPivotText(container, "csPivotTripLabel", "")
+        setPivotText(container, "csPivotCapFit", "")
     end
+
+    -- [BUILD 18:42] Say what the two angle pairs are for. The dial already names
+    -- sweep start and sweep end; these put the same words over the buttons that
+    -- move them, so "Min 45" stops being a number without a subject.
+    setPivotText(container, "csPivotCapMin", tr("cs_rf_pda_cap_sweep_start", "Sweep start"))
+    setPivotText(container, "csPivotCapMax", tr("cs_rf_pda_cap_sweep_end", "Sweep end"))
 end
 
 

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -789,7 +789,7 @@ local function refreshPivotSwitcher(container, mgr, memberIds, cands)
             for _, id in ipairs(subset) do parts[#parts + 1] = tostring(id) end
             subsetText = table.concat(parts, ", ")
         end
-        local tpl = tr("cs_rf_pda_pivot_switch", "Pivot %s · covers %s of this block")
+        local tpl = tr("cs_rf_pda_pivot_switch", "Pivot %s - covers %s of this block")
         local ok, label = pcall(string.format, tpl, tostring(c.id), subsetText)
         texts[i] = ok and label or string.format("Pivot %s · covers %s of this block", tostring(c.id), subsetText)
         if selectedId ~= nil and fieldIdEquals(c.id, selectedId) then
@@ -1315,7 +1315,7 @@ local function buildScheduleRateClause(fieldId, covered)
 
     if schedule ~= nil then
         local hours = string.format(
-            tr("cs_rf_pda_sched_hours", "Sched %d–%d"),
+            tr("cs_rf_pda_sched_hours", "Sched %d-%d"),
             schedule.startHour or 0,
             schedule.endHour or 0
         )
@@ -1326,7 +1326,7 @@ local function buildScheduleRateClause(fieldId, covered)
     if rate > 0 then
         return "No schedule · " .. rateStr
     end
-    return tr("cs_rf_pda_covered_no_sched", "Covered · no schedule") .. " · " .. rateStr
+    return tr("cs_rf_pda_covered_no_sched", "Covered - no schedule") .. " · " .. rateStr
 end
 
 --- Pack Status line: optional Alert + schedule/rate + Status. Never duplicate Alert on Next.
@@ -1334,7 +1334,7 @@ end
 local function buildStatusLine(fieldId, covered, statusWord, alertHint, alertOnStatus)
     local schedRate = buildScheduleRateClause(fieldId, covered)
     local statusJoin = string.format(
-        tr("cs_rf_pda_status_join", "%s  ·  Status: %s"),
+        tr("cs_rf_pda_status_join", "%s  -  Status: %s"),
         schedRate,
         statusWord or "-"
     )
@@ -1368,7 +1368,7 @@ local function buildStatusLine(fieldId, covered, statusWord, alertHint, alertOnS
         shortLeft = rateStr
     end
     return alertPrefix .. " · " .. string.format(
-        tr("cs_rf_pda_status_join", "%s  ·  Status: %s"),
+        tr("cs_rf_pda_status_join", "%s  -  Status: %s"),
         shortLeft,
         statusWord or "-"
     )
@@ -1462,6 +1462,9 @@ local PIVOT_CHIP_IDS = {
     "csPivotBtnSpeed", "csPivotBtnStart", "csPivotBtnStop",
     "csPivotBtnMinUp", "csPivotBtnMinDn", "csPivotBtnMaxUp", "csPivotBtnMaxDn",
     "csPivotBtnArmPlus", "csPivotBtnArmMinus", "csBtnSchedule",
+    -- [SCS-046] Rain key. csPivotTripLabel is a Text, not a chip, so it is
+    -- deliberately absent from this list.
+    "csPivotBtnFit", "csPivotBtnTripMinus", "csPivotBtnTripPlus",
 }
 
 --- Paint one remote as a vanilla key chip, centred in its hit box.
@@ -1530,6 +1533,91 @@ local function wirePivotChipPaint(container)
     end
 end
 
+--- [BUILD 17:16] Deliver the Fit and Trip clicks ourselves.
+---
+--- Evidence first: with the 15:58 prints in place, a whole session of clicking
+--- Fit produced ZERO "[CropStress] Esc rain key" lines while Door and Power
+--- logged normally. So the click was never reaching onClickCsPivotFit at all;
+--- the event shape was worth fixing but was never the reason the chip looked
+--- dead.
+---
+--- Why the click goes missing, from the engine source: ButtonElement.mouseEvent
+--- hit-tests absPosition plus `size`, while the chip overlay is painted from
+--- absPosition plus `absSize`. When those disagree the chip is drawn where the
+--- mouse is not, so the press falls through to the sibling walk, and that walk
+--- runs last-to-first: Door sits earlier in the XML than Fit, which is exactly
+--- why Wizard's Fit presses show up in the log as Door and Power events.
+---
+--- So the card hit-tests the three rain-key chips itself, using the SAME
+--- absPosition and absSize the overlay draws with, and consumes the click by
+--- returning true. Fit therefore works whether or not Giants ever delivers its
+--- Button onClick, and because we consume it, it cannot double-fire.
+local RAIN_KEY_CHIPS = {
+    { id = "csPivotBtnFit",       token = "FIT_TOGGLE" },
+    { id = "csPivotBtnTripMinus", token = "TRIP_MINUS" },
+    { id = "csPivotBtnTripPlus",  token = "TRIP_PLUS"  },
+}
+
+local function wirePivotFitMouse(container)
+    local card = findDescendant(container, "csPivotCard")
+    -- A NEW flag on purpose: sharing _rfPivotChipWired would mean a card that
+    -- already had its draw wrapped (hot reload, or the light tick) would skip
+    -- the mouse wrap forever.
+    if card == nil or card._rfPivotFitMouseWired then return end
+    card._rfPivotFitMouseWired = true
+
+    local prevMouse = card.mouseEvent
+
+    function card:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+        -- Some call paths in this file arrive with a nil button (see the
+        -- mouseUp guard further up), so nil counts as left rather than
+        -- silently dropping the click.
+        if not eventUsed and (isDown or isUp)
+           and (button == nil or button == Input.MOUSE_BUTTON_LEFT)
+           and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function" then
+            for _, chip in ipairs(RAIN_KEY_CHIPS) do
+                local el = findDescendant(self, chip.id) or findDescendant(container, chip.id)
+                if el ~= nil and el.absPosition ~= nil and el.rfPivotChipDead ~= true then
+                    -- absSize is what the overlay paints with. If the layout has
+                    -- not resolved one yet, borrow Door's: every remote on this
+                    -- row is declared the same 80x32, so it is the right box
+                    -- rather than a guess.
+                    local w, h = nil, nil
+                    if el.absSize ~= nil then w, h = el.absSize[1], el.absSize[2] end
+                    if w == nil or h == nil or w <= 0 or h <= 0 then
+                        local door = findDescendant(self, "csPivotBtnDoor")
+                                  or findDescendant(container, "csPivotBtnDoor")
+                        if door ~= nil and door.absSize ~= nil then
+                            w, h = door.absSize[1], door.absSize[2]
+                        end
+                    end
+                    if w ~= nil and h ~= nil and w > 0 and h > 0
+                       and GuiUtils.checkOverlayOverlap(posX, posY,
+                            el.absPosition[1], el.absPosition[2], w, h, nil) then
+                        print(string.format(
+                            "[CropStress] Esc Fit chip mouse hit id=%s token=%s %s",
+                            chip.id, chip.token, isUp and "UP" or "DOWN"))
+                        -- Act on release only, the way a button behaves, but
+                        -- consume the press too so no sibling can claim it.
+                        if isUp and type(CsRfPdaGuest.onRainKeyCommand) == "function" then
+                            local ok, err = pcall(CsRfPdaGuest.onRainKeyCommand, container, chip.token)
+                            if not ok then
+                                print(string.format("[CropStress] Esc rain key %s FAILED: %s",
+                                    chip.token, tostring(err)))
+                            end
+                        end
+                        return true
+                    end
+                end
+            end
+        end
+        if prevMouse ~= nil then
+            return prevMouse(self, posX, posY, isDown, isUp, button, eventUsed)
+        end
+        return false
+    end
+end
+
 --- BUILD 15:30: put the rotation origin on the dial hub.
 ---
 --- GuiOverlay.renderOverlay defaults the pivot to the element centre:
@@ -1581,7 +1669,7 @@ local function formatScheduleGlance(sys)
     local endH = tonumber(s.endHour) or 0
     local tag = scheduleDaysTag(s.activeDays)
     return string.format(
-        tr("cs_rf_pda_pivot_sched", "Schedule: %02d:00–%02d:00%s"),
+        tr("cs_rf_pda_pivot_sched", "Schedule: %02d:00-%02d:00%s"),
         startH, endH, tag or ""
     )
 end
@@ -1681,6 +1769,7 @@ updatePivotCard = function(container, fieldId)
         return
     end
     wirePivotChipPaint(container)
+    wirePivotFitMouse(container)
     applyDialFace(container)
     if card.setVisible then card:setVisible(true) end
 
@@ -1700,21 +1789,23 @@ updatePivotCard = function(container, fieldId)
 
     if sysId == nil or sys == nil then
         setPivotText(container, "csPivotTitle", tr("cs_rf_pda_pivot_title", "PIVOT"))
-        setPivotText(container, "csPivotDialCur", tr("cs_rf_pda_pivot_dial_empty", "Cur —"))
-        setPivotText(container, "csPivotDialMin", tr("cs_rf_pda_pivot_dial_min_empty", "Min —"))
-        setPivotText(container, "csPivotDialMax", tr("cs_rf_pda_pivot_dial_max_empty", "Max —"))
+        setPivotText(container, "csPivotDialCur", tr("cs_rf_pda_pivot_dial_empty", "Arm -"))
+        setPivotText(container, "csPivotDialMin", tr("cs_rf_pda_pivot_dial_min_empty", "Sweep start -"))
+        setPivotText(container, "csPivotDialMax", tr("cs_rf_pda_pivot_dial_max_empty", "Sweep end -"))
         setPivotText(container, "csPivotCoverage", tr("cs_rf_pda_pivot_coverage_none", "Coverage: No fields covered"))
         setPivotText(container, "csPivotWatering", tr("cs_rf_pda_pivot_watering_off", "Watering now: Off"))
-        setPivotText(container, "csPivotPressure", tr("cs_rf_pda_pivot_pressure_na", "Pressure: —"))
-        setPivotText(container, "csPivotRate", tr("cs_rf_pda_pivot_rate_na", "Rate: —"))
+        setPivotText(container, "csPivotPressure", tr("cs_rf_pda_pivot_pressure_na", "Pressure: -"))
+        setPivotText(container, "csPivotRate", tr("cs_rf_pda_pivot_rate_na", "Rate: -"))
         setPivotText(container, "csPivotSchedule", tr("cs_rf_pda_pivot_sched_none", "Schedule: No schedule"))
         setPivotText(container, "csPivotWarn",
             tr("cs_rf_pda_pivot_warn_none", "No pivot on this field"))
+        setPivotText(container, "csPivotTripLabel", "")
         local dead = {
             "csPivotBtnDoor", "csPivotBtnPower", "csPivotBtnSpray", "csPivotBtnEndGun",
             "csPivotBtnSpeed", "csPivotBtnStart", "csPivotBtnStop",
             "csPivotBtnMinUp", "csPivotBtnMinDn", "csPivotBtnMaxUp", "csPivotBtnMaxDn",
             "csPivotBtnArmPlus", "csPivotBtnArmMinus", "csBtnSchedule",
+            "csPivotBtnFit", "csPivotBtnTripMinus", "csPivotBtnTripPlus",
         }
         local labels = {
             csPivotBtnDoor = tr("cs_rf_pda_pivot_btn_door", "Door"),
@@ -1725,12 +1816,15 @@ updatePivotCard = function(container, fieldId)
             csPivotBtnStart = tr("cs_rf_pda_pivot_btn_start", "Start"),
             csPivotBtnStop = tr("cs_rf_pda_pivot_btn_stop", "Stop"),
             csPivotBtnMinUp = tr("cs_rf_pda_pivot_btn_min_up", "Min+"),
-            csPivotBtnMinDn = tr("cs_rf_pda_pivot_btn_min_dn", "Min−"),
+            csPivotBtnMinDn = tr("cs_rf_pda_pivot_btn_min_dn", "Min-"),
             csPivotBtnMaxUp = tr("cs_rf_pda_pivot_btn_max_up", "Max+"),
-            csPivotBtnMaxDn = tr("cs_rf_pda_pivot_btn_max_dn", "Max−"),
+            csPivotBtnMaxDn = tr("cs_rf_pda_pivot_btn_max_dn", "Max-"),
             csPivotBtnArmPlus = tr("cs_rf_pda_pivot_btn_arm_plus", "Arm+"),
-            csPivotBtnArmMinus = tr("cs_rf_pda_pivot_btn_arm_minus", "Arm−"),
+            csPivotBtnArmMinus = tr("cs_rf_pda_pivot_btn_arm_minus", "Arm-"),
             csBtnSchedule = tr("cs_rf_pda_pivot_btn_schedule", "Schedule"),
+            csPivotBtnFit = tr("cs_rf_pda_rk_btn_fit", "Fit"),
+            csPivotBtnTripMinus = tr("cs_rf_pda_rk_btn_trip_minus", "Trip-"),
+            csPivotBtnTripPlus = tr("cs_rf_pda_rk_btn_trip_plus", "Trip+"),
         }
 
         -- RAINSTAR SEAT: a vehicle irrigator is not a placeable system, so no
@@ -1780,9 +1874,9 @@ updatePivotCard = function(container, fieldId)
                 and tr("cs_rf_pda_pivot_watering_on", "Watering now: On")
                 or tr("cs_rf_pda_pivot_watering_off", "Watering now: Off"))
             setPivotText(container, "csPivotPressure",
-                tr("cs_rf_pda_pivot_pressure_na", "Pressure: —"))
+                tr("cs_rf_pda_pivot_pressure_na", "Pressure: -"))
             setPivotText(container, "csPivotRate",
-                tr("cs_rf_pda_pivot_rate_na", "Rate: —"))
+                tr("cs_rf_pda_pivot_rate_na", "Rate: -"))
             setPivotText(container, "csPivotSchedule",
                 tr("cs_rf_pda_pivot_sched_none", "Schedule: No schedule"))
             setPivotText(container, "csPivotWarn",
@@ -1806,43 +1900,87 @@ updatePivotCard = function(container, fieldId)
     -- Title surfaces resolved covering systemId for the selected field (multi-cover honesty).
     local sysTag = tostring(sysId)
     if not reinke then
-        -- Drip / non-pivot: honest status, no fake needles.
-        setPivotText(container, "csPivotTitle",
-            string.format("%s #%s", tr("cs_rf_pda_pivot_title_irrig", "IRRIGATION"), sysTag))
-        setPivotText(container, "csPivotDialCur", tr("cs_rf_pda_pivot_drip_label", "Drip line"))
+        -- No Reinke controller: no needles and no angles, which is honest.
+        -- [SCS-046] But the TYPE is not the controller. A shop center pivot
+        -- without a Reinke spec is still a pivot, and calling it IRRIGATION and
+        -- labelling it "Drip line" is what made Wizard's #1139 read as a drip
+        -- line on the Esc card while the tablet correctly called it a pivot.
+        -- Title follows sys.type; the drip label appears only for a drip row.
+        local isPivotType = (sys ~= nil) and (sys.type == "pivot")
+        setPivotText(container, "csPivotTitle", string.format("%s #%s",
+            isPivotType and tr("cs_rf_pda_pivot_title", "PIVOT")
+                        or tr("cs_rf_pda_pivot_title_irrig", "IRRIGATION"), sysTag))
+        if sys ~= nil and sys.type == "drip" then
+            setPivotText(container, "csPivotDialCur", tr("cs_rf_pda_pivot_drip_label", "Drip line"))
+        else
+            setPivotText(container, "csPivotDialCur", "")
+        end
         setPivotText(container, "csPivotDialMin", "")
         setPivotText(container, "csPivotDialMax", "")
     else
         setPivotText(container, "csPivotTitle",
             string.format("%s #%s", tr("cs_rf_pda_pivot_title", "PIVOT"), sysTag))
-        local curDeg, minDeg, maxDeg = 0, 0, 0
+        -- [BUILD 12:51] The two sweep marks ALWAYS show the machine's real sweep
+        -- bounds. They used to collapse onto the arm target whenever autoRotate
+        -- was off, so a farmer setting his arc while watering was off watched
+        -- both marks sit on the arm and reasonably concluded the buttons did
+        -- nothing. The bounds exist and persist in either mode; only the arm is
+        -- mode-dependent.
+        local curDeg, minDeg, maxDeg = 0, 0, 360
         if spec ~= nil then
             curDeg = math.deg(spec.armAngle or 0) % 360
-            if spec.autoRotate then
-                minDeg = spec.autoMinAngleDeg or 0
-                maxDeg = spec.autoMaxAngleDeg or 360
-            else
-                local tgt = spec.targetAngle or spec.armAngle or 0
-                minDeg = math.deg(tgt) % 360
-                maxDeg = minDeg
-            end
+            minDeg = spec.autoMinAngleDeg or 0
+            maxDeg = spec.autoMaxAngleDeg or 360
         end
         setPivotText(container, "csPivotDialCur",
-            string.format(tr("cs_rf_pda_pivot_dial_cur", "Cur %.0f°"), curDeg))
+            string.format(tr("cs_rf_pda_pivot_dial_cur", "Arm %.0f deg"), curDeg))
         setPivotText(container, "csPivotDialMin",
-            string.format(tr("cs_rf_pda_pivot_dial_min", "Min %.0f°"), minDeg))
+            string.format(tr("cs_rf_pda_pivot_dial_min", "Sweep start %.0f deg"), minDeg))
         setPivotText(container, "csPivotDialMax",
-            string.format(tr("cs_rf_pda_pivot_dial_max", "Max %.0f°"), maxDeg))
+            string.format(tr("cs_rf_pda_pivot_dial_max", "Sweep end %.0f deg"), maxDeg))
         rotateNeedle(findDescendant(container, "csPivotNeedleCur"), curDeg)
         rotateNeedle(findDescendant(container, "csPivotNeedleMin"), minDeg)
         rotateNeedle(findDescendant(container, "csPivotNeedleMax"), maxDeg)
     end
 
     setPivotText(container, "csPivotCoverage", formatCoverageFields(sys))
-    local watering = sys.isActive == true
-    setPivotText(container, "csPivotWatering", watering
-        and tr("cs_rf_pda_pivot_watering_on", "Watering now: On")
-        or tr("cs_rf_pda_pivot_watering_off", "Watering now: Off"))
+
+    -- [SCS-046] Activity comes from the SAME resolver the snapshot publishes to
+    -- FarmTablet, so the card and the tablet cannot describe one pivot two ways
+    -- (acceptance point 4). A rain-paused machine says so rather than showing
+    -- the bare "Off" that used to make a tripped key look like an idle pivot.
+    local irrMgrRK = (getMgr() ~= nil) and getMgr().irrigationManager or nil
+    local rkActivity, rkReason = nil, nil
+    if irrMgrRK ~= nil and type(irrMgrRK.getActivityState) == "function" then
+        rkActivity, rkReason = irrMgrRK:getActivityState(sys)
+    end
+    local wateringText
+    if rkActivity == "RAIN_PAUSED" then
+        wateringText = tr("cs_rf_pda_pivot_watering_rain", "Watering now: Rain paused")
+    elseif rkActivity == "RUNNING" or (rkActivity == nil and sys.isActive == true) then
+        wateringText = tr("cs_rf_pda_pivot_watering_on", "Watering now: On")
+    else
+        wateringText = tr("cs_rf_pda_pivot_watering_off", "Watering now: Off")
+    end
+
+    -- [SCS-046] The rain-key reading rides the existing full-width status line
+    -- rather than a new row. The card's rows are laid out on fixed pixel
+    -- offsets with the warning line last, so adding one would mean moving
+    -- Wizard's layout, and pixels are explicitly his. Modelled mm is this
+    -- feature's own sensor unit and is labelled every time it is shown, so it
+    -- can never read as a soil-moisture percentage.
+    if sys.rainKeyFitted == true then
+        local collected
+        if sys.rainKeyInputState == "INPUT_UNAVAILABLE" then
+            collected = tr("cs_rf_pda_rk_unknown", "unknown")
+        else
+            collected = string.format("%.1f", sys.rainKeyAccumulatedMm or 0)
+        end
+        wateringText = wateringText .. string.format(
+            tr("cs_rf_pda_rk_suffix", "  -  rain key %s / %.1f mm modelled"),
+            collected, sys.rainKeyTripMm or 2.5)
+    end
+    setPivotText(container, "csPivotWatering", wateringText)
 
     local pressurePct = math.floor((sys.pressureMultiplier or 0) * 100 + 0.5)
     setPivotText(container, "csPivotPressure",
@@ -1854,13 +1992,29 @@ updatePivotCard = function(container, fieldId)
         setPivotText(container, "csPivotRate",
             string.format(tr("cs_rf_pda_pivot_rate", "Rate: +%.3f/h"), rate))
     else
-        setPivotText(container, "csPivotRate", tr("cs_rf_pda_pivot_rate_na", "Rate: —"))
+        setPivotText(container, "csPivotRate", tr("cs_rf_pda_pivot_rate_na", "Rate: -"))
     end
     setPivotText(container, "csPivotSchedule", formatScheduleGlance(sys))
 
     local warn = ""
     if not owned then
         warn = tr("cs_rf_pda_pivot_warn_owner", "Not your pivot")
+    elseif rkReason == "RAIN_KEY_TRIPPED" then
+        -- The most actionable thing a farmer can be told about this machine
+        -- right now, so it outranks the door and power hints below.
+        local wakeKind, wakeMin = nil, -1
+        if irrMgrRK ~= nil and type(irrMgrRK.getNextWake) == "function" then
+            wakeKind, wakeMin = irrMgrRK:getNextWake(sys)
+        end
+        if wakeKind == "DRY_RESET" and wakeMin ~= nil and wakeMin >= 0 then
+            warn = string.format(
+                tr("cs_rf_pda_rk_warn_tripped_in", "Rain key tripped, dry reset in %d min"),
+                math.floor(wakeMin + 0.5))
+        else
+            warn = tr("cs_rf_pda_rk_warn_tripped", "Rain key tripped")
+        end
+    elseif rkReason == "INPUT_UNAVAILABLE" then
+        warn = tr("cs_rf_pda_rk_warn_noinput", "Rain key cannot read weather")
     elseif reinke and spec ~= nil and not spec.doorOpen then
         warn = tr("cs_rf_pda_pivot_warn_door", "Open door for ops")
     elseif reinke and spec ~= nil and not spec.masterPower then
@@ -1894,12 +2048,37 @@ updatePivotCard = function(container, fieldId)
     setPivotBtn(container, "csPivotBtnStart", tr("cs_rf_pda_pivot_btn_start", "Start"), owned and (reinke or sys ~= nil))
     setPivotBtn(container, "csPivotBtnStop", tr("cs_rf_pda_pivot_btn_stop", "Stop"), owned and (reinke or sys ~= nil))
     setPivotBtn(container, "csPivotBtnMinUp", tr("cs_rf_pda_pivot_btn_min_up", "Min+"), opsOk)
-    setPivotBtn(container, "csPivotBtnMinDn", tr("cs_rf_pda_pivot_btn_min_dn", "Min−"), opsOk)
+    setPivotBtn(container, "csPivotBtnMinDn", tr("cs_rf_pda_pivot_btn_min_dn", "Min-"), opsOk)
     setPivotBtn(container, "csPivotBtnMaxUp", tr("cs_rf_pda_pivot_btn_max_up", "Max+"), opsOk)
-    setPivotBtn(container, "csPivotBtnMaxDn", tr("cs_rf_pda_pivot_btn_max_dn", "Max−"), opsOk)
+    setPivotBtn(container, "csPivotBtnMaxDn", tr("cs_rf_pda_pivot_btn_max_dn", "Max-"), opsOk)
     setPivotBtn(container, "csPivotBtnArmPlus", tr("cs_rf_pda_pivot_btn_arm_plus", "Arm+"), armOk)
-    setPivotBtn(container, "csPivotBtnArmMinus", tr("cs_rf_pda_pivot_btn_arm_minus", "Arm−"), armOk)
+    setPivotBtn(container, "csPivotBtnArmMinus", tr("cs_rf_pda_pivot_btn_arm_minus", "Arm-"), armOk)
     setPivotBtn(container, "csBtnSchedule", tr("cs_rf_pda_pivot_btn_schedule", "Schedule"), true)
+
+    -- [SCS-046] Rain key remotes. A key is pivot equipment, so Fit is dead on a
+    -- drip line or a Rainstar rather than gated: there is nothing to fit it to.
+    local isPivotRow = (sys ~= nil) and (sys.type == "pivot")
+    local fitted     = sys ~= nil and sys.rainKeyFitted == true
+    local fitOk      = owned and isPivotRow
+    setPivotBtn(container, "csPivotBtnFit",
+        fitted and tr("cs_rf_pda_rk_btn_remove", "Remove") or tr("cs_rf_pda_rk_btn_fit", "Fit"),
+        fitOk, not isPivotRow)
+
+    -- The stepper is gated, not dead, while unfitted: the control exists for this
+    -- machine, it simply has nothing to step until a key is on it.
+    local tripOk = fitOk and fitted
+    setPivotBtn(container, "csPivotBtnTripMinus", tr("cs_rf_pda_rk_btn_trip_minus", "Trip-"), tripOk)
+    setPivotBtn(container, "csPivotBtnTripPlus", tr("cs_rf_pda_rk_btn_trip_plus", "Trip+"), tripOk)
+
+    if isPivotRow then
+        -- Unfitted shows the default it would be fitted at, so the number the
+        -- player is about to accept is visible before they accept it.
+        local tripMm = (sys ~= nil and tonumber(sys.rainKeyTripMm)) or 2.5
+        setPivotText(container, "csPivotTripLabel",
+            string.format(tr("cs_rf_pda_rk_trip_label", "%.1fmm"), tripMm))
+    else
+        setPivotText(container, "csPivotTripLabel", "")
+    end
 end
 
 
@@ -1985,6 +2164,80 @@ local function updateAgronomistCard(container, fieldId)
 end
 
 --- Esc PIVOT remote: send CropStressPivotRemoteEvent (server authority).
+--- [SCS-046] Esc rain-key remotes. This is the ONLY write path from the card:
+--- it sends CropStressRainKeyCommandEvent and never touches
+--- irrigationManager.systems, so a client cannot paint a state the server has
+--- not agreed to. The current revision travels with the request, so a card that
+--- was showing stale state is refused rather than applied.
+function CsRfPdaGuest.onRainKeyCommand(container, token)
+    local mgr = getMgr()
+    local members = selectedMemberIds(container)
+    local fieldId = selectedFieldId(container)
+    if (members == nil or #members == 0) and fieldId ~= nil then
+        members = { fieldId }
+    end
+    local sysId = select(1, selectedSystemId(container, mgr, members))
+    if sysId == nil then
+        print(string.format(
+            "[CropStress] Esc rain key %s IGNORED: no system resolved for fieldId=%s",
+            tostring(token), tostring(fieldId)))
+        return
+    end
+
+    local irr = mgr ~= nil and mgr.irrigationManager or nil
+    local sys = irr ~= nil and irr.systems ~= nil and irr.systems[sysId] or nil
+    if sys == nil then
+        print(string.format("[CropStress] Esc rain key %s IGNORED: system %s unknown",
+            tostring(token), tostring(sysId)))
+        return
+    end
+    if sys.type ~= "pivot" then
+        print("[CropStress] Esc rain key IGNORED: not a center pivot")
+        return
+    end
+
+    local revision = sys.rainKeyStateRevision or 0
+    local action, value = nil, nil
+    if token == "FIT_TOGGLE" then
+        action = (sys.rainKeyFitted == true) and "REMOVE" or "FIT"
+    elseif token == "TRIP_MINUS" or token == "TRIP_PLUS" then
+        if sys.rainKeyFitted ~= true then
+            print("[CropStress] Esc rain key trip IGNORED: no key fitted")
+            return
+        end
+        local step = (token == "TRIP_PLUS") and 0.5 or -0.5
+        local cur  = tonumber(sys.rainKeyTripMm) or 2.5
+        value = cur + step
+        -- Clamp on the way out so the stepper stops at the ends instead of
+        -- sending a value the server will refuse. The server validates again:
+        -- this is convenience, not the authority.
+        if value < 0.5 then value = 0.5 end
+        if value > 10.0 then value = 10.0 end
+        -- Round to the exact half step, because repeated float addition drifts
+        -- and the server refuses anything off the step.
+        value = math.floor((value * 2) + 0.5) / 2
+        if value == cur then return end
+        action = "SET_TRIP_MM"
+    else
+        print(string.format("[CropStress] Esc rain key IGNORED: unknown token %s", tostring(token)))
+        return
+    end
+
+    if CropStressRainKeyCommandEvent ~= nil
+       and type(CropStressRainKeyCommandEvent.sendToServer) == "function" then
+        print(string.format(
+            "[CropStress] Esc rain key %s -> sendToServer(sysId=%s, action=%s, value=%s, rev=%d)",
+            tostring(token), tostring(sysId), tostring(action), tostring(value), revision))
+        CropStressRainKeyCommandEvent.sendToServer(sysId, action, value, revision)
+    else
+        print("[CropStress] Esc rain key IGNORED: CropStressRainKeyCommandEvent.sendToServer unavailable")
+    end
+
+    if type(CsRfPdaGuest.onShow) == "function" then
+        CsRfPdaGuest.onShow(container, true)
+    end
+end
+
 function CsRfPdaGuest.onPivotRemote(container, actionToken)
     local A = CropStressPivotRemoteEvent ~= nil and CropStressPivotRemoteEvent.ACTION or PIVOT_ACTION
     local action = A[actionToken]
@@ -2139,7 +2392,7 @@ local function updateDetailBand(container)
     local nextBody, nextColor = CsRfPdaGuest.buildNextStepLine(fieldId)
     local alertOnStatus = false
     if alertHint ~= nil and nextBody ~= nil and nextBody ~= "" and moisture < 0.25 then
-        local sepTpl = tr("cs_rf_pda_next_alert_sep", " · %s")
+        local sepTpl = tr("cs_rf_pda_next_alert_sep", " - %s")
         local append = string.format(sepTpl, alertHint)
         if (#nextBody + #append) <= 110 then
             nextBody = nextBody .. append
@@ -2194,7 +2447,7 @@ local function updateDetailBand(container)
         local stressLabel = string.format("%s: %s",
             tr("cs_rf_pda_col_stress", "Stress"), entry.stressText or "-")
         local heatClause = string.format(
-            tr("cs_rf_pda_heat_clause", "Air %.0f°C, dry pull %.1f"),
+            tr("cs_rf_pda_heat_clause", "Air %.0f deg C, dry pull %.1f"),
             tempC,
             evap
         )

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -2764,6 +2764,42 @@ local function _csPivotRemote(self, action)
     end
 end
 
+-- [SCS-046] Rain-key clicks take the same host-then-resolved-guest route as the
+-- pivot remotes above, but a DIFFERENT handler: these become
+-- CropStressRainKeyCommandEvent, never a pivot remote action.
+local function _csRainKey(self, token)
+    -- [BUILD 15:58] The pcall stays, because a UI click must never take the
+    -- menu down, but the error is PRINTED now. A bare pcall here is what made
+    -- Fit look like a dead chip: the send threw, the throw was swallowed, and
+    -- nothing reached the log, so there was no difference between "the button
+    -- is not wired" and "the button threw on every press".
+    local function call(fn)
+        local ok, err = pcall(fn, self.rfHostPlaceholder, token)
+        if not ok then
+            print(string.format("[CropStress] Esc rain key %s FAILED: %s",
+                tostring(token), tostring(err)))
+        end
+        return ok
+    end
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active ~= nil and type(active.onRainKeyCommand) == "function" then
+        call(active.onRainKeyCommand)
+    else
+        local csGuest = (type(mdResolve) == "function")
+                and mdResolve(CsRfPdaGuest, "CsRfPdaGuest") or CsRfPdaGuest
+        if csGuest ~= nil and type(csGuest.onRainKeyCommand) == "function" then
+            call(csGuest.onRainKeyCommand)
+        else
+            print("[CropStress] Esc rain key IGNORED: no onRainKeyCommand handler resolved")
+        end
+    end
+end
+
+function RfPdaMenuPage:onClickCsPivotFit()       _csRainKey(self, "FIT_TOGGLE") end
+function RfPdaMenuPage:onClickCsPivotTripMinus() _csRainKey(self, "TRIP_MINUS") end
+function RfPdaMenuPage:onClickCsPivotTripPlus()  _csRainKey(self, "TRIP_PLUS") end
+
 function RfPdaMenuPage:onClickCsPivotDoor()    _csPivotRemote(self, "DOOR_TOGGLE") end
 function RfPdaMenuPage:onClickCsPivotPower()   _csPivotRemote(self, "POWER_TOGGLE") end
 function RfPdaMenuPage:onClickCsPivotSpray()   _csPivotRemote(self, "SPRAY_TOGGLE") end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Braco %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Inicio varredura %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fim varredura %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Braco -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Inicio varredura -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fim varredura -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensor de chuva %s / %.1f mm modelados" />
+    <text name="cs_rf_pda_rk_unknown" text="desconhecido" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensor de chuva disparado" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor disparado, reinicio seco em %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="O sensor nao consegue ler o clima" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montar" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Remover" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Limite-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Limite+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Limite-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Limite+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Irrigacao: pausa por chuva" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Inicio varredura" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fim varredura" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensor de chuva" />
 </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="臂桿 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="掃描起點 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="掃描終點 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="臂桿 -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="掃描起點 -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="掃描終點 -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  雨量感測器 %s / %.1f mm 模擬" />
+    <text name="cs_rf_pda_rk_unknown" text="未知" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="雨量感測器已觸發" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="感測器已觸發, %d 分鐘後乾燥重設" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="雨量感測器無法讀取天氣" />
+    <text name="cs_rf_pda_rk_btn_fit" text="安裝" />
+    <text name="cs_rf_pda_rk_btn_remove" text="移除" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="門檻-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="門檻+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="門檻-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="門檻+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="灌溉: 因雨暫停" />
+        <text name="cs_rf_pda_cap_sweep_start" text="掃描起點" />
+        <text name="cs_rf_pda_cap_sweep_end" text="掃描終點" />
+        <text name="cs_rf_pda_cap_rain_key" text="雨量感測器" />
 </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -409,12 +409,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Rameno %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Zacatek vysece %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Konec vysece %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Rameno -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Zacatek vysece -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Konec vysece -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -503,5 +503,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  cidlo deste %s / %.1f mm modelovanych" />
+    <text name="cs_rf_pda_rk_unknown" text="neznamo" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Cidlo deste sepnulo" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Cidlo sepnulo, suchy reset za %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Cidlo neprecte pocasi" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Osadit" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Sejmout" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Prah-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Prah+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -513,5 +513,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Prah-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Prah+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Zavlaha: pauza kvuli desti" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Zacatek vysece" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Konec vysece" />
+        <text name="cs_rf_pda_cap_rain_key" text="Cidlo deste" />
 </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -393,12 +393,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Sving start %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Sving slut %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Sving start -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Sving slut -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -487,5 +487,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  regnsensor %s / %.1f mm modelleret" />
+    <text name="cs_rf_pda_rk_unknown" text="ukendt" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Regnsensor udlost" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor udlost, tor nulstilling om %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Sensoren kan ikke laese vejret" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Monter" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Fjern" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Graense-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Graense+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -497,5 +497,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Graense-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Graense+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Vanding: regnpause" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Sving start" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Sving slut" />
+        <text name="cs_rf_pda_cap_rain_key" text="Regnsensor" />
 </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -408,12 +408,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Schwenk Start %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Schwenk Ende %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Schwenk Start -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Schwenk Ende -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -502,5 +502,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  Regensensor %s / %.1f mm modelliert" />
+    <text name="cs_rf_pda_rk_unknown" text="unbekannt" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Regensensor ausgeloest" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Regensensor ausgeloest, Trockenreset in %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Regensensor kann Wetter nicht lesen" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Anbau" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Abbau" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Schw-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Schw+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -512,5 +512,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Schw-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Schw+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Bewaesserung: Regenpause" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Schwenk Start" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Schwenk Ende" />
+        <text name="cs_rf_pda_cap_rain_key" text="Regensensor" />
 </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Brazo %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Inicio barrido %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fin barrido %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Brazo -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Inicio barrido -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fin barrido -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensor de lluvia %s / %.1f mm modelados" />
+    <text name="cs_rf_pda_rk_unknown" text="desconocido" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensor de lluvia activado" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor activado, reinicio seco en %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="El sensor no puede leer el clima" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montar" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Quitar" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Umbral-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Umbral+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Umbral-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Umbral+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Riego: pausa por lluvia" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Inicio barrido" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fin barrido" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensor lluvia" />
 </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -517,5 +517,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Trip-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Trip+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Watering now: Rain paused" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Sweep start" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Sweep end" />
+        <text name="cs_rf_pda_cap_rain_key" text="Rain key" />
 </texts>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -412,12 +412,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Sweep start %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Sweep end %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Sweep start -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Sweep end -"/>
     <text name="cs_rf_pda_pivot_coverage" text="Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="Watering now: On"/>
@@ -507,5 +507,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  rain key %s / %.1f mm modelled" />
+    <text name="cs_rf_pda_rk_unknown" text="unknown" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Rain key tripped" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Rain key tripped, dry reset in %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Rain key cannot read weather" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Fit" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Remove" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Trip-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Trip+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Brazo %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Inicio barrido %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fin barrido %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Brazo -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Inicio barrido -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fin barrido -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensor de lluvia %s / %.1f mm modelados" />
+    <text name="cs_rf_pda_rk_unknown" text="desconocido" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensor de lluvia activado" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor activado, reinicio seco en %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="El sensor no puede leer el clima" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montar" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Quitar" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Umbral-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Umbral+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Umbral-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Umbral+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Riego: pausa por lluvia" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Inicio barrido" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fin barrido" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensor lluvia" />
 </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="臂杆 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="扫描起点 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="扫描终点 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="臂杆 -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="扫描起点 -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="扫描终点 -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  雨量传感器 %s / %.1f mm 模拟" />
+    <text name="cs_rf_pda_rk_unknown" text="未知" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="雨量传感器已触发" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="传感器已触发, %d 分钟后干燥重置" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="雨量传感器无法读取天气" />
+    <text name="cs_rf_pda_rk_btn_fit" text="安装" />
+    <text name="cs_rf_pda_rk_btn_remove" text="移除" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="阈值-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="阈值+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="阈值-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="阈值+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="灌溉: 因雨暂停" />
+        <text name="cs_rf_pda_cap_sweep_start" text="扫描起点" />
+        <text name="cs_rf_pda_cap_sweep_end" text="扫描终点" />
+        <text name="cs_rf_pda_cap_rain_key" text="雨量传感器" />
 </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Raja-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Raja+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Kastelu: sadetauko" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Kaaren alku" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Kaaren loppu" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sadeanturi" />
 </texts>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Puomi %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Kaaren alku %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Kaaren loppu %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Puomi -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Kaaren alku -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Kaaren loppu -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sadeanturi %s / %.1f mm mallinnettua" />
+    <text name="cs_rf_pda_rk_unknown" text="tuntematon" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sadeanturi lauennut" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Anturi lauennut, kuiva nollaus %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Anturi ei lue saatietoa" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Asenna" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Poista" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Raja-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Raja+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -510,5 +510,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Seuil-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Seuil+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Arrosage: pause pluie" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Debut balayage" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fin balayage" />
+        <text name="cs_rf_pda_cap_rain_key" text="Capteur pluie" />
 </texts>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -406,12 +406,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Bras %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Debut balayage %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fin balayage %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Bras -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Debut balayage -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fin balayage -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -500,5 +500,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  capteur de pluie %s / %.1f mm modelises" />
+    <text name="cs_rf_pda_rk_unknown" text="inconnu" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Capteur de pluie declenche" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Capteur declenche, reinitialisation dans %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Le capteur ne peut pas lire la meteo" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Poser" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Retirer" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Seuil-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Seuil+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Kuszob-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Kuszob+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Ontozes: eso miatt szunetel" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Iv kezdete" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Iv vege" />
+        <text name="cs_rf_pda_cap_rain_key" text="Esoerzekelo" />
 </texts>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Kar %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Iv kezdete %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Iv vege %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Kar -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Iv kezdete -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Iv vege -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  esoerzekelo %s / %.1f mm modellezett" />
+    <text name="cs_rf_pda_rk_unknown" text="ismeretlen" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Esoerzekelo jelzett" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Erzekelo jelzett, szaraz visszaallas %d perc mulva" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Az erzekelo nem olvassa az idojarast" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Felszer" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Levesz" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Kuszob-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Kuszob+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Lengan %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Awal sapuan %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Akhir sapuan %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Lengan -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Awal sapuan -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Akhir sapuan -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensor hujan %s / %.1f mm model" />
+    <text name="cs_rf_pda_rk_unknown" text="tidak diketahui" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensor hujan aktif" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor aktif, reset kering dalam %d menit" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Sensor tidak dapat membaca cuaca" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Pasang" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Lepas" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Ambang-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Ambang+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Ambang-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Ambang+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Irigasi: jeda hujan" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Awal sapuan" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Akhir sapuan" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensor hujan" />
 </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -510,5 +510,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Soglia-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Soglia+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Irrigazione: pausa pioggia" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Inizio settore" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fine settore" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensore pioggia" />
 </texts>
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -406,12 +406,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Braccio %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Inizio settore %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fine settore %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Braccio -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Inizio settore -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fine settore -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -500,5 +500,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensore pioggia %s / %.1f mm modellati" />
+    <text name="cs_rf_pda_rk_unknown" text="sconosciuto" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensore pioggia scattato" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensore scattato, reset asciutto tra %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Il sensore non legge il meteo" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Monta" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Togli" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Soglia-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Soglia+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="しきい-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="しきい+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="かん水: 降雨で一時停止" />
+        <text name="cs_rf_pda_cap_sweep_start" text="スイープ開始" />
+        <text name="cs_rf_pda_cap_sweep_end" text="スイープ終了" />
+        <text name="cs_rf_pda_cap_rain_key" text="レインセンサー" />
 </texts>
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="アーム %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="スイープ開始 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="スイープ終了 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="アーム -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="スイープ開始 -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="スイープ終了 -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  レインセンサー %s / %.1f mm モデル化" />
+    <text name="cs_rf_pda_rk_unknown" text="不明" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="レインセンサー作動" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="センサー作動、%d分後に乾燥リセット" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="レインセンサーが天候を読めません" />
+    <text name="cs_rf_pda_rk_btn_fit" text="装着" />
+    <text name="cs_rf_pda_rk_btn_remove" text="取外" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="しきい-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="しきい+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="암 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="스윙 시작 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="스윙 끝 %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="암 -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="스윙 시작 -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="스윙 끝 -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  레인 센서 %s / %.1f mm 모델링" />
+    <text name="cs_rf_pda_rk_unknown" text="알 수 없음" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="레인 센서 작동됨" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="센서 작동됨, %d분 후 건조 초기화" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="레인 센서가 날씨를 읽을 수 없음" />
+    <text name="cs_rf_pda_rk_btn_fit" text="장착" />
+    <text name="cs_rf_pda_rk_btn_remove" text="제거" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="기준-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="기준+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="기준-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="기준+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="관수: 강우 일시정지" />
+        <text name="cs_rf_pda_cap_sweep_start" text="스윙 시작" />
+        <text name="cs_rf_pda_cap_sweep_end" text="스윙 끝" />
+        <text name="cs_rf_pda_cap_rain_key" text="레인 센서" />
 </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -510,5 +510,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Drempel-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Drempel+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Bewatering: regenpauze" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Start zwenk" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Einde zwenk" />
+        <text name="cs_rf_pda_cap_rain_key" text="Regensensor" />
 </texts>
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -406,12 +406,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Start zwenk %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Einde zwenk %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Start zwenk -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Einde zwenk -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -500,5 +500,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  regensensor %s / %.1f mm gemodelleerd" />
+    <text name="cs_rf_pda_rk_unknown" text="onbekend" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Regensensor geactiveerd" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor geactiveerd, droge reset over %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Regensensor kan het weer niet lezen" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Monteer" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Haal weg" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Drempel-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Drempel+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Terskel-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Terskel+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Vanning: regnpause" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Sving start" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Sving slutt" />
+        <text name="cs_rf_pda_cap_rain_key" text="Regnsensor" />
 </texts>
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Sving start %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Sving slutt %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Sving start -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Sving slutt -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  regnsensor %s / %.1f mm modellert" />
+    <text name="cs_rf_pda_rk_unknown" text="ukjent" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Regnsensor utlost" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor utlost, torr tilbakestilling om %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Sensoren kan ikke lese vaeret" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Monter" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Fjern" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Terskel-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Terskel+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -406,12 +406,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Ramie %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Poczatek luku %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Koniec luku %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Ramie -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Poczatek luku -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Koniec luku -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -500,5 +500,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  czujnik deszczu %s / %.1f mm modelowane" />
+    <text name="cs_rf_pda_rk_unknown" text="nieznany" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Czujnik deszczu zadzialal" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Czujnik zadzialal, reset po %d min suszy" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Czujnik nie odczytuje pogody" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montuj" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Zdejmij" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Prog-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Prog+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -510,5 +510,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Prog-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Prog+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Nawadnianie: pauza deszczowa" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Poczatek luku" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Koniec luku" />
+        <text name="cs_rf_pda_cap_rain_key" text="Czujnik deszczu" />
 </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Braco %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Inicio varrimento %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Fim varrimento %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Braco -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Inicio varrimento -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Fim varrimento -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  sensor de chuva %s / %.1f mm modelados" />
+    <text name="cs_rf_pda_rk_unknown" text="desconhecido" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Sensor de chuva disparado" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor disparado, reinicio seco em %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="O sensor nao consegue ler o tempo" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montar" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Remover" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Limite-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Limite+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Limite-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Limite+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Rega: pausa por chuva" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Inicio varrimento" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Fim varrimento" />
+        <text name="cs_rf_pda_cap_rain_key" text="Sensor de chuva" />
 </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Prag-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Prag+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Irigare: pauza de ploaie" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Start baleiaj" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Final baleiaj" />
+        <text name="cs_rf_pda_cap_rain_key" text="Senzor ploaie" />
 </texts>
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Brat %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Start baleiaj %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Final baleiaj %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Brat -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Start baleiaj -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Final baleiaj -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  senzor de ploaie %s / %.1f mm modelati" />
+    <text name="cs_rf_pda_rk_unknown" text="necunoscut" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Senzor de ploaie declansat" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Senzor declansat, resetare uscata in %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Senzorul nu poate citi vremea" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Monteaza" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Scoate" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Prag-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Prag+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Порог-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Порог+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fмм" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Полив: пауза по дождю" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Начало сектора" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Конец сектора" />
+        <text name="cs_rf_pda_cap_rain_key" text="Датчик дождя" />
 </texts>
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Стрела %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Начало сектора %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Конец сектора %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Стрела -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Начало сектора -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Конец сектора -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  датчик дождя %s / %.1f мм расчетных" />
+    <text name="cs_rf_pda_rk_unknown" text="неизвестно" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Датчик дождя сработал" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Датчик сработал, сухой сброс через %d мин" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Датчик не читает погоду" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Уст." />
+    <text name="cs_rf_pda_rk_btn_remove" text="Снять" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Порог-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Порог+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fмм" />
 </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Troskel-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Troskel+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Bevattning: regnpaus" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Svep start" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Svep slut" />
+        <text name="cs_rf_pda_cap_rain_key" text="Regnsensor" />
 </texts>
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Arm %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Svep start %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Svep slut %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Arm -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Svep start -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Svep slut -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  regnsensor %s / %.1f mm modellerat" />
+    <text name="cs_rf_pda_rk_unknown" text="okant" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Regnsensor utlost" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor utlost, torr aterstallning om %d min" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Sensorn kan inte lasa vadret" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Montera" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Ta bort" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Troskel-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Troskel+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Kol %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Tarama basi %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Tarama sonu %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Kol -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Tarama basi -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Tarama sonu -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  yagmur sensoru %s / %.1f mm modellenen" />
+    <text name="cs_rf_pda_rk_unknown" text="bilinmiyor" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Yagmur sensoru devreye girdi" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Sensor devreye girdi, kuru sifirlama %d dk" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Sensor hava durumunu okuyamiyor" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Tak" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Cikar" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Esik-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Esik+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Esik-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Esik+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Sulama: yagmur molasi" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Tarama basi" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Tarama sonu" />
+        <text name="cs_rf_pda_cap_rain_key" text="Yagmur sensoru" />
 </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -497,5 +497,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Поріг-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Поріг+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fмм" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Полив: пауза через дощ" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Початок сектора" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Кінець сектора" />
+        <text name="cs_rf_pda_cap_rain_key" text="Датчик дощу" />
 </texts>
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -393,12 +393,12 @@
 <text name="cs_rf_pda_pivot_coverage_rainstar" text="[EN] Coverage: Rainstar spraying this field"/>
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Стріла %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Початок сектора %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Кінець сектора %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Стріла -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Початок сектора -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Кінець сектора -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -487,5 +487,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  датчик дощу %s / %.1f мм розрахункових" />
+    <text name="cs_rf_pda_rk_unknown" text="невідомо" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Датчик дощу спрацював" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Датчик спрацював, сухе скидання через %d хв" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Датчик не читає погоду" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Вст." />
+    <text name="cs_rf_pda_rk_btn_remove" text="Зняти" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Поріг-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Поріг+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fмм" />
 </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -402,12 +402,12 @@
 <text name="cs_rf_pda_pivot_warn_rainstar" text="[EN] Vehicle irrigator"/>
     <text name="cs_rf_pda_pivot_switch" text="[EN] Pivot %s Â· covers %s of this block"/>
     <text name="cs_rf_pda_pivot_drip_label" text="[EN] Drip line"/>
-    <text name="cs_rf_pda_pivot_dial_cur" text="[EN] Cur %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_min" text="[EN] Min %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_max" text="[EN] Max %.0fÂ°"/>
-    <text name="cs_rf_pda_pivot_dial_empty" text="[EN] Cur â€”"/>
-    <text name="cs_rf_pda_pivot_dial_min_empty" text="[EN] Min â€”"/>
-    <text name="cs_rf_pda_pivot_dial_max_empty" text="[EN] Max â€”"/>
+    <text name="cs_rf_pda_pivot_dial_cur" text="Can %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_min" text="Bat dau quet %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_max" text="Ket thuc quet %.0f deg"/>
+    <text name="cs_rf_pda_pivot_dial_empty" text="Can -"/>
+    <text name="cs_rf_pda_pivot_dial_min_empty" text="Bat dau quet -"/>
+    <text name="cs_rf_pda_pivot_dial_max_empty" text="Ket thuc quet -"/>
     <text name="cs_rf_pda_pivot_coverage" text="[EN] Coverage: Fields %s"/>
     <text name="cs_rf_pda_pivot_coverage_none" text="[EN] Coverage: No fields covered"/>
     <text name="cs_rf_pda_pivot_watering_on" text="[EN] Watering now: On"/>
@@ -468,5 +468,15 @@
     <text name="input_REINKE_PIVOT_SPRAY"           text="Toggle Spray (KP5)"/>
     <text name="input_REINKE_END_GUN"               text="Toggle End Gun (KP0)"/>
     <text name="input_REINKE_SPEED_CYCLE"           text="Cycle Speed 1X/2X/3X/4X"/>
+    <text name="cs_rf_pda_rk_suffix" text="  ·  cảm biến mưa %s / %.1f mm mô phỏng" />
+    <text name="cs_rf_pda_rk_unknown" text="không rõ" />
+    <text name="cs_rf_pda_rk_warn_tripped" text="Cảm biến mưa đã kích hoạt" />
+    <text name="cs_rf_pda_rk_warn_tripped_in" text="Cảm biến kích hoạt, đặt lại khô sau %d phút" />
+    <text name="cs_rf_pda_rk_warn_noinput" text="Cảm biến không đọc được thời tiết" />
+    <text name="cs_rf_pda_rk_btn_fit" text="Lắp" />
+    <text name="cs_rf_pda_rk_btn_remove" text="Tháo" />
+    <text name="cs_rf_pda_rk_btn_trip_minus" text="Ngưỡng-" />
+    <text name="cs_rf_pda_rk_btn_trip_plus" text="Ngưỡng+" />
+    <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
 </texts>
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -478,5 +478,9 @@
     <text name="cs_rf_pda_rk_btn_trip_minus" text="Ngưỡng-" />
     <text name="cs_rf_pda_rk_btn_trip_plus" text="Ngưỡng+" />
     <text name="cs_rf_pda_rk_trip_label" text="%.1fmm" />
+        <text name="cs_rf_pda_pivot_watering_rain" text="Tưới: tạm dừng do mưa" />
+        <text name="cs_rf_pda_cap_sweep_start" text="Bat dau quet" />
+        <text name="cs_rf_pda_cap_sweep_end" text="Ket thuc quet" />
+        <text name="cs_rf_pda_cap_rain_key" text="Cam bien mua" />
 </texts>
 </l10n>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -792,6 +792,10 @@
                                  remote row, one chip whose label follows the fitted state. -->
                             <Button profile="RF_CsPivotBtn" id="csPivotBtnFit" position="890px -28px" size="80px 32px"
                                     text="" onClick="onClickCsPivotFit"/>
+                            <!-- [BUILD 18:42] Captions for the angle pairs and the rain key. -->
+                            <Text profile="RF_ProductCell" id="csPivotCapMin" position="590px -62px" size="180px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotCapMax" position="790px -62px" size="180px 16px" text=""/>
+                            <Text profile="RF_ProductCell" id="csPivotCapFit" position="890px -12px" size="80px 16px" text=""/>
                             <Button profile="RF_CsPivotBtn" id="csBtnSchedule" position="590px -132px" size="250px 32px"
                                     text="" onClick="onClickCsSchedule"/>
                             <!-- [SCS-046] Rain-key trip stepper, in the gap Schedule gave up (George

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -788,8 +788,19 @@
                                     text="" onClick="onClickCsPivotArmPlus"/>
                             <Button profile="RF_CsPivotBtn" id="csPivotBtnArmMinus" position="490px -132px" size="80px 32px"
                                     text="" onClick="onClickCsPivotArmMinus"/>
-                            <Button profile="RF_CsPivotBtn" id="csBtnSchedule" position="590px -132px" size="530px 32px"
+                            <!-- [SCS-046] Fit / Remove sits with the other pivot remotes on the top
+                                 remote row, one chip whose label follows the fitted state. -->
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnFit" position="890px -28px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotFit"/>
+                            <Button profile="RF_CsPivotBtn" id="csBtnSchedule" position="590px -132px" size="250px 32px"
                                     text="" onClick="onClickCsSchedule"/>
+                            <!-- [SCS-046] Rain-key trip stepper, in the gap Schedule gave up (George
+                                 CLOSED DESIGN 00:05). Angle Min/Max on this row are untouched. -->
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnTripMinus" position="850px -132px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotTripMinus"/>
+                            <Text profile="RF_ProductCell" id="csPivotTripLabel" position="950px -132px" size="80px 32px" text=""/>
+                            <Button profile="RF_CsPivotBtn" id="csPivotBtnTripPlus" position="1050px -132px" size="80px 32px"
+                                    text="" onClick="onClickCsPivotTripPlus"/>
                         </GuiElement>
                     </GuiElement>
 


### PR DESCRIPTION
## Summary
- Esc Fit on an owned Reinke works in playtest: the pivot card hit-tests Fit so the click cannot fall through to Door.
- Reinke registers toggleDoor (menu, no standing at the box) plus sweep min/max helpers. Dial copy is ASCII (Arm / Sweep start / Sweep end).
- Rain-key command and result events use Event.new so the engine can run them. Server apply still goes through applyRainKeyCommand. Finite-water engine from development is unchanged.
- Door, Power, Spray, End gun, Start, and Stop invert the live chip colours when that function is on. Locked chips stay grey.
- Sweep start sits above the min pair, Sweep end above the max pair, and Rain key sits on Fit, in the same type as the pivot status lines.

Based on origin/development (finite water + rain-key engine). Playtest Crop Stress zip is 1.2.5.104. This branch is 1.2.5.104 on current development.

If another mod creates the Esc door first, that host page also needs the Fit chips and caption texts. Crop Stress guest paints invert and fills the captions once those ids exist.

## Test plan
- [ ] Full start (not only a menu reload).
- [ ] Esc Crop Stress, owned Reinke: Fit changes to Remove and Trip unlocks.
- [ ] Door, Power, Spray, End gun, Start, Stop invert when that function is on.
- [ ] Sweep start / Sweep end / Rain key captions are readable and do not cover the title.
- [ ] Dedicated plus client: Fit still applies on the server (label and tablet rain-key line agree).