### PR TITLE
feat(SCS-037): caught-up hour — refuse lower/equal/invalid hour keys

### DIFF
--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -124,21 +124,23 @@ CropStressManager.MAX_CATCHUP_HOURS = 168
 
 --- Hours elapsed between two hour keys, as the hourly path should charge them.
 --- Pure and static so the bench can drive it without a mission.
---- Returns 1 (today's behaviour exactly) for the first tick, for a key that did
---- not advance, and for any key that moved backwards.
+--- Returns 1 for the FIRST observation (nil, nonnumeric or negative prior key).
+--- Returns 0 — no hourly work — for a lower, equal, fractional-under-one or
+--- invalid observed key: the live clock never re-runs already-consumed hours.
+--- Otherwise returns the positive floored span, capped at MAX_CATCHUP_HOURS.
 ---@param lastKey number|nil  the previously seen key, or -1/nil before the first
 ---@param hourKey number      the key just observed
----@return number hours       1 .. MAX_CATCHUP_HOURS
+---@return number hours       0 .. MAX_CATCHUP_HOURS
 function CropStressManager.elapsedHoursFrom(lastKey, hourKey)
+    local now = tonumber(hourKey)
+    if now == nil then return 0 end
+
     local last = tonumber(lastKey)
-    local now  = tonumber(hourKey)
-    if last == nil or now == nil or last < 0 then return 1 end
-    local delta = now - last
-    if delta < 1 then return 1 end
-    if delta > CropStressManager.MAX_CATCHUP_HOURS then
-        return CropStressManager.MAX_CATCHUP_HOURS
-    end
-    return math.floor(delta)
+    if last == nil or last < 0 then return 1 end
+
+    local delta = math.floor(now - last)
+    if delta <= 0 then return 0 end
+    return math.min(delta, CropStressManager.MAX_CATCHUP_HOURS)
 end
 
 
@@ -550,14 +552,20 @@ function CropStressManager:update(dt)
         -- SCS-037: the delta this detector already holds is the elapsed count.
         -- Read it BEFORE the key is advanced, or it is gone.
         local elapsedHours = CropStressManager.elapsedHoursFrom(self.lastHourKey, hourKey)
-        self.lastHourKey = hourKey
-        -- BUILD 19:47: nothing hourly runs until the player has actually entered. During a
-        -- long 4x compile this loop was rebuilding a 122-field map every thirty seconds for
-        -- a world nobody was looking at yet, on the same machine that was trying to finish
-        -- loading. The key is still advanced above, so no hours are lost or double counted
-        -- when the gate opens; only the work is held.
-        if g_currentMission ~= nil and g_currentMission.isMissionStarted == true then
-            self:onHourlyTick(elapsedHours)
+        -- A lower, equal or invalid observed key returns 0: no hourly work runs and
+        -- the forward frontier is NOT rewound. Only a positive span advances the key.
+        -- NO function-level return here — the HUD/settings tail below must still run
+        -- every frame, including the refused ones.
+        if elapsedHours > 0 then
+            self.lastHourKey = hourKey
+            -- BUILD 19:47: nothing hourly runs until the player has actually entered. During a
+            -- long 4x compile this loop was rebuilding a 122-field map every thirty seconds for
+            -- a world nobody was looking at yet, on the same machine that was trying to finish
+            -- loading. The key is still advanced above, so no hours are lost or double counted
+            -- when the gate opens; only the work is held.
+            if g_currentMission ~= nil and g_currentMission.isMissionStarted == true then
+                self:onHourlyTick(elapsedHours)
+            end
         end
     end
 

--- a/tools/test/lua/scs037_caught_up_hour_test.lua
+++ b/tools/test/lua/scs037_caught_up_hour_test.lua
@@ -23,10 +23,19 @@ do
   T.eq("elapsed.firstTickIsOne", f(-1, 5000), 1)
   T.eq("elapsed.nilLastIsOne", f(nil, 5000), 1)
 
-  -- The key cannot move backwards (currentMonotonicDay is monotonic), but a
-  -- reseed on savegame switch could make it look that way. Never charge negative.
-  T.eq("elapsed.backwardsIsOne", f(200, 100), 1)
-  T.eq("elapsed.sameKeyIsOne", f(200, 200), 1)
+  -- A lower or equal observed key performs ZERO hourly work and does not rewind
+  -- the forward frontier. The live clock never re-runs already-consumed hours; the
+  -- only witness is a developer gsTimeSet to an earlier hour of the same day.
+  T.eq("elapsed.backwardsIsZero", f(200, 100), 0)
+  T.eq("elapsed.sameKeyIsZero", f(200, 200), 0)
+
+  -- An invalid observed key is refused as zero, never charged as a stray hour.
+  T.eq("elapsed.invalidObservedIsZero", f(100, nil), 0)
+  T.eq("elapsed.invalidObservedNaNIsZero", f(100, "x"), 0)
+
+  -- A fractional positive delta below one hour has not crossed an hour boundary
+  -- yet: it floors to zero and waits, rather than charging a premature hour.
+  T.eq("elapsed.fractionalUnderOneIsZero", f(100, 100.5), 0)
 
   -- THE CAP is one in-game week, and it is a ceiling rather than a tuning number.
   T.eq("elapsed.capAtWeek", f(0, 168), 168)


### PR DESCRIPTION
## SCS-037 — lower-hour admission (build brief amendment)

Travelled irrigation-set card (`d34a9dd`), Stage 6B certified. Host-side, one of four.

### What changed
- **`src/CropStressManager.lua`**
  - `elapsedHoursFrom` now returns **0** for a lower, equal, fractional-under-one or invalid observed key; **1** for first observation (nil/nonnumeric/negative prior); positive floored span capped at 168 otherwise.
  - The `update` hour branch advances `lastHourKey` **only on a positive span** (no frontier rewind) and calls `onHourlyTick` only then. **No function-level return** — the HUD/settings tail still runs on refused frames.
- **`tools/test/lua/scs037_caught_up_hour_test.lua`** — elapsed-count contract updated: `backwardsIsZero`/`sameKeyIsZero` replace the old is-one cases, plus invalid-observed and fractional-under-one assertions. Downstream span assertions unchanged.

### Why
A developer `gsTimeSet` to an earlier hour of the same monotonic day was replaying already-consumed hourly work. This makes the detector positive-only; `onHourlyTick`'s existing clamp (which turns 0 back into 1) is never reached on a refusal.

### Verification
- `✓ scs037_caught_up_hour_test.lua (45 passed, 0 failed)` (42 → 45).
- Full suite: 0 assertions failed. The single load error (`scs039_delegation_test.lua`, `worldToPixel` nil) is pre-existing on `development` — unbuilt SCS-039 surface, out of scope for this PR.

### Boundaries (per brief)
No new persistence, sync event, setting, authority, grid or player surface. Live-session scoped. First observation and positive forward behaviour unchanged. Release remains locked under the irrigation-set gate.