### PR TITLE
fix: water source names and pump register so saves load

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.104</version>
+    <version>1.2.5.108</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/placeables/waterPump/waterPump.lua
+++ b/placeables/waterPump/waterPump.lua
@@ -1,6 +1,6 @@
 -- ============================================================
 -- waterPump.lua
--- Water pump placeable — FS25 specialization pattern.
+-- Water pump placeable, FS25 specialization pattern.
 -- Registers with IrrigationManager as a water source.
 -- ============================================================
 
@@ -23,7 +23,13 @@ function WaterPump.prerequisitesPresent(specializations)
 end
 
 function WaterPump.registerFunctions(placeableType)
-    -- No additional public functions needed for water pump
+    -- BUILD 21:44: 1.2.5.105 called registerWithIrrigationManager as an instance
+    -- method from onFinalizePlacement, but the function only lived on the
+    -- WaterPump spec table, so both pumps threw "attempt to call missing method",
+    -- their loads stayed pending, and the mission loader waited forever after
+    -- the last vehicle. Register it on the placeable type so an instance call
+    -- resolves.
+    SpecializationUtil.registerFunction(placeableType, "registerWithIrrigationManager", WaterPump.registerWithIrrigationManager)
 end
 
 function WaterPump.registerEventListeners(placeableType)
@@ -56,7 +62,7 @@ function WaterPump.onLoad(self, savegame)
 
     -- SCS-023: onLoad reads config and initializes full or Unlimited state; it
     -- does NOT register the source. Registration happens at finalize placement
-    -- (or the mission-start sweep) so saved state is applied first.
+    -- so saved state is applied first.
     local capacity = self.waterUnitsCapacity or 48.0
     if capacity <= 0 then
         self.waterRemaining = nil
@@ -67,8 +73,8 @@ function WaterPump.onLoad(self, savegame)
     end
     self.waterDirty = false
 
-    -- Do not register here; onFinalizePlacement (or the manager's sweep) does it
-    -- once load state is available.
+    -- Do not register here; onFinalizePlacement does it once load state is
+    -- available.
 end
 
 function WaterPump.loadFromXMLFile(self, xmlFile, key)
@@ -92,7 +98,9 @@ end
 
 function WaterPump.onFinalizePlacement(self)
     if self.isPreviewMode == true or self.isConstructionPreview == true then return end
-    self:registerWithIrrigationManager()
+    -- Class function with the placeable as self: this cannot miss even if a
+    -- future placeable type forgets registerFunctions.
+    WaterPump.registerWithIrrigationManager(self)
 end
 
 function WaterPump.onOwnerChanged(self, farmId)
@@ -103,14 +111,17 @@ function WaterPump.onOwnerChanged(self, farmId)
     end
 end
 
--- Register once with the manager after load state is available. Marks pending if
--- the manager is unavailable; the manager performs one mission-start sweep.
-function WaterPump:registerWithIrrigationManager()
+-- Register once with the manager after load state is available. If the manager
+-- is missing the pump is only flagged pendingRegistration; there is NO sweep in
+-- IrrigationManager that picks such pumps up later. In practice the manager is
+-- created in Mission00.load, before any placeable finalizes, so this branch is
+-- not expected to run.
+function WaterPump.registerWithIrrigationManager(self)
     self.irrigationManager = g_cropStressManager and g_cropStressManager.irrigationManager or nil
     if self.irrigationManager ~= nil then
         self.irrigationManager:registerWaterSource(self)
     else
-        csLog("waterPump: IrrigationManager not available — pump marked pending")
+        csLog("waterPump: IrrigationManager not available, pump marked pending")
         self.pendingRegistration = true
     end
 end
@@ -149,5 +160,5 @@ function WaterPump.onReadStream(self, streamId, connection)
     end
 end
 
--- No onUpdate needed: pumps are passive and register once at onLoad.
--- No onReadStream / onWriteStream: no additional state to sync.
+-- No onUpdate needed: pumps are passive and register once at finalize placement.
+-- onReadStream / onWriteStream above carry only the finite remainder on join.

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1405,8 +1405,11 @@ function IrrigationManager:getIrrigationWaterSources(farmId)
                 waterRemaining = source.finite and source.waterRemaining or nil,
                 unlimited = not source.finite,
                 hasWater = source.hasWater == true,
-                label = (g_i18n ~= nil and g_i18n:getText("cs_water_source_label"))
-                    or "Water source",
+                -- BUILD 07:10: getText on a key absent from l10n returns the truthy
+                -- "Missing '...'" string, so an `or` fallback after it never fires.
+                -- Ask hasText first, for the key the 26 translation files carry.
+                label = (g_i18n ~= nil and g_i18n:hasText("cs_irr_water_source")
+                    and g_i18n:getText("cs_irr_water_source")) or "Water source",
                 connectedSystems = connected,
             }
         end


### PR DESCRIPTION
## Summary
- Irrigation Suite WATER SOURCES rows used `getText` on a key that does not exist, so the game printed `Missing 'cs_water_sou...`. The getter now asks `hasText` for the existing Water Source string, then `getText`, else the English words.
- Water pumps called `registerWithIrrigationManager` as an instance method that was never registered on the placeable type, so load hung after the last vehicle. The function is now registered and called on the class.

Playtest pack was Crop Stress 1.2.5.108. Farm Tablet is unchanged.

## Test plan
- [ ] Full start (zip load, not a workshop-file reload).
- [ ] Save loads past the last vehicle; both pumps register as finite water sources.
- [ ] Farm Tablet Irrigation Suite, Operations: WATER SOURCES rows say Water Source (or the localized string), not Missing. Hours and connected count unchanged.
