### PR TITLE
feat(SCS-039): moisture truth grid — slices 1–5 (revision, honest reads, accepted-water preservation, fail-closed)

### DIFF
--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -129,6 +129,17 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
             end
             i = i + 1
         end
+
+        -- SCS-039 v2.1 (SDS 3.4): persist the positional accepted-water store
+        -- deterministically, so slice-3 UNRESOLVED world leaves and resolved
+        -- pixel remainders survive save and reload instead of dying in-mission.
+        -- nil when nothing is pending; the string form round-trips exactly.
+        if soilSystem.packMapWaterPendingString ~= nil then
+            local pendingPacked = soilSystem:packMapWaterPendingString()
+            if pendingPacked ~= nil then
+                setString(root .. "#mapWaterPending", pendingPacked)
+            end
+        end
     end
 
     -- HUD state
@@ -257,6 +268,18 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
             end
             i = i + 1
         end
+
+        -- SCS-039 v2.1 (SDS 3.4): restore the positional accepted-water store.
+        -- The leaves are pending-only (nothing spends them until the provider
+        -- accepts water again), so restoring before the map is seeded is safe
+        -- and nothing is lost even if the reload selects a ZONE carrier.
+        local pendingPacked = getString(root .. "#mapWaterPending", nil)
+        if pendingPacked ~= nil and soilSystem.unpackMapWaterPendingString ~= nil then
+            local restored = soilSystem:unpackMapWaterPendingString(pendingPacked)
+            if restored > 0 then
+                csLog(string.format("SaveLoadHandler: restored %d positional water leaves", restored))
+            end
+        end
         csLog(string.format("SaveLoadHandler: loaded moisture/stress for %d fields", i))
     end
 
@@ -337,6 +360,13 @@ function SaveLoadHandler:buildStateTable()
             end
             out.fields[fieldId] = entry
         end
+
+        -- SCS-039 v2.1 (SDS 3.4): the deterministic positional row array rides
+        -- the ledger table so StateLedger mirrors the own-XML pending store.
+        if soilSystem.packMapWaterPending ~= nil then
+            local pendingRows = soilSystem:packMapWaterPending()
+            if #pendingRows > 0 then out.mapWaterPending = pendingRows end
+        end
     end
 
     -- HUD state
@@ -396,6 +426,16 @@ function SaveLoadHandler:applyStateTable(data)
                     soilSystem:unpackCells(fieldId, f.cells)
                 end
                 n = n + 1
+            end
+        end
+
+        -- SCS-039 v2.1 (SDS 3.4): restore the positional pending store from the
+        -- ledger-packed row array (mirror of the own-XML string path above).
+        if soilSystem.unpackMapWaterPending ~= nil
+           and type(data.mapWaterPending) == "table" then
+            local restored = soilSystem:unpackMapWaterPending(data.mapWaterPending)
+            if restored > 0 then
+                csLog(string.format("SaveLoadHandler: restored %d ledger positional water leaves", restored))
             end
         end
         csLog(string.format("SaveLoadHandler: applied ledger moisture/stress for %d fields", n))

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -127,7 +127,22 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
                     setString(key .. "#cells", packed)
                 end
             end
+            -- SCS-039 v2.1 (SDS 3.5 capture groundwork): the field-wide pending
+            -- sub-step carry is accepted water that must survive save and reload
+            -- like the positional store. Zero is written explicitly so a cleared
+            -- carry is not mistaken for a pre-feature save.
+            setFloat(key .. "#mapPending", data.mapPending or 0)
             i = i + 1
+        end
+
+        -- SCS-039 v2.1 (SDS 3.2/3.5): the provider revision and the settled-day
+        -- cursor are persisted server integers. Clients adopt them on load and
+        -- never mint their own; the SDS 3.5 COMPLETE envelope carries them. The
+        -- cursor is written only once seeded, so a fresh save keeps nil and the
+        -- first wake seeds the current day without inventing history.
+        setInt(root .. "#moistureRevision", soilSystem.moistureRevision or 1)
+        if soilSystem._lastSettledDay ~= nil then
+            setInt(root .. "#lastSettledDay", soilSystem._lastSettledDay)
         end
 
         -- SCS-039 v2.1 (SDS 3.4): persist the positional accepted-water store
@@ -265,9 +280,22 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
                 if cellsStr ~= nil and soilSystem.unpackCells ~= nil then
                     soilSystem:unpackCells(fieldId, cellsStr)
                 end
+                -- SCS-039 v2.1 (SDS 3.5): restore the field-wide pending carry.
+                local mapPending = getFloat(key .. "#mapPending", nil)
+                if mapPending ~= nil then
+                    soilSystem.fieldData[fieldId].mapPending = mapPending
+                end
             end
             i = i + 1
         end
+
+        -- SCS-039 v2.1 (SDS 3.2/3.5): adopt the persisted provider revision and
+        -- settled-day cursor on the server. Clients adopt the server value via
+        -- the sync path and never mint their own.
+        local revision = getInt(root .. "#moistureRevision", nil)
+        if revision ~= nil then soilSystem.moistureRevision = revision end
+        local settledDay = getInt(root .. "#lastSettledDay", nil)
+        if settledDay ~= nil then soilSystem._lastSettledDay = settledDay end
 
         -- SCS-039 v2.1 (SDS 3.4): restore the positional accepted-water store.
         -- The leaves are pending-only (nothing spends them until the provider
@@ -354,11 +382,24 @@ function SaveLoadHandler:buildStateTable()
                 stress   = (stressModifier ~= nil) and stressModifier:getStress(fieldId) or 0.0,
                 soilType = data.soilType or "loamy",
             }
+            -- SCS-039 v2.1 (SDS 3.5): carry the field-wide pending sub-step
+            -- remainder on the ledger table mirror (own-XML writes it too).
+            if data.mapPending ~= nil and data.mapPending ~= 0 then
+                entry.mapPending = data.mapPending
+            end
             -- SCS-018 3.8: packed cell leaf rides the ledger table (nil when no cells).
             if soilSystem.packCells ~= nil then
                 entry.cells = soilSystem:packCells(fieldId)
             end
             out.fields[fieldId] = entry
+        end
+
+        -- SCS-039 v2.1 (SDS 3.2/3.5): the revision and settled-day cursor ride
+        -- the ledger so the mirror matches the own-XML carrier. The cursor is
+        -- carried only once seeded (nil otherwise, mirroring the XML path).
+        out.moistureRevision = soilSystem.moistureRevision or 1
+        if soilSystem._lastSettledDay ~= nil then
+            out.lastSettledDay = soilSystem._lastSettledDay
         end
 
         -- SCS-039 v2.1 (SDS 3.4): the deterministic positional row array rides
@@ -421,6 +462,10 @@ function SaveLoadHandler:applyStateTable(data)
                 if f.soilType ~= nil and SoilMoistureSystem.SOIL_PARAMS[f.soilType] ~= nil then
                     soilSystem.fieldData[fieldId].soilType = f.soilType
                 end
+                -- SCS-039 v2.1 (SDS 3.5): restore the field-wide pending carry.
+                if f.mapPending ~= nil then
+                    soilSystem.fieldData[fieldId].mapPending = f.mapPending
+                end
                 -- SCS-018 3.8: install cells from the ledger-packed leaf.
                 if f.cells ~= nil and soilSystem.unpackCells ~= nil then
                     soilSystem:unpackCells(fieldId, f.cells)
@@ -428,6 +473,10 @@ function SaveLoadHandler:applyStateTable(data)
                 n = n + 1
             end
         end
+
+        -- SCS-039 v2.1 (SDS 3.2/3.5): adopt the ledger revision and cursor.
+        if data.moistureRevision ~= nil then soilSystem.moistureRevision = data.moistureRevision end
+        if data.lastSettledDay ~= nil then soilSystem._lastSettledDay = data.lastSettledDay end
 
         -- SCS-039 v2.1 (SDS 3.4): restore the positional pending store from the
         -- ledger-packed row array (mirror of the own-XML string path above).

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -40,6 +40,18 @@ function SaveLoadHandler.new(manager)
     self.manager = manager
     self.isInitialized = false
     self._saveDataLoaded = false  -- set true once we successfully read from xmlFile
+
+    -- SCS-039 v2.1 (SDS 3.5): the two retained COMPLETE generations. Generation 0
+    -- is the legacy/fresh baseline (a pre-feature .grle is imported as generation
+    -- 0); a COMPLETE commit advances it only after the native write AND the
+    -- compact write both succeed. A native failure with a usable compact write
+    -- records one PENDING_ONLY payload bound to the base generation instead.
+    self._completePair = {
+        current  = { generation = 0, digest = nil, revision = 1, lastSettledMonotonicDay = nil },
+        previous = nil,
+    }
+    self._pendingOnly = nil
+    self._saveEnvelopeSchema = 2
     return self
 end
 
@@ -60,6 +72,7 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
     -- posture. The per-field scalar rows written below stay exactly as they are
     -- and become the DEGRADE layer: if the .grle is missing or refuses to load,
     -- the field scalars still restore and the cell store carries the save.
+    local nativeSaveOk = false
     local soilSystemForMap = self.manager ~= nil and self.manager.soilSystem or nil
     if soilSystemForMap ~= nil and soilSystemForMap.valueMap ~= nil
        and soilSystemForMap.valueMap.available then
@@ -71,7 +84,7 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
             -- then carry the save as the honest degrade layer, and the next load
             -- re-selects a readable carrier rather than trusting bytes that never
             -- reached disk.
-            soilSystemForMap:saveNativeMap(sgDir)
+            nativeSaveOk = soilSystemForMap:saveNativeMap(sgDir) == true
         end
     end
 
@@ -153,6 +166,25 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
             local pendingPacked = soilSystem:packMapWaterPendingString()
             if pendingPacked ~= nil then
                 setString(root .. "#mapWaterPending", pendingPacked)
+            end
+        end
+
+        -- SCS-039 v2.1 (SDS 3.5): when the native carrier is current, capture one
+        -- immutable envelope at this save's revision and commit it against the
+        -- native and compact write receipts. The compact write (this own-XML
+        -- block) is what just succeeded; the generation advances only when the
+        -- native write did too, and a native failure records a PENDING_ONLY
+        -- bound to the base generation. The current generation is persisted so
+        -- the next load knows which pair to reconcile against. ZONE missions
+        -- (no native map) keep the scalar carrier and no generation bookkeeping.
+        if soilSystem.valueMap ~= nil and soilSystem.valueMap.available
+           and self.captureMoistureEnvelope ~= nil and self.commitMoistureEnvelope ~= nil then
+            local capture = self:captureMoistureEnvelope()
+            if capture ~= nil then
+                local outcome = self:commitMoistureEnvelope(capture, nativeSaveOk, true)
+                if outcome == "COMPLETE" or outcome == "PENDING_ONLY" then
+                    setInt(root .. "#saveGeneration", self._completePair.current.generation)
+                end
             end
         end
     end
@@ -296,6 +328,12 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
         if revision ~= nil then soilSystem.moistureRevision = revision end
         local settledDay = getInt(root .. "#lastSettledDay", nil)
         if settledDay ~= nil then soilSystem._lastSettledDay = settledDay end
+        -- SCS-039 v2.1 (SDS 3.5): resume the retained-pair bookkeeping at the
+        -- persisted generation so the next COMPLETE commit builds on it.
+        local saveGeneration = getInt(root .. "#saveGeneration", nil)
+        if saveGeneration ~= nil then
+            self._completePair.current.generation = saveGeneration
+        end
 
         -- SCS-039 v2.1 (SDS 3.4): restore the positional accepted-water store.
         -- The leaves are pending-only (nothing spends them until the provider
@@ -524,6 +562,226 @@ function SaveLoadHandler:applyStateTable(data)
     end
 
     return true
+end
+
+-- ============================================================
+-- SCS-039 v2.1 (SDS 3.5): SYNCHRONOUS IMMUTABLE SAVE CAPTURE.
+--
+-- The save act freezes ONE envelope at the current provider revision (revision,
+-- settled-day cursor, refreshed aggregates, both pending packs) and commits it
+-- as a new COMPLETE generation ONLY after the native write AND the compact
+-- write both succeed exactly. A native failure with a usable compact write
+-- records one PENDING_ONLY payload bound to the base generation; it names no
+-- native file and never advances the generation. On load, candidates from the
+-- mirrors are grouped by generation and canonical digest, identical mirrors
+-- deduplicate, conflicting digests reject that generation, and the highest
+-- valid COMPLETE native pair wins (Group D and Group K mirror this contract).
+-- The generation-qualified native FILE names, on-disk retention of both pairs
+-- and interrupted-file cleanup are wired by the follow-on slices; this core is
+-- the engine-free state machine the file layer will drive.
+-- ============================================================
+
+--- Deterministic canonical digest of one envelope's logical payload. Two
+--- identical logical payloads produce the same string; any drift (revision,
+--- cursor, aggregate, pending amount) changes it. Used to reconcile identical
+--- mirrors and reject conflicting ones at the same generation.
+function SaveLoadHandler:compactDigest(env)
+    if env == nil then return nil end
+    local parts = {}
+    parts[#parts + 1] = "s=" .. tostring(env.schema)
+    parts[#parts + 1] = "p=" .. tostring(env.payloadKind)
+    parts[#parts + 1] = "g=" .. tostring(env.generation)
+    parts[#parts + 1] = "r=" .. tostring(env.moistureRevision)
+    parts[#parts + 1] = "d=" .. tostring(env.lastSettledMonotonicDay or -1)
+    local aggKeys, fpKeys = {}, {}
+    for fieldId in pairs(env.aggregates or {}) do aggKeys[#aggKeys + 1] = fieldId end
+    for fieldId in pairs(env.fieldPending or {}) do fpKeys[#fpKeys + 1] = fieldId end
+    table.sort(aggKeys)
+    table.sort(fpKeys)
+    for i = 1, #aggKeys do
+        parts[#parts + 1] = string.format("a%d=%.6f", aggKeys[i], env.aggregates[aggKeys[i]] or 0)
+    end
+    for i = 1, #fpKeys do
+        parts[#parts + 1] = string.format("f%d=%.6f", fpKeys[i], env.fieldPending[fpKeys[i]] or 0)
+    end
+    local rows = env.positionalRows or {}
+    local posTotal = 0
+    for i = 1, #rows do posTotal = posTotal + (rows[i].amount or 0) end
+    parts[#parts + 1] = string.format("pos=%d:%.6f", #rows, posTotal)
+    return table.concat(parts, "|")
+end
+
+--- Capture one immutable COMPLETE envelope at the current provider revision.
+--- Returns nil when there is no soil system to capture.
+function SaveLoadHandler:captureMoistureEnvelope()
+    local soil = self.manager ~= nil and self.manager.soilSystem or nil
+    if soil == nil or type(soil.fieldData) ~= "table" then return nil end
+    local base = self._completePair.current
+    local env = {
+        schema   = self._saveEnvelopeSchema or 2,
+        payloadKind = "COMPLETE",
+        generation = base.generation or 0,
+        filename   = nil,
+        mapWidth   = nil,
+        grain      = nil,
+        moistureRevision = soil.moistureRevision or 1,
+        lastSettledMonotonicDay = soil._lastSettledDay,
+        aggregates = {},
+        fieldPending = {},
+        positionalRows = {},
+    }
+    local vm = soil.valueMap
+    if vm ~= nil and vm.available then
+        env.mapWidth = vm.resolution
+        if type(vm.getGrainMetres) == "function" then
+            env.grain = vm:getGrainMetres()
+        end
+    end
+    for fieldId, d in pairs(soil.fieldData) do
+        env.aggregates[fieldId] = d.moisture
+        if d.mapPending ~= nil and d.mapPending ~= 0 then
+            env.fieldPending[fieldId] = d.mapPending
+        end
+    end
+    if type(soil.packMapWaterPending) == "function" then
+        env.positionalRows = soil:packMapWaterPending()
+    end
+    env.digest = self:compactDigest(env)
+    return env
+end
+
+--- Commit a captured envelope. Mirrors Group K's synchronousSave exactly:
+---   "COMPLETE"    - native AND compact both true; previous pair retained, current
+---                   advances one generation, any PENDING_ONLY is superseded.
+---   "PENDING_ONLY" - native false but compact true; one PENDING_ONLY bound to the
+---                   base generation/revision/cursor is recorded, pair unchanged.
+---   "FAILED"      - compact also failed; pair unchanged, no recovery payload.
+function SaveLoadHandler:commitMoistureEnvelope(capture, nativeOk, compactOk)
+    if capture == nil then return "FAILED" end
+    local base = self._completePair.current
+    if nativeOk == true and compactOk == true then
+        self._completePair.previous = self._completePair.current
+        self._completePair.current = {
+            generation = (base.generation or 0) + 1,
+            digest     = capture.digest,
+            revision   = capture.moistureRevision,
+            lastSettledMonotonicDay = capture.lastSettledMonotonicDay,
+        }
+        self._pendingOnly = nil
+        return "COMPLETE"
+    end
+    if compactOk == true then
+        self._pendingOnly = {
+            payloadKind = "PENDING_ONLY",
+            baseGeneration = base.generation or 0,
+            baseRevision   = capture.moistureRevision,
+            baseLastSettledMonotonicDay = capture.lastSettledMonotonicDay,
+            aggregates = capture.aggregates,
+            fieldPending = capture.fieldPending,
+            positionalRows = capture.positionalRows,
+            zoneOk = true,
+            digest = "P:" .. tostring(self:compactDigest(capture)),
+        }
+        return "PENDING_ONLY"
+    end
+    return "FAILED"
+end
+
+--- Select the carrier from a candidate list gathered at load (own XML and the
+--- StateLedger mirror). Mirrors the bar's Group D selection: group candidates by
+--- generation and canonical digest, deduplicate identical mirrors, reject a
+--- generation whose mirrors conflict, then take the highest valid COMPLETE
+--- native pair, degrading to ZONE on a newer valid compact without a native
+--- file. A PENDING_ONLY row is applied only when its complete-pair identity
+--- (generation, revision, cursor) matches exactly.
+---@return string mode  "TRUTH" | "ZONE" | "NONE"
+---@return number|nil generation
+---@return string|nil digest
+---@return string|nil pendingDigest
+---@return string|nil pendingStatus  "APPLIED" | "CONFLICT" | "BASE_MISMATCH" | "NONE"
+---@return number|nil cursor
+---@return number|nil revision
+function SaveLoadHandler:selectMoistureCarrier(candidates)
+    -- Phase 1: pick the complete generation.
+    local byGeneration = {}
+    local order = {}
+    for _, c in ipairs(candidates or {}) do
+        if c.payloadKind ~= "PENDING_ONLY" and c.compactOk and type(c.generation) == "number" then
+            local g = byGeneration[c.generation]
+            if g == nil then
+                g = { digests = {}, rows = {} }
+                byGeneration[c.generation] = g
+                order[#order + 1] = c.generation
+            end
+            g.digests[c.digest] = true
+            g.rows[#g.rows + 1] = c
+        end
+    end
+    table.sort(order, function(a, b) return a > b end)
+
+    local function selectPendingOnly(baseGeneration, baseRevision, baseCursor)
+        local digests, rows = {}, {}
+        for _, c in ipairs(candidates or {}) do
+            if c.payloadKind == "PENDING_ONLY" and c.compactOk
+               and c.baseGeneration == baseGeneration then
+                digests[c.digest] = true
+                rows[#rows + 1] = c
+            end
+        end
+        local count = 0
+        for _ in pairs(digests) do count = count + 1 end
+        if count == 0 then return nil, "NONE" end
+        if count > 1 then return nil, "CONFLICT" end
+        local row = rows[1]
+        if baseRevision ~= nil and row.baseRevision ~= baseRevision then
+            return nil, "BASE_MISMATCH"
+        end
+        if baseCursor ~= nil and row.baseLastSettledMonotonicDay ~= baseCursor then
+            return nil, "BASE_MISMATCH"
+        end
+        return row, "APPLIED"
+    end
+
+    for i = 1, #order do
+        local generation = order[i]
+        local g = byGeneration[generation]
+        local digestCount = 0
+        for _ in pairs(g.digests) do digestCount = digestCount + 1 end
+        if digestCount == 1 then
+            local row = g.rows[1]
+            local cursor = row.lastSettledMonotonicDay
+            local revision = row.revision
+            if row.nativeOk then
+                local pending, pendingStatus =
+                    selectPendingOnly(generation, revision, cursor)
+                return "TRUTH", generation, row.digest,
+                    pending ~= nil and pending.digest or nil,
+                    pendingStatus, cursor, revision
+            end
+            return "ZONE", generation, row.digest,
+                nil, "NONE", cursor, revision
+        end
+    end
+
+    -- No complete pair: a PENDING_ONLY row may provide explicit ZONE recovery.
+    local bases = {}
+    for _, c in ipairs(candidates or {}) do
+        if c.payloadKind == "PENDING_ONLY" and c.compactOk and c.zoneOk
+           and type(c.baseGeneration) == "number" then
+            bases[c.baseGeneration] = true
+        end
+    end
+    local baseOrder = {}
+    for b in pairs(bases) do baseOrder[#baseOrder + 1] = b end
+    table.sort(baseOrder, function(a, b) return a > b end)
+    for i = 1, #baseOrder do
+        local pending, pendingStatus = selectPendingOnly(baseOrder[i], nil, nil)
+        if pending ~= nil and pending.zoneOk then
+            return "ZONE", baseOrder[i], nil, pending.digest, pendingStatus,
+                pending.baseLastSettledMonotonicDay, pending.baseRevision
+        end
+    end
+    return "NONE", nil, nil, nil, "NONE", nil, nil
 end
 
 function SaveLoadHandler:delete()

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -325,9 +325,15 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
         -- settled-day cursor on the server. Clients adopt the server value via
         -- the sync path and never mint their own.
         local revision = getInt(root .. "#moistureRevision", nil)
-        if revision ~= nil then soilSystem.moistureRevision = revision end
+        if revision ~= nil then
+            soilSystem.moistureRevision = revision
+            self._completePair.current.revision = revision
+        end
         local settledDay = getInt(root .. "#lastSettledDay", nil)
-        if settledDay ~= nil then soilSystem._lastSettledDay = settledDay end
+        if settledDay ~= nil then
+            soilSystem._lastSettledDay = settledDay
+            self._completePair.current.lastSettledMonotonicDay = settledDay
+        end
         -- SCS-039 v2.1 (SDS 3.5): resume the retained-pair bookkeeping at the
         -- persisted generation so the next COMPLETE commit builds on it.
         local saveGeneration = getInt(root .. "#saveGeneration", nil)
@@ -605,9 +611,24 @@ function SaveLoadHandler:compactDigest(env)
         parts[#parts + 1] = string.format("f%d=%.6f", fpKeys[i], env.fieldPending[fpKeys[i]] or 0)
     end
     local rows = env.positionalRows or {}
-    local posTotal = 0
-    for i = 1, #rows do posTotal = posTotal + (rows[i].amount or 0) end
-    parts[#parts + 1] = string.format("pos=%d:%.6f", #rows, posTotal)
+    -- SCS-039 v2.1 (Iris fix 5): the digest binds the FULL canonical positional
+    -- payload, not just count and total. Each leaf's field, status, coordinates
+    -- (pixel key or canonical world position), source grain and amount appear in
+    -- the pack's deterministic order, so two equal-sized leaves at different
+    -- positions never produce the same digest.
+    for i = 1, #rows do
+        local r = rows[i]
+        local where
+        if r.status == "RESOLVED" then
+            where = "p" .. tostring(r.pixelKey)
+        else
+            where = "w" .. tostring(r.worldX) .. "," .. tostring(r.worldZ)
+        end
+        parts[#parts + 1] = string.format("l%d=%s/%s/%s/%s/%.6f", i,
+            tostring(r.fieldId), tostring(r.status), where,
+            tostring(r.sourceWidth or "nil"), r.amount or 0)
+    end
+    parts[#parts + 1] = "lc=" .. tostring(#rows)
     return table.concat(parts, "|")
 end
 
@@ -638,6 +659,13 @@ function SaveLoadHandler:captureMoistureEnvelope()
         end
     end
     for fieldId, d in pairs(soil.fieldData) do
+        -- SCS-039 v2.1 (Iris fix 6): refresh a dirty native aggregate BEFORE it is
+        -- frozen into the envelope, so the capture never pairs the new revision
+        -- with a stale mean from an earlier positional write.
+        if d.aggregateDirty == true and soil.valueMap ~= nil and soil.valueMap.available
+           and type(soil._refreshFieldAggregate) == "function" then
+            soil:_refreshFieldAggregate(fieldId, d)
+        end
         env.aggregates[fieldId] = d.moisture
         if d.mapPending ~= nil and d.mapPending ~= 0 then
             env.fieldPending[fieldId] = d.mapPending
@@ -671,11 +699,16 @@ function SaveLoadHandler:commitMoistureEnvelope(capture, nativeOk, compactOk)
         return "COMPLETE"
     end
     if compactOk == true then
+        -- SCS-039 v2.1 (Iris fix 7): a PENDING_ONLY recovery row binds to the
+        -- RETAINED complete pair's identity (generation, revision, cursor), never
+        -- the current RAM revision/cursor, so the selector does not reject it as
+        -- BASE_MISMATCH when RAM moved on after the last successful save. The
+        -- pending payload itself stays the captured one.
         self._pendingOnly = {
             payloadKind = "PENDING_ONLY",
             baseGeneration = base.generation or 0,
-            baseRevision   = capture.moistureRevision,
-            baseLastSettledMonotonicDay = capture.lastSettledMonotonicDay,
+            baseRevision   = base.revision or capture.moistureRevision,
+            baseLastSettledMonotonicDay = base.lastSettledMonotonicDay,
             aggregates = capture.aggregates,
             fieldPending = capture.fieldPending,
             positionalRows = capture.positionalRows,

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -66,7 +66,12 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
         local sgDir = g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
             and g_currentMission.missionInfo.savegameDirectory or nil
         if sgDir ~= nil then
-            soilSystemForMap.valueMap:saveToSavegame(sgDir)
+            -- SCS-039 v2.1 (SDS 3.3): route the native save through the soil system
+            -- so a refusal fails the provider closed. The scalar rows written below
+            -- then carry the save as the honest degrade layer, and the next load
+            -- re-selects a readable carrier rather than trusting bytes that never
+            -- reached disk.
+            soilSystemForMap:saveNativeMap(sgDir)
         end
     end
 

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -189,6 +189,17 @@ function SoilMoistureSystem.new(manager)
     -- and spend only whole raw steps, or water lands on the map as nothing.
     self._mapWaterPending = {} -- fieldId -> [px * 4096 + pz] -> remainder
 
+    -- SCS-039 v2.1: the persisted server integer that stamps every readable
+    -- moisture answer. Advanced ONCE per successful readable mutation (native or
+    -- zone write, whole-field replacement, committed settle, migration). A
+    -- pending-only sub-step remainder does not advance it. Clients adopt the
+    -- server value through the sync path and never mint their own.
+    self.moistureRevision = 1
+    -- The frozen per-mission carrier decision: "TRUTH" (the native 2 m map is
+    -- the current authority) or "ZONE" (the sparse cell store is). nil until
+    -- initValueMap runs and makes the one-way choice.
+    self.providerMode = nil
+
     self.isInitialized = false
     return self
 end
@@ -205,6 +216,10 @@ function SoilMoistureSystem:initValueMap(savegameDir)
     -- nil-on-failure below would make every caller retry the whole engine probe.
     if self._valueMapTried then return false end
     self._valueMapTried = true
+    -- SCS-039 v2.1: default the carrier to ZONE. Every decline path below leaves
+    -- it here; only a live native map promotes it to TRUTH. The choice is frozen
+    -- for the mission once made.
+    self.providerMode = "ZONE"
     if CropStressValueMap == nil then return false end
 
     -- SCS-039 ships LOCKED. Until the in-game layer look clears it, the map only
@@ -219,6 +234,7 @@ function SoilMoistureSystem:initValueMap(savegameDir)
     self.valueMap = CropStressValueMap.new()
     local ok = self.valueMap:initialize(savegameDir)
     if ok then
+        self.providerMode = "TRUTH"
         csLog("Moisture: the 2m value map is live; the cell store is now the fallback only")
     else
         -- THE DEGRADE, and it is the whole reason the scalar rows stay in the
@@ -687,27 +703,32 @@ end
 ---@return number|nil moisture 0..1
 ---@return number|nil grainMetres
 function SoilMoistureSystem:getMoisture(fieldId, x, z)
+    -- SCS-039 v2.1: the third return is the provider revision. It is additive, so
+    -- one- and two-value callers (FarmTablet, SoilFertilizer) stay compatible.
+    local rev = self.moistureRevision or 1
     local d = self.fieldData[fieldId]
-    if d == nil then return nil, nil end
+    if d == nil then return nil, nil, rev end
 
     if x ~= nil and z ~= nil then
         if self:mapActive() then
             local v, grain = self.valueMap:readValueAtWorld(x, z)
-            -- nil means nothing is written at that pixel (off-field or not yet
-            -- seeded), which is the aggregate's job to answer, not a hole.
-            if v ~= nil then return v, grain end
-            return self:getFieldAggregate(d), grain
+            -- A written pixel answers with its ACTUAL carrier grain.
+            if v ~= nil then return v, grain, rev end
+            -- In-domain but unwritten: the field aggregate answers, and it is NOT
+            -- a local reading, so it carries NIL grain rather than the map's. A
+            -- consumer must never mistake a field mean for a 2 m local sample.
+            return self:getFieldAggregate(d), nil, rev
         end
         local cx, cz = self:worldToCell(x, z)
         local row = d.cells and d.cells[cx]
         local cell = row and row[cz]
-        if cell ~= nil then return cell.moisture, self:getCellSize() end
-        return self:getFieldAggregate(d), self:getCellSize()
+        if cell ~= nil then return cell.moisture, self:getCellSize(), rev end
+        return self:getFieldAggregate(d), self:getCellSize(), rev
     end
 
     -- Field-level read: the scalar is the derived aggregate either way, so the
     -- grain reported is the field itself rather than any cell size.
-    return self:getFieldAggregate(d), nil
+    return self:getFieldAggregate(d), nil, rev
 end
 
 -- Derived field aggregate, O(1). Once a field has cells it is the mean of the
@@ -718,6 +739,39 @@ function SoilMoistureSystem:getFieldAggregate(d)
         return d.cellSum / d.cellCount
     end
     return d.moisture
+end
+
+-- ============================================================
+-- SCS-039 v2.1: PROVIDER REVISION AND HONEST PUBLIC READS (SDS 3.2).
+-- The revision is one persisted server integer; every readable answer carries
+-- it so an aggregate and a fine consumer can agree on which ground they saw.
+-- ============================================================
+
+--- The current server provider revision. Consumers stamp their reads with it and
+--- a client never mints its own; it adopts the server value through the sync path.
+function SoilMoistureSystem:getMoistureRevision()
+    return self.moistureRevision or 1
+end
+
+--- True only while the native 2 m map is the current authority. A ZONE carrier,
+--- an absent map, or a native provider that has failed closed for the mission all
+--- answer false, so a consumer never draws a stale or partial fine map as current.
+function SoilMoistureSystem:isMoistureMapCurrent()
+    return self:mapActive() and self.providerMode == "TRUTH"
+end
+
+--- The live native map, and ONLY while it is current. nil otherwise, so the host
+--- overlay falls back to the aggregate rather than drawing non-current bytes.
+function SoilMoistureSystem:getMoistureDisplayMap()
+    if not self:isMoistureMapCurrent() then return nil end
+    return self.valueMap
+end
+
+--- Advance the persisted revision exactly once for a successful readable mutation.
+--- A pending-only sub-step remainder must never call this.
+function SoilMoistureSystem:_advanceMoistureRevision()
+    self.moistureRevision = (self.moistureRevision or 1) + 1
+    return self.moistureRevision
 end
 
 -- THE SINGLE WRITE PATH (SCS-018 brief 3.3): read the cell, compute, write the
@@ -772,8 +826,13 @@ function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
         -- The scalar is the derived aggregate, and a uniform paint makes the
         -- mean exactly the painted value. Any carried sub-step delta is now
         -- stale: it was accumulated against ground that no longer exists.
+        -- SCS-039 v2.1: a whole-field replacement supersedes BOTH pending stores
+        -- together, the field-wide carry and every positional leaf, or a stale
+        -- leaf would re-spend onto ground the replacement already overwrote.
         d.mapPending = 0
+        self._mapWaterPending[fieldId] = nil
         d.moisture = newValue
+        self:_advanceMoistureRevision()
         return newValue
     end
 
@@ -787,6 +846,8 @@ function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
         d.cellSum = d.cellSum + delta * d.cellCount
     end
     d.moisture = newValue
+    -- ZONE whole-field replacement is a readable mutation too.
+    self:_advanceMoistureRevision()
     return newValue
 end
 
@@ -900,8 +961,12 @@ end
 -- materialising it if needed (the materialisation door for water application).
 -- ============================================================
 function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
+    -- SCS-039 v2.1: return a literal boolean receipt. true = the accepted water
+    -- joined its store (even a sub-step amount that floored to no write yet);
+    -- false = an invalid field, non-positive gain or an unresolved position.
+    -- SCS-023's COVER step consumes only this boolean.
     local d = self.fieldData[fieldId]
-    if d == nil or gain <= 0 then return end
+    if d == nil or type(gain) ~= "number" or gain <= 0 then return false end
 
     -- SCS-039: water lands on a PLACE, and on the map that place is a 2 m pixel
     -- instead of a 10-40 m cell. Read what is there, add the gain, write it back.
@@ -913,35 +978,41 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
     if self:mapActive() then
         self:migrateFieldToMap(fieldId)
         local px, pz = self.valueMap:worldToPixel(x, z)
-        if px ~= nil then
-            local fieldAcc = self._mapWaterPending[fieldId]
-            if fieldAcc == nil then fieldAcc = {}; self._mapWaterPending[fieldId] = fieldAcc end
-            local key = px * 4096 + pz
-            local pending = (fieldAcc[key] or 0) + gain
-            local applied, remainder = CropStressValueMap.quantiseDelta(pending)
-            fieldAcc[key] = remainder
-            if applied ~= 0 then
-                local grain = self.valueMap:getGrainMetres() or 2
-                local current = self.valueMap:readValueAtWorld(x, z)
-                if current == nil then current = self:getFieldAggregate(d) or 0 end
-                self.valueMap:writeValueAtWorld(x, z, math.max(0.0, math.min(1.0, current + applied)), grain * 0.5)
-            end
+        if px == nil then
+            -- Slice 1: an unresolved member pixel is refused rather than swallowed
+            -- into a fabricated pixel id. Preserving it as an UNRESOLVED positional
+            -- leaf (finite world coords + source grain) is a later SCS-039 slice.
+            return false
         end
-        -- The field aggregate is re-derived from the map on the daily settle;
-        -- a single pixel's gain is below the noise of the field mean until then.
-        return
+        local fieldAcc = self._mapWaterPending[fieldId]
+        if fieldAcc == nil then fieldAcc = {}; self._mapWaterPending[fieldId] = fieldAcc end
+        local key = px * 4096 + pz
+        local pending = (fieldAcc[key] or 0) + gain
+        local applied, remainder = CropStressValueMap.quantiseDelta(pending)
+        fieldAcc[key] = remainder
+        if applied ~= 0 then
+            local grain = self.valueMap:getGrainMetres() or 2
+            local current = self.valueMap:readValueAtWorld(x, z)
+            if current == nil then current = self:getFieldAggregate(d) or 0 end
+            self.valueMap:writeValueAtWorld(x, z, math.max(0.0, math.min(1.0, current + applied)), grain * 0.5)
+            -- A whole-raw-step spend moved readable ground: advance the revision.
+            self:_advanceMoistureRevision()
+        end
+        -- Accepted. The field aggregate is re-derived from the map on the daily
+        -- settle; a single pixel's gain is below the field-mean noise until then.
+        return true
     end
 
     local cx, cz = self:worldToCell(x, z)
     local row = d.cells[cx]
     if row == nil then
-        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return end
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return false end
         row = {}
         d.cells[cx] = row
     end
     local cell = row[cz]
     if cell == nil then
-        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return end
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return false end
         cell = { moisture = self:getFieldAggregate(d) }
         row[cz] = cell
         d.cellCount = d.cellCount + 1
@@ -956,6 +1027,10 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
     -- the raw d.moisture scalar. Without this line water lands, cells rise, and
     -- every surface the player actually looks at keeps showing the old number.
     d.moisture = self:getFieldAggregate(d)
+    -- ZONE positional water moved readable ground: advance the revision and
+    -- return the accept receipt.
+    self:_advanceMoistureRevision()
+    return true
 end
 
 -- ============================================================
@@ -1371,6 +1446,11 @@ function SoilMoistureSystem:setRWMoistureSystem(rwSystem)
 end
 
 function SoilMoistureSystem:delete()
+    -- SCS-039 v2.1: release the native carrier so its engine handle is freed and a
+    -- teardown or same-process reload starts from a clean map, not a stale one.
+    if self.valueMap ~= nil and self.valueMap.delete ~= nil then
+        self.valueMap:delete()
+    end
     self.isInitialized = false
 end
 

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -716,13 +716,21 @@ function SoilMoistureSystem:getMoisture(fieldId, x, z)
 
     if x ~= nil and z ~= nil then
         if self:mapActive() then
-            local v, grain = self.valueMap:readValueAtWorld(x, z)
-            -- A written pixel answers with its ACTUAL carrier grain.
+            -- SCS-039 v2.1 (SDS 3.2/3.3): the point read is TYPED. A written
+            -- pixel answers with its ACTUAL carrier grain; a benign unwritten or
+            -- out-of-range pixel keeps the aggregate fallback at nil grain; a
+            -- genuine native refusal (pcall threw) fails the provider closed for
+            -- the mission, exactly like the polygon-aggregate refusal.
+            local v, grain, outcome = self.valueMap:readValueAtWorld(x, z)
             if v ~= nil then return v, grain, rev end
-            -- In-domain but unwritten: the NATIVE field aggregate answers, at nil
-            -- grain (it is not a local reading). Never the retained zone cells.
-            self:_refreshFieldAggregate(fieldId, d)
-            return d.moisture, nil, rev
+            if outcome == "PROVIDER_REFUSAL" then
+                self:_failNativeClosed("native point-read refusal")
+                -- Fall through to the retained cell store below, which answers
+                -- exactly as a ZONE read would for the rest of the mission.
+            else
+                self:_refreshFieldAggregate(fieldId, d)
+                return d.moisture, nil, rev
+            end
         end
         local cx, cz = self:worldToCell(x, z)
         local row = d.cells and d.cells[cx]

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -428,6 +428,18 @@ function SoilMoistureSystem:initialize()
         self.manager.eventBus.subscribe("CS_IRRIGATION_STOPPED", self.onIrrigationStopped, self)
     end
 
+    -- SCS-039 v2.1 (SDS 3.4): server-side farmland ownership change revalidates
+    -- pending positional membership. The engine installs the new ownership and
+    -- publishes (farmlandId, farmId, loadFromSavegame) after it, which is when
+    -- our cached field polygons go stale. Subscription is capability-guarded so
+    -- an engine without the message (or a client peer) never subscribes.
+    if g_server ~= nil and g_messageCenter ~= nil and MessageType ~= nil
+       and MessageType.FARMLAND_OWNER_CHANGED ~= nil
+       and g_messageCenter.subscribe ~= nil then
+        g_messageCenter:subscribe(MessageType.FARMLAND_OWNER_CHANGED, self.onFarmlandOwnerChanged, self)
+        self._farmlandSubscribed = true
+    end
+
     self.isInitialized = true
 end
 
@@ -1669,6 +1681,139 @@ function SoilMoistureSystem:unpackMapWaterPendingString(packed)
     return self:unpackMapWaterPending(rows)
 end
 
+-- ============================================================
+-- SCS-039 v2.1 GEOMETRY-CHANGE RE-KEY (SDS 3.4 tail, slice 9)
+--
+-- On a farmland ownership/geometry change the engine installs the new state and
+-- publishes FARMLAND_OWNER_CHANGED. Our cached field polygons go stale, so the
+-- handler invalidates them and revalidates every pending positional leaf against
+-- the CURRENT geometry. Accepted water is never lost and never moves by
+-- identifier accident: a leaf re-keys only when exactly one current field owns
+-- its world position. Ambiguous or missing membership stays an UNRESOLVED
+-- world leaf (a resolved pixel leaf whose membership vanished is demoted to
+-- one), so it is never applied to the wrong field.
+-- ============================================================
+
+--- Ordered polygon fingerprint for a field, as a stable string of the vertex
+--- world coordinates. Two equal polygons produce equal strings; a geometry
+--- change changes the string (the SDS 3.6 daily-plan pinning compares these).
+--- nil when the field has no resolvable polygon.
+function SoilMoistureSystem:fieldGeometryFingerprint(fieldId)
+    local vx, vz, n = self:_getFieldVerts(fieldId)
+    if vx == nil then return nil end
+    local parts = {}
+    for i = 1, n do
+        parts[i] = string.format("%.2f,%.2f", vx[i], vz[i])
+    end
+    return table.concat(parts, ";")
+end
+
+--- Exactly one current field contains the world position, else nil. A field
+--- whose polygon cannot be resolved (deleted farmland still in fieldData) can
+--- never own a point, and a point inside two fields is ambiguous, so neither
+--- answers.
+function SoilMoistureSystem:_uniqueFieldOwnerAt(worldX, worldZ)
+    local owner, count = nil, 0
+    for fieldId in pairs(self.fieldData) do
+        local vx, vz, n = self:_getFieldVerts(fieldId)
+        if vx ~= nil and csPointInPolygon(worldX, worldZ, vx, vz, n) then
+            count = count + 1
+            owner = fieldId
+        end
+    end
+    if count == 1 then return owner end
+    return nil
+end
+
+--- Revalidate every pending positional leaf against current field geometry and
+--- re-key the ones that now belong to a different field. Returns the number of
+--- leaves whose home changed (bucket move or a resolved demotion to unresolved).
+function SoilMoistureSystem:rekeyPositionalWaterForOwnership()
+    if type(self._mapWaterPending) ~= "table" then return 0 end
+
+    local m = self.valueMap
+    local hasPixelMap = m ~= nil and m.available == true
+        and type(m.resolution) == "number" and m.resolution > 0
+        and type(m.terrainSize) == "number" and m.terrainSize > 0
+    local function pixelToWorld(px, pz)
+        local g = m.terrainSize / m.resolution
+        local half = m.terrainSize * 0.5
+        return (px + 0.5) * g - half, (pz + 0.5) * g - half, g
+    end
+
+    local newStore = {}
+    local moved = 0
+    for fieldId, acc in pairs(self._mapWaterPending) do
+        for key, value in pairs(acc) do
+            local isResolved = type(key) == "number"
+            local amount = isResolved and value or (value ~= nil and value.amount) or 0
+            if amount == 0 then
+                -- Zero carries no water; pack never emits it, and re-key need not
+                -- preserve an empty remainder.
+            else
+                local worldX, worldZ, grain = nil, nil, nil
+                if isResolved then
+                    if not hasPixelMap then
+                        -- A resolved remainder without the map cannot be
+                        -- reconstructed to a world position: keep it exactly
+                        -- where it is rather than guess at a home.
+                        local acc2 = newStore[fieldId]
+                        if acc2 == nil then acc2 = {}; newStore[fieldId] = acc2 end
+                        acc2[key] = value
+                    else
+                        local px = math.floor(key / 4096)
+                        local pz = key - px * 4096
+                        worldX, worldZ, grain = pixelToWorld(px, pz)
+                    end
+                else
+                    worldX, worldZ = value.worldX, value.worldZ
+                    grain = value.sourceWidth
+                end
+                if worldX == nil then
+                    -- handled above for the no-map resolved case
+                else
+                    local owner = self:_uniqueFieldOwnerAt(worldX, worldZ)
+                    local destField = owner or fieldId
+                    local demote = (owner == nil and isResolved)
+                    if destField ~= fieldId or demote then moved = moved + 1 end
+                    local acc2 = newStore[destField]
+                    if acc2 == nil then acc2 = {}; newStore[destField] = acc2 end
+                    if isResolved and not demote then
+                        acc2[key] = (acc2[key] or 0) + amount
+                    else
+                        local leafKey = "WORLD:" .. tostring(worldX) .. "," .. tostring(worldZ)
+                        local leaf = acc2[leafKey]
+                        if leaf == nil then
+                            leaf = { status = "UNRESOLVED", worldX = worldX, worldZ = worldZ,
+                                     sourceWidth = grain, amount = 0 }
+                            acc2[leafKey] = leaf
+                        end
+                        leaf.amount = leaf.amount + amount
+                    end
+                end
+            end
+        end
+    end
+    self._mapWaterPending = newStore
+    return moved
+end
+
+--- Farmland ownership/geometry change handler (server). The engine installs the
+--- new ownership before publishing, which is exactly when our cached field
+--- polygons become stale. Replays during load (loadFromSavegame) only invalidate
+--- caches; the load door restores a fresh pending store afterwards, so re-keying
+--- now would run against the previous mission's leaves.
+function SoilMoistureSystem:onFarmlandOwnerChanged(farmlandId, farmId, loadFromSavegame)
+    if g_server == nil then return end
+    self._fieldVerts = {}
+    if loadFromSavegame then return end
+    local moved = self:rekeyPositionalWaterForOwnership()
+    if moved > 0 and csLog ~= nil then
+        csLog(string.format("Moisture: farmland change re-keyed %d positional water leaves (field %s)",
+            moved, tostring(farmlandId)))
+    end
+end
+
 -- Returns a sorted list of {fieldId, moisture, soilType} for HUD display
 function SoilMoistureSystem:getFieldsSortedByMoisture()
     local list = {}
@@ -1737,6 +1882,12 @@ function SoilMoistureSystem:delete()
     if self.valueMap ~= nil and self.valueMap.delete ~= nil then
         self.valueMap:delete()
     end
+    -- SCS-039 v2.1 (SDS 3.4): drop the farmland-ownership subscription so a
+    -- same-process reload does not keep a stale handler attached to the mission.
+    if g_messageCenter ~= nil and g_messageCenter.unsubscribeAll ~= nil then
+        g_messageCenter:unsubscribeAll(self)
+    end
+    self._farmlandSubscribed = false
     self.isInitialized = false
 end
 

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -572,6 +572,11 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours, posit
     local sfHasEvap   = sfInteg ~= nil and type(sfInteg.getFieldEvapMod)   == "function"
     local sfHasStress = sfInteg ~= nil and type(sfInteg.getFieldStressMod) == "function"
 
+    -- SCS-039 v2.1 (Iris fix): one provider revision advance per hourly act that
+    -- actually changed readable moisture. A pending-only sub-step remainder
+    -- never advances it.
+    local readableChanged = false
+
     for fieldId, data in pairs(self.fieldData) do
         local soilParams = SoilMoistureSystem.SOIL_PARAMS[data.soilType]
             or SoilMoistureSystem.SOIL_PARAMS.loamy
@@ -650,6 +655,7 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours, posit
                         -- The daily settle re-derives from the map and corrects
                         -- any drift the positional writes introduce.
                         data.moisture = math.max(0.0, math.min(1.0, data.moisture + moved))
+                        readableChanged = true
                     end
                 end
             end
@@ -664,9 +670,12 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours, posit
             end
             data.cellSum = newSum
             data.moisture = newSum / data.cellCount
+            if net ~= 0 then readableChanged = true end
         else
+            local net = -evapLoss + rainGain + irrigGain
             data.moisture = math.max(0.0, math.min(1.0,
                 data.moisture - evapLoss + rainGain + irrigGain))
+            if net ~= 0 then readableChanged = true end
         end
 
         -- Publish moisture update event
@@ -711,6 +720,11 @@ function SoilMoistureSystem:hourlyUpdate(weather, elapsedHours, rainHours, posit
             ))
         end
     end
+    -- SCS-039 v2.1 (Iris fix 4): a readable hourly mutation advances the provider
+    -- revision once per transaction; a pending-only remainder never does.
+    if readableChanged then
+        self:_advanceMoistureRevision()
+    end
 end
 
 -- Returns moisture (0.0–1.0) for a field, or nil if unknown.
@@ -731,29 +745,45 @@ function SoilMoistureSystem:getMoisture(fieldId, x, z)
     local d = self.fieldData[fieldId]
     if d == nil then return nil, nil, rev end
 
+    -- SCS-039 v2.1 (Iris fix): a POSITIONAL query needs BOTH coordinates as
+    -- finite numbers. Mixed nil coordinates and non-finite input are rejected,
+    -- never silently downgraded to a field query.
+    if (x ~= nil) ~= (z ~= nil) then return nil, nil, rev end
+    if x ~= nil and (type(x) ~= "number" or x ~= x or math.abs(x) == math.huge
+        or type(z) ~= "number" or z ~= z or math.abs(z) == math.huge) then
+        return nil, nil, rev
+    end
+
+    -- SCS-039 v2.1 (Iris fix): a native provider that has failed closed for the
+    -- mission answers UNAVAILABLE. Its retained zone cells and cached aggregate
+    -- are never promoted as current ground, and no zone mutation may follow.
+    if self.providerMode == "UNAVAILABLE_PENDING_RELOAD" then
+        return nil, nil, rev
+    end
+
     if x ~= nil and z ~= nil then
         if self:mapActive() then
             -- SCS-039 v2.1 (SDS 3.2/3.3): the point read is TYPED. A written
             -- pixel answers with its ACTUAL carrier grain; a benign unwritten or
             -- out-of-range pixel keeps the aggregate fallback at nil grain; a
             -- genuine native refusal (pcall threw) fails the provider closed for
-            -- the mission, exactly like the polygon-aggregate refusal.
+            -- the mission and the read answers unavailable.
             local v, grain, outcome = self.valueMap:readValueAtWorld(x, z)
             if v ~= nil then return v, grain, rev end
             if outcome == "PROVIDER_REFUSAL" then
                 self:_failNativeClosed("native point-read refusal")
-                -- Fall through to the retained cell store below, which answers
-                -- exactly as a ZONE read would for the rest of the mission.
-            else
-                self:_refreshFieldAggregate(fieldId, d)
-                return d.moisture, nil, rev
+                return nil, nil, rev
             end
+            self:_refreshFieldAggregate(fieldId, d)
+            return d.moisture, nil, rev
         end
         local cx, cz = self:worldToCell(x, z)
         local row = d.cells and d.cells[cx]
         local cell = row and row[cz]
         if cell ~= nil then return cell.moisture, self:getCellSize(), rev end
-        return self:getFieldAggregate(d), self:getCellSize(), rev
+        -- SCS-039 v2.1 (Iris fix): an absent zone cell falls back to the field
+        -- aggregate at NIL grain, never a fabricated zone-cell grain.
+        return self:getFieldAggregate(d), nil, rev
     end
 
     -- Field-level read.
@@ -916,8 +946,16 @@ function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
     if self:mapActive() then
         self:migrateFieldToMap(fieldId)
         local vx, vz, n = self:_getFieldVerts(fieldId)
+        local painted = false
         if vx ~= nil then
-            self.valueMap:paintPolygon(vx, vz, n, newValue)
+            painted = self.valueMap:paintPolygon(vx, vz, n, newValue) == true
+        end
+        -- SCS-039 v2.1 (Iris fix 2): a whole-field replacement commits ONLY when
+        -- the native paint was accepted. A failed polygon binding or a thrown
+        -- native write leaves BOTH pending stores, the cached scalar and the
+        -- readable revision exactly as they were; the caller keeps the old ground.
+        if not painted then
+            return nil
         end
         -- The scalar is the derived aggregate, and a uniform paint makes the
         -- mean exactly the painted value. Any carried sub-step delta is now
@@ -953,8 +991,9 @@ end
 -- today's signature; the sprayer per-cell path calls _writeCell directly.
 function SoilMoistureSystem:setMoisture(fieldId, value)
     if self.fieldData[fieldId] ~= nil then
-        self:_writeFieldMoisture(fieldId, value)
-        return true
+        -- SCS-039 v2.1 (Iris fix 2): the receipt is the write result, so a
+        -- whole-field replacement the native paint refused reports false.
+        return self:_writeFieldMoisture(fieldId, value) ~= nil
     end
     return false
 end
@@ -1065,6 +1104,15 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
     -- SCS-023's COVER step consumes only this boolean.
     local d = self.fieldData[fieldId]
     if d == nil or type(gain) ~= "number" or gain <= 0 then return false end
+
+    -- SCS-039 v2.1 (Iris fix): a native provider that has failed closed for the
+    -- mission must never have its retained zone cells MUTATED as if they were
+    -- current ground. Accepted water is still conserved into the field-wide
+    -- pending namespace (pending-only, no revision) until the next mission load.
+    if self.providerMode == "UNAVAILABLE_PENDING_RELOAD" then
+        d.mapPending = (d.mapPending or 0) + gain
+        return true
+    end
 
     -- SCS-039: water lands on a PLACE, and on the map that place is a 2 m pixel
     -- instead of a 10-40 m cell. Read what is there, add the gain, write it back.

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -248,8 +248,13 @@ function SoilMoistureSystem:initValueMap(savegameDir)
 end
 
 --- THE SINGLE DELEGATE TEST. Read it as "is the map carrying the truth".
+--- SCS-039 v2.1 (SDS 3.3): a provider that has failed closed for the mission
+--- answers false here, so getMoisture, the overlay and every native read path
+--- detach from the fine map without the handle being nil-ed (teardown still
+--- releases the carrier). The one-way choice is only reset by the next load.
 function SoilMoistureSystem:mapActive()
     return self.valueMap ~= nil and self.valueMap.available == true
+        and self.providerMode ~= "UNAVAILABLE_PENDING_RELOAD"
 end
 
 --- Field polygon in world space, cached. The map's region ops need it on every
@@ -757,10 +762,16 @@ function SoilMoistureSystem:_refreshFieldAggregate(fieldId, d)
     if self.valueMap.readAverageOfPolygon == nil then return end
     local vx, vz, n = self:_getFieldVerts(fieldId)
     if vx == nil then return end
-    local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
-    if mean ~= nil then
+    -- SCS-039 v2.1 (SDS 3.2/3.3): typed outcome. Only OK re-derives the scalar and
+    -- clears the dirty flag; a genuine PROVIDER_REFUSAL fails the provider closed
+    -- for the mission; EMPTY and INVALID_FIELD_GEOMETRY are not refusals and leave
+    -- the last cached scalar (and the dirty flag) exactly as they were.
+    local outcome, mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
+    if outcome == "OK" then
         d.moisture = mean
         d.aggregateDirty = false
+    elseif outcome == "PROVIDER_REFUSAL" then
+        self:_failNativeClosed("polygon-aggregate refusal on field refresh")
     end
 end
 
@@ -795,6 +806,28 @@ end
 function SoilMoistureSystem:_advanceMoistureRevision()
     self.moistureRevision = (self.moistureRevision or 1) + 1
     return self.moistureRevision
+end
+
+--- SCS-039 v2.1 (SDS 3.3): a native refusal AFTER TRUTH became the current
+--- authority is a ONE-WAY transition for the rest of the mission. A native point
+--- read, valid-polygon aggregate read, region write or native save that refuses
+--- calls this one path. It changes the mode exactly once, makes the fine map
+--- non-current and detaches it from public reads and the overlay (mapActive() now
+--- answers false), HOLDS the readable revision, leaves BOTH accepted-water pending
+--- stores intact, and never promotes the retained zone cells. Only the next
+--- mission load selects a readable TRUTH or ZONE carrier again. Invalid geometry
+--- and an empty polygon are NOT provider refusals and must never call this.
+function SoilMoistureSystem:_failNativeClosed(reason)
+    if self.providerMode ~= "TRUTH" then return end   -- once only, from current TRUTH
+    self.providerMode = "UNAVAILABLE_PENDING_RELOAD"
+    self._nativeFailedReason = reason
+    -- The revision is intentionally NOT advanced and the pending stores are left
+    -- exactly as they are. The native handle is retained (not nil-ed) so teardown
+    -- can still release the carrier; mapActive() is what detaches the reads.
+    if csLog ~= nil then
+        csLog("Moisture: native provider failed closed (" .. tostring(reason) ..
+            "); reads fall to the aggregate then the cell store until the next load")
+    end
 end
 
 -- THE SINGLE WRITE PATH (SCS-018 brief 3.3): read the cell, compute, write the
@@ -1117,8 +1150,17 @@ function SoilMoistureSystem:settleDaily(boundariesCrossed)
             end
             local vx, vz, n = self:_getFieldVerts(fieldId)
             if vx ~= nil then
-                local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
-                if mean ~= nil then d.moisture = mean end
+                -- SCS-039 v2.1 (SDS 3.2/3.3): only OK re-derives the scalar. A
+                -- genuine native refusal fails the provider closed for the mission
+                -- and stops trusting the fine map this settle; EMPTY and invalid
+                -- geometry are not refusals and leave the scalar in place.
+                local outcome, mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
+                if outcome == "OK" then
+                    d.moisture = mean
+                elseif outcome == "PROVIDER_REFUSAL" then
+                    self:_failNativeClosed("polygon-aggregate refusal on daily settle")
+                    break
+                end
             end
         end
         self._lastSettleFields = fields

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -714,10 +714,10 @@ function SoilMoistureSystem:getMoisture(fieldId, x, z)
             local v, grain = self.valueMap:readValueAtWorld(x, z)
             -- A written pixel answers with its ACTUAL carrier grain.
             if v ~= nil then return v, grain, rev end
-            -- In-domain but unwritten: the field aggregate answers, and it is NOT
-            -- a local reading, so it carries NIL grain rather than the map's. A
-            -- consumer must never mistake a field mean for a 2 m local sample.
-            return self:getFieldAggregate(d), nil, rev
+            -- In-domain but unwritten: the NATIVE field aggregate answers, at nil
+            -- grain (it is not a local reading). Never the retained zone cells.
+            self:_refreshFieldAggregate(fieldId, d)
+            return d.moisture, nil, rev
         end
         local cx, cz = self:worldToCell(x, z)
         local row = d.cells and d.cells[cx]
@@ -726,8 +726,14 @@ function SoilMoistureSystem:getMoisture(fieldId, x, z)
         return self:getFieldAggregate(d), self:getCellSize(), rev
     end
 
-    -- Field-level read: the scalar is the derived aggregate either way, so the
-    -- grain reported is the field itself rather than any cell size.
+    -- Field-level read.
+    if self:mapActive() then
+        -- SCS-039 v2.1 (SDS 3.2): under the native map the field scalar is the
+        -- revisioned polygon aggregate, refreshed when a positional write marked
+        -- it dirty. It is NEVER derived from the retained zone cells.
+        self:_refreshFieldAggregate(fieldId, d)
+        return d.moisture, nil, rev
+    end
     return self:getFieldAggregate(d), nil, rev
 end
 
@@ -739,6 +745,23 @@ function SoilMoistureSystem:getFieldAggregate(d)
         return d.cellSum / d.cellCount
     end
     return d.moisture
+end
+
+--- SCS-039 v2.1 (SDS 3.2): refresh the cached native field aggregate when a
+--- positional write has marked it dirty. Under TRUTH the scalar `d.moisture`
+--- holds the polygon mean read from the map, never a mean of the zone cells. A
+--- nil native answer leaves the last cached scalar in place rather than zeroing.
+function SoilMoistureSystem:_refreshFieldAggregate(fieldId, d)
+    if not self:mapActive() then return end
+    if d.aggregateDirty == false then return end
+    if self.valueMap.readAverageOfPolygon == nil then return end
+    local vx, vz, n = self:_getFieldVerts(fieldId)
+    if vx == nil then return end
+    local mean = self.valueMap:readAverageOfPolygon(vx, vz, n)
+    if mean ~= nil then
+        d.moisture = mean
+        d.aggregateDirty = false
+    end
 end
 
 -- ============================================================
@@ -832,6 +855,8 @@ function SoilMoistureSystem:_writeFieldMoisture(fieldId, newValue)
         d.mapPending = 0
         self._mapWaterPending[fieldId] = nil
         d.moisture = newValue
+        -- A uniform paint makes the polygon mean exactly newValue: cache is clean.
+        d.aggregateDirty = false
         self:_advanceMoistureRevision()
         return newValue
     end
@@ -995,7 +1020,9 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
             local current = self.valueMap:readValueAtWorld(x, z)
             if current == nil then current = self:getFieldAggregate(d) or 0 end
             self.valueMap:writeValueAtWorld(x, z, math.max(0.0, math.min(1.0, current + applied)), grain * 0.5)
-            -- A whole-raw-step spend moved readable ground: advance the revision.
+            -- A whole-raw-step spend moved readable ground: the cached field
+            -- aggregate is now stale, and the revision advances once.
+            d.aggregateDirty = true
             self:_advanceMoistureRevision()
         end
         -- Accepted. The field aggregate is re-derived from the map on the daily
@@ -1006,13 +1033,27 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
     local cx, cz = self:worldToCell(x, z)
     local row = d.cells[cx]
     if row == nil then
-        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return false end
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then
+            -- SCS-039 v2.1 (SDS 3.4): at the relief cap we cannot materialise a new
+            -- cell, but accepted water is NEVER discarded. Keep it as field-wide
+            -- pending so a later flush can spend it once cells free up. Pending-only
+            -- does not advance the readable revision.
+            d.mapPending = (d.mapPending or 0) + gain
+            return true
+        end
         row = {}
         d.cells[cx] = row
     end
     local cell = row[cz]
     if cell == nil then
-        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then return false end
+        if (d.cellCount or 0) >= SoilMoistureSystem.CELL_BACKSTOP_CAP then
+            -- SCS-039 v2.1 (SDS 3.4): at the relief cap we cannot materialise a new
+            -- cell, but accepted water is NEVER discarded. Keep it as field-wide
+            -- pending so a later flush can spend it once cells free up. Pending-only
+            -- does not advance the readable revision.
+            d.mapPending = (d.mapPending or 0) + gain
+            return true
+        end
         cell = { moisture = self:getFieldAggregate(d) }
         row[cz] = cell
         d.cellCount = d.cellCount + 1

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -1085,16 +1085,36 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
         local key = px * 4096 + pz
         local pending = (fieldAcc[key] or 0) + gain
         local applied, remainder = CropStressValueMap.quantiseDelta(pending)
-        fieldAcc[key] = remainder
         if applied ~= 0 then
-            local grain = self.valueMap:getGrainMetres() or 2
-            local current = self.valueMap:readValueAtWorld(x, z)
+            -- SCS-039 v2.1 (SDS 3.4): debit pending only after the destination
+            -- READ and WRITE both succeed exactly. A genuine native refusal at
+            -- either point (SDS 3.3: a point-read or region-write refusal while
+            -- TRUTH is current) fails the provider closed for the mission and
+            -- keeps the FULL pre-spend amount in the pending store, so accepted
+            -- water is never lost and no false revision is minted. The water was
+            -- accepted into pending before the spend, so the receipt stays true.
+            local current, _, readOutcome = self.valueMap:readValueAtWorld(x, z)
+            if readOutcome == "PROVIDER_REFUSAL" then
+                fieldAcc[key] = pending
+                self:_failNativeClosed("native destination-read refusal on water spend")
+                return true
+            end
             if current == nil then current = self:getFieldAggregate(d) or 0 end
-            self.valueMap:writeValueAtWorld(x, z, math.max(0.0, math.min(1.0, current + applied)), grain * 0.5)
+            local grain = self.valueMap:getGrainMetres() or 2
+            local _, writeOutcome = self.valueMap:writeValueAtWorld(x, z,
+                math.max(0.0, math.min(1.0, current + applied)), grain * 0.5)
+            if writeOutcome == "PROVIDER_REFUSAL" then
+                fieldAcc[key] = pending
+                self:_failNativeClosed("native region-write refusal on water spend")
+                return true
+            end
+            fieldAcc[key] = remainder
             -- A whole-raw-step spend moved readable ground: the cached field
             -- aggregate is now stale, and the revision advances once.
             d.aggregateDirty = true
             self:_advanceMoistureRevision()
+        else
+            fieldAcc[key] = remainder
         end
         -- Accepted. The field aggregate is re-derived from the map on the daily
         -- settle; a single pixel's gain is below the field-mean noise until then.

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -187,7 +187,7 @@ function SoilMoistureSystem.new(manager)
     -- a float so it never floors; the 2 m map has 254 raw steps, so a single
     -- irrigator tick's gain (liters over the whole sector) must accumulate here
     -- and spend only whole raw steps, or water lands on the map as nothing.
-    self._mapWaterPending = {} -- fieldId -> [px * 4096 + pz] -> remainder
+    self._mapWaterPending = {} -- fieldId -> resolved [px*4096+pz]=remainder | unresolved ["WORLD:x,z"]=leaf
 
     -- SCS-039 v2.1: the persisted server integer that stamps every readable
     -- moisture answer. Advanced ONCE per successful readable mutation (native or
@@ -1004,10 +1004,25 @@ function SoilMoistureSystem:applyWaterAtCell(fieldId, x, z, gain)
         self:migrateFieldToMap(fieldId)
         local px, pz = self.valueMap:worldToPixel(x, z)
         if px == nil then
-            -- Slice 1: an unresolved member pixel is refused rather than swallowed
-            -- into a fabricated pixel id. Preserving it as an UNRESOLVED positional
-            -- leaf (finite world coords + source grain) is a later SCS-039 slice.
-            return false
+            -- SCS-039 v2.1 (SDS 3.4): a member position whose native pixel cannot
+            -- yet resolve is NOT dropped. Accepted water is never lost. Keep it as
+            -- an UNRESOLVED positional leaf keyed by canonical world coordinates
+            -- (never a fabricated pixel id) and carrying the source grain, so a
+            -- later membership revalidation can re-key it onto a real pixel. This
+            -- is pending-only: the readable revision does not advance.
+            -- (Deterministic persistence + geometry-change re-key are a later slice.)
+            local grain = (type(self.valueMap.getGrainMetres) == "function"
+                and self.valueMap:getGrainMetres()) or 2
+            local fieldAcc = self._mapWaterPending[fieldId]
+            if fieldAcc == nil then fieldAcc = {}; self._mapWaterPending[fieldId] = fieldAcc end
+            local leafKey = "WORLD:" .. x .. "," .. z
+            local leaf = fieldAcc[leafKey]
+            if leaf == nil then
+                leaf = { status = "UNRESOLVED", worldX = x, worldZ = z, sourceWidth = grain, amount = 0 }
+                fieldAcc[leafKey] = leaf
+            end
+            leaf.amount = leaf.amount + gain
+            return true
         end
         local fieldAcc = self._mapWaterPending[fieldId]
         if fieldAcc == nil then fieldAcc = {}; self._mapWaterPending[fieldId] = fieldAcc end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -187,6 +187,11 @@ function SoilMoistureSystem.new(manager)
     -- a float so it never floors; the 2 m map has 254 raw steps, so a single
     -- irrigator tick's gain (liters over the whole sector) must accumulate here
     -- and spend only whole raw steps, or water lands on the map as nothing.
+    -- Two key kinds coexist without collision (SDS 3.4):
+    --   resolved    [px*4096+pz] (a number)      = sub-step remainder
+    --   unresolved  ["WORLD:x,z"] (a string)     = {status, worldX, worldZ,
+    --                                               sourceWidth, amount} leaf
+    -- packMapWaterPending / unpackMapWaterPending persist both deterministically.
     self._mapWaterPending = {} -- fieldId -> resolved [px*4096+pz]=remainder | unresolved ["WORLD:x,z"]=leaf
 
     -- SCS-039 v2.1: the persisted server integer that stamps every readable
@@ -1522,6 +1527,146 @@ function SoilMoistureSystem:unpackCells(fieldId, packed)
     -- Sibling of the F1 path: rebuilding cells on load moves the aggregate, so the
     -- scalar has to follow or a reloaded save paints the pre-save number.
     d.moisture = self:getFieldAggregate(d)
+end
+
+-- ============================================================
+-- SCS-039 v2.1 POSITIONAL PENDING PERSISTENCE (SDS 3.4 tail, slice 8)
+--
+-- The accepted-water store (_mapWaterPending) held resolved pixel remainders and
+-- UNRESOLVED world leaves in-mission only; slice 3 preserved the leaves until a
+-- reload but nothing wrote them to the save. These seams pack the store into a
+-- deterministic ordered row list (and a string form for the own-XML path) so no
+-- accepted water is lost across save and reload. The rows are what the later
+-- SDS 3.5 compact envelope will pack, so this is not throwaway work.
+--
+-- ORDER (SDS 3.4): resolved leaves ascend by field id then pixel key, then
+-- unresolved leaves ascend by field id then canonical world coordinates. Only
+-- non-zero amounts are emitted and there is no 1024-entry ceiling (Group C).
+-- ============================================================
+
+--- Pack the whole positional pending store into a deterministic row array.
+---@return table rows  {fieldId, status, ...} sorted; empty array when nothing
+---  is pending. RESOLVED rows carry pixelKey + amount; UNRESOLVED rows carry
+---  worldX, worldZ, sourceWidth + amount.
+function SoilMoistureSystem:packMapWaterPending()
+    local rows = {}
+    if type(self._mapWaterPending) ~= "table" then return rows end
+    local fieldIds = {}
+    for fieldId in pairs(self._mapWaterPending) do fieldIds[#fieldIds + 1] = fieldId end
+    table.sort(fieldIds)
+    for i = 1, #fieldIds do
+        local fieldId = fieldIds[i]
+        local acc = self._mapWaterPending[fieldId]
+        local resolved, unresolved = {}, {}
+        for key, value in pairs(acc or {}) do
+            if type(key) == "number" then
+                if value ~= nil and value ~= 0 then
+                    resolved[#resolved + 1] = { pixelKey = key, amount = value }
+                end
+            elseif type(key) == "string" and type(value) == "table" then
+                if value.amount ~= nil and value.amount ~= 0 then
+                    unresolved[#unresolved + 1] = {
+                        worldX = value.worldX, worldZ = value.worldZ,
+                        sourceWidth = value.sourceWidth, amount = value.amount,
+                    }
+                end
+            end
+        end
+        table.sort(resolved, function(a, b) return a.pixelKey < b.pixelKey end)
+        table.sort(unresolved, function(a, b)
+            local ax = tostring(a.worldX)
+            local az = tostring(a.worldZ)
+            local bx = tostring(b.worldX)
+            local bz = tostring(b.worldZ)
+            return ax .. "," .. az < bx .. "," .. bz
+        end)
+        for j = 1, #resolved do
+            rows[#rows + 1] = {
+                fieldId = fieldId, status = "RESOLVED",
+                pixelKey = resolved[j].pixelKey, amount = resolved[j].amount,
+            }
+        end
+        for j = 1, #unresolved do
+            rows[#rows + 1] = {
+                fieldId = fieldId, status = "UNRESOLVED",
+                worldX = unresolved[j].worldX, worldZ = unresolved[j].worldZ,
+                sourceWidth = unresolved[j].sourceWidth, amount = unresolved[j].amount,
+            }
+        end
+    end
+    return rows
+end
+
+--- Rebuild the whole positional pending store from a packMapWaterPending row
+--- array. The store is replaced, mirroring unpackCells (a load is a fresh
+--- mission store). Returns the number of leaves restored.
+function SoilMoistureSystem:unpackMapWaterPending(rows)
+    self._mapWaterPending = {}
+    if type(rows) ~= "table" then return 0 end
+    local count = 0
+    for i = 1, #rows do
+        local r = rows[i]
+        if type(r) == "table" and r.fieldId ~= nil then
+            local acc = self._mapWaterPending[r.fieldId]
+            if acc == nil then acc = {}; self._mapWaterPending[r.fieldId] = acc end
+            if r.status == "RESOLVED" and type(r.pixelKey) == "number" then
+                acc[r.pixelKey] = r.amount
+                count = count + 1
+            elseif r.status == "UNRESOLVED" and r.worldX ~= nil and r.worldZ ~= nil then
+                local leafKey = "WORLD:" .. tostring(r.worldX) .. "," .. tostring(r.worldZ)
+                acc[leafKey] = {
+                    status = "UNRESOLVED", worldX = r.worldX, worldZ = r.worldZ,
+                    sourceWidth = r.sourceWidth, amount = r.amount,
+                }
+                count = count + 1
+            end
+        end
+    end
+    return count
+end
+
+--- String form of packMapWaterPending for the own-XML save path. Rows are
+--- ';'-separated and fields '|'-separated; numbers use tostring/tonumber, so a
+--- load returns the exact same doubles the save captured. nil when empty.
+function SoilMoistureSystem:packMapWaterPendingString()
+    local rows = self:packMapWaterPending()
+    if #rows == 0 then return nil end
+    local parts = {}
+    for i = 1, #rows do
+        local r = rows[i]
+        if r.status == "RESOLVED" then
+            parts[#parts + 1] = table.concat(
+                { "R", tostring(r.fieldId), tostring(r.pixelKey), tostring(r.amount) }, "|")
+        else
+            parts[#parts + 1] = table.concat(
+                { "U", tostring(r.fieldId), tostring(r.worldX), tostring(r.worldZ),
+                  tostring(r.sourceWidth), tostring(r.amount) }, "|")
+        end
+    end
+    return table.concat(parts, ";")
+end
+
+--- Inverse of packMapWaterPendingString. Returns the number of leaves restored.
+function SoilMoistureSystem:unpackMapWaterPendingString(packed)
+    if packed == nil or packed == "" then return 0 end
+    local rows = {}
+    for part in string.gmatch(packed, "[^;]+") do
+        local fields = {}
+        for token in string.gmatch(part, "[^|]+") do fields[#fields + 1] = token end
+        if fields[1] == "R" and #fields == 4 then
+            rows[#rows + 1] = {
+                status = "RESOLVED", fieldId = tonumber(fields[2]),
+                pixelKey = tonumber(fields[3]), amount = tonumber(fields[4]),
+            }
+        elseif fields[1] == "U" and #fields == 6 then
+            rows[#rows + 1] = {
+                status = "UNRESOLVED", fieldId = tonumber(fields[2]),
+                worldX = tonumber(fields[3]), worldZ = tonumber(fields[4]),
+                sourceWidth = tonumber(fields[5]), amount = tonumber(fields[6]),
+            }
+        end
+    end
+    return self:unpackMapWaterPending(rows)
 end
 
 -- Returns a sorted list of {fieldId, moisture, soilType} for HUD display

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -830,6 +830,21 @@ function SoilMoistureSystem:_failNativeClosed(reason)
     end
 end
 
+--- SCS-039 v2.1 (SDS 3.3): the native-save call site. saveToSavegame already
+--- requires the engine's inner true (slice 1); this routes its refusal through
+--- the one fail-closed path so a save that never reached disk cannot leave the
+--- mission still trusting the fine map. The per-field scalar rows the save
+--- handler writes next are the honest degrade layer, and the next load re-selects
+--- a readable TRUTH or ZONE carrier. Returns the literal save receipt.
+function SoilMoistureSystem:saveNativeMap(savegameDir)
+    if self.valueMap == nil or not self.valueMap.available then return false end
+    local savedOk = self.valueMap:saveToSavegame(savegameDir) == true
+    if not savedOk then
+        self:_failNativeClosed("native save refusal")
+    end
+    return savedOk
+end
+
 -- THE SINGLE WRITE PATH (SCS-018 brief 3.3): read the cell, compute, write the
 -- cell, adjust the field's running sum by the delta, in that order. All eight
 -- simulation doors fold through here. Returns the new aggregate.

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -292,22 +292,33 @@ end
 --- Write a value over a square region centred on a world position.
 --- `radius` is in metres; it floors to one pixel so a point write is never a
 --- no-op on a coarse map.
+--- SCS-039 v2.1 (SDS 3.3/3.4): the second return is a TYPED outcome, so a caller
+--- can tell a genuine native region-write refusal (the execute threw) from a
+--- benign no-op (map not carrying the data). Only a refusal fails the provider
+--- closed; NOOP leaves the carrier untouched. Returns: wrote, outcome.
+---   "PROVIDER_REFUSAL" - the native region write threw
+---   "NOOP"             - nothing attempted (map absent, no modifier)
+---   "OK"               - the region write executed
+---@return boolean wrote   true only when the native execute ran
+---@return string outcome  one of the typed outcomes above
 function CropStressValueMap:writeValueAtWorld(worldX, worldZ, value, radius)
-    if not self.available then return false end
+    if not self.available then return false, "NOOP" end
     local grain = self:getGrainMetres() or 2
     local r = math.max(radius or 0, grain * 0.5)
     local raw = encode(value, CropStressValueMap.LAYER_DEF)
     return self:_setRegion(worldX - r, worldZ - r, worldX + r, worldZ + r, raw)
 end
 
+---@return boolean wrote, string outcome (see writeValueAtWorld)
 function CropStressValueMap:_setRegion(x0, z0, x1, z1, raw)
     local m = self.modifier
-    if m == nil then return false end
+    if m == nil then return false, "NOOP" end
     local ok = pcall(function()
         m:setParallelogramWorldCoords(x0, z0, x1, z0, x0, z1, DensityCoordType.POINT_POINT_POINT)
         m:executeSet(raw)
     end)
-    return ok
+    if not ok then return false, "PROVIDER_REFUSAL" end
+    return true, "OK"
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -378,10 +378,25 @@ end
 ---@return number|nil mean   0..1, nil when nothing is written in the polygon
 ---@return number|nil grain  metres per pixel (the concordance)
 function CropStressValueMap:readAverageOfPolygon(vx, vz, n)
-    if not self.available then return nil, nil end
+    -- SCS-039 v2.1 (SDS 3.2/3.3): TYPED outcomes, so a caller can tell a genuine
+    -- native provider refusal (which fails the provider closed for the mission)
+    -- apart from a malformed polygon or a valid-but-empty one; neither of the
+    -- latter is a refusal. Returns: outcome, mean, grain.
+    --   "INVALID_FIELD_GEOMETRY" - malformed polygon; the caller rebuilds context
+    --   "PROVIDER_REFUSAL"       - the native provider did not answer
+    --   "EMPTY"                  - a valid polygon with zero written pixels
+    --   "OK"                     - the mean over the written pixels
+    if vx == nil or vz == nil or n == nil or n < 3 then
+        return "INVALID_FIELD_GEOMETRY", nil, nil
+    end
+    if not self.available then return "PROVIDER_REFUSAL", nil, nil end
     local m = self.modifier
-    if m == nil or m.executeGet == nil then return nil, nil end
-    if not self:_setPolygonRegion(vx, vz, n) then return nil, nil end
+    if m == nil or m.executeGet == nil then return "PROVIDER_REFUSAL", nil, nil end
+    if not self:_setPolygonRegion(vx, vz, n) then
+        -- Geometry is already validated, so a bind failure here is the provider
+        -- (polygon ops unavailable, or a native throw), not bad geometry.
+        return "PROVIDER_REFUSAL", nil, nil
+    end
     -- executeGet returns (accumulator, numPixels, totalArea), confirmed at the
     -- decompile: PrecisionFarming NitrogenMap.lua:1034 reads it as
     -- `local acc, numPixels, _ = modifierFruit:executeGet()`. The mean we want
@@ -389,10 +404,13 @@ function CropStressValueMap:readAverageOfPolygon(vx, vz, n)
     local ok, acc, numPixels = pcall(function()
         return m:executeGet()
     end)
-    if not ok or acc == nil or numPixels == nil or numPixels == 0 then
-        return nil, nil
+    if not ok or acc == nil or numPixels == nil then
+        return "PROVIDER_REFUSAL", nil, nil
     end
-    return decode(acc / numPixels, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
+    if numPixels == 0 then
+        return "EMPTY", nil, self:getGrainMetres()
+    end
+    return "OK", decode(acc / numPixels, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -234,11 +234,15 @@ function CropStressValueMap:saveToSavegame(savegameDir)
     if not self.available or savegameDir == nil then return false end
     if saveBitVectorMapToFile == nil then return false end
     local path = savegameDir .. "/" .. CropStressValueMap.LAYER_DEF.file
-    local ok = pcall(saveBitVectorMapToFile, self.bvm, path)
-    if not ok then
+    -- SCS-039 v2.1: a native mutator succeeds only when BOTH the outer pcall
+    -- survived AND the engine returned literal true. A non-throwing false return
+    -- was previously misread as a saved file, a silent data-loss report.
+    local ok, nativeResult = pcall(saveBitVectorMapToFile, self.bvm, path)
+    local success = ok and nativeResult == true
+    if not success then
         csvmLog("Moisture map: native save failed; the StateLedger scalar degrade carries this save")
     end
-    return ok
+    return success
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -250,16 +250,30 @@ end
 -- ─────────────────────────────────────────────────────────
 
 --- Read moisture at a world position.
----@return number|nil value  0..1, or nil where nothing has been written
----@return number|nil grain  metres per pixel of the reading (the concordance)
+--- SCS-039 v2.1 (SDS 3.2/3.3): the third return is a TYPED outcome, so a caller
+--- can tell a genuine native provider refusal (which fails the provider closed
+--- for the mission) apart from a benign unwritten or out-of-range position;
+--- neither of the latter is a refusal. Returns: value, grain, outcome.
+---   "PROVIDER_REFUSAL" - the native provider did not answer
+---   "OUT_OF_RANGE"     - the position maps outside the pixel grid
+---   "EMPTY"            - a resolvable pixel that has never been written
+---   "OK"               - a written pixel's decoded value
+---@return number|nil value  0..1, nil when not answered or nothing written
+---@return number|nil grain  metres per pixel (nil for refusal and out-of-range)
+---@return string outcome     one of the typed outcomes above
 function CropStressValueMap:readValueAtWorld(worldX, worldZ)
-    if not self.available then return nil, nil end
-    if getBitVectorMapPoint == nil then return nil, nil end
+    if not self.available then return nil, nil, "PROVIDER_REFUSAL" end
+    if getBitVectorMapPoint == nil then return nil, nil, "PROVIDER_REFUSAL" end
     local px, pz = self:worldToPixel(worldX, worldZ)
-    if px == nil then return nil, nil end
+    if px == nil then return nil, nil, "OUT_OF_RANGE" end
     local ok, raw = pcall(getBitVectorMapPoint, self.bvm, px, pz, 0, NUM_CHANNELS)
-    if not ok or raw == nil then return nil, nil end
-    return decode(raw, CropStressValueMap.LAYER_DEF), self:getGrainMetres()
+    -- A nil raw answer is the provider not answering, never a written pixel: an
+    -- unwritten pixel reads back the raw-0 no-data sentinel (a number), so nil
+    -- here is treated as a refusal exactly as readAverageOfPolygon treats a nil
+    -- executeGet accumulator.
+    if not ok or raw == nil then return nil, nil, "PROVIDER_REFUSAL" end
+    if raw <= 0 then return nil, self:getGrainMetres(), "EMPTY" end
+    return decode(raw, CropStressValueMap.LAYER_DEF), self:getGrainMetres(), "OK"
 end
 
 --- World position to map pixel. Terrain is centred on the origin, so the

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -60,8 +60,8 @@ local function currentSystem()
 end
 
 -- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
--- Slice 1 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A7, A9, A11 and A13 are
--- re-pointed from absence to PRESENCE against the built SCS-039 surfaces. A6, A8,
+-- Slices 1-2 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A6, A7, A8, A9, A11 and
+-- A13 are re-pointed from absence to PRESENCE against the built SCS-039 surfaces.
 -- A12 and A14 remain absence assertions for the still-unbuilt later slices, so
 -- the tripwire keeps tracking what has not landed yet.
 -- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
@@ -88,8 +88,8 @@ do
     aggregateSys.fieldData[1].cells = { [0] = { [0] = { moisture = 0.20 } } }
     aggregateSys.fieldData[1].cellSum = 0.20
     aggregateSys.fieldData[1].cellCount = 1
-    T.near("A6 current active-map aggregate still prefers retained cells",
-        aggregateSys:getMoisture(1), 0.20, 1e-12)
+    T.near("A6 BUILT: active-map field read uses the native aggregate, not retained cells",
+        aggregateSys:getMoisture(1), 0.80, 1e-12)
 
     local deleteSys = currentSystem()
     deleteSys.valueMap = currentStubMap(2)
@@ -99,9 +99,12 @@ do
     local capSys = currentSystem()
     capSys.fieldData[1].cellCount = SoilMoistureSystem.CELL_BACKSTOP_CAP
     capSys.fieldData[1].cellSum = SoilMoistureSystem.CELL_BACKSTOP_CAP * 0.60
-    capSys:applyWaterAtCell(1, 10, 10, 0.10)
-    T.eq("A8 current ZONE event water stops at the relief backstop",
+    local a8accepted = capSys:applyWaterAtCell(1, 10, 10, 0.10)
+    T.eq("A8 BUILT: ZONE water beyond the cap is accepted, not discarded", a8accepted, true)
+    T.eq("A8b the cap still limits cell materialisation",
         capSys.fieldData[1].cellCount, SoilMoistureSystem.CELL_BACKSTOP_CAP)
+    T.near("A8c over-cap ZONE water is preserved as field pending",
+        capSys.fieldData[1].mapPending, 0.10, 1e-12)
     T.eq("A9 BUILT: currentness getter exists and is false without a current TRUTH map",
         capSys:isMoistureMapCurrent(), false)
     T.eq("A10 current source exposes the 400-operation technical precedent",

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -27,7 +27,9 @@ local function currentStubMap(grain)
         return true
     end
     function m:readValueAtWorld(_x, _z)
-        return nil, self.grain
+        -- SCS-039 v2.1 typed contract: a resolvable pixel with nothing written
+        -- is EMPTY (benign), never a provider refusal.
+        return nil, self.grain, "EMPTY"
     end
     function m:worldToPixel(_x, _z) return 1, 1 end
     function m:writeValueAtWorld(_x, _z, _value, _radius) return true end
@@ -60,13 +62,14 @@ local function currentSystem()
 end
 
 -- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
--- Slices 1-4 (Fred, PENDING DESIGN REVIEW): every Group A assertion A1-A14 is now
--- re-pointed from absence to PRESENCE against the built SCS-039 surfaces. Slice 4
--- lands the native-refusal fail-closed path (A12), so no Group A tripwire remains
--- on absence. (The member is not complete: SDS 3.5-3.9 live wiring -- atomic save
--- generations, daily plan + Time Guard subscribeTick, snapshot/delta events,
--- NetworkSync compat, overlay gate -- are still later slices, modelled by the
--- pure-contract Groups B-P.)
+-- Slices 1-6 (Fred): every Group A assertion A1-A15 is now re-pointed from
+-- absence to PRESENCE against the built SCS-039 surfaces. Slice 4 lands the
+-- polygon-aggregate fail-closed path (A12); slice 6 lands the point-read
+-- fail-closed path (A15). No Group A tripwire remains on absence. (The member
+-- is not complete: SDS 3.5-3.9 live wiring, atomic save generations, daily
+-- plan + Time Guard subscribeTick, snapshot/delta events, NetworkSync compat
+-- and the overlay gate, are still later slices, modelled by the pure-contract
+-- Groups B-P.)
 -- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
 -- 893-943, 1038-1064, 1364-1366. Design corrections: SDS 3.2-3.11.
 do
@@ -140,6 +143,24 @@ do
         meanSys:isMoistureMapCurrent(), false)
     T.eq("A12c BUILT: failing closed holds the readable revision",
         meanSys.moistureRevision, a12revBefore)
+
+    -- SCS-039 slice 6 re-point: a genuine native POINT-READ refusal at the
+    -- public positional getMoisture read fails the provider closed (SDS 3.3)
+    -- instead of silently serving the retained field scalar as if the pixel
+    -- were merely unwritten. The typed readValueAtWorld outcome is what makes a
+    -- refusal distinct from a benign EMPTY/OUT_OF_RANGE pixel (A4/A5).
+    local pointSys = currentSystem()
+    pointSys.valueMap = currentStubMap(2)
+    pointSys.providerMode = "TRUTH"
+    pointSys.valueMap.readValueAtWorld = function() return nil, nil, "PROVIDER_REFUSAL" end
+    local a15revBefore = pointSys.moistureRevision
+    pointSys:getMoisture(1, 10, 10)
+    T.eq("A15 BUILT: a native point-read refusal after TRUTH fails the provider closed",
+        pointSys.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+    T.eq("A15b BUILT: the point-read failed-closed provider is no longer current",
+        pointSys:isMoistureMapCurrent(), false)
+    T.eq("A15c BUILT: point-read fail-closed holds the readable revision",
+        pointSys.moistureRevision, a15revBefore)
 
     local acceptedSys = currentSystem()
     acceptedSys.valueMap = currentStubMap(2)

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -60,10 +60,10 @@ local function currentSystem()
 end
 
 -- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
--- Slices 1-2 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A6, A7, A8, A9, A11 and
--- A13 are re-pointed from absence to PRESENCE against the built SCS-039 surfaces.
--- A12 and A14 remain absence assertions for the still-unbuilt later slices, so
--- the tripwire keeps tracking what has not landed yet.
+-- Slices 1-3 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A6, A7, A8, A9, A11, A13
+-- and A14 are re-pointed from absence to PRESENCE against the built SCS-039
+-- surfaces. A12 alone remains an absence assertion for the still-unbuilt native
+-- refusal fail-closed slice, so the tripwire keeps tracking what has not landed yet.
 -- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
 -- 893-943, 1038-1064, 1364-1366. Design corrections: SDS 3.2-3.11.
 do
@@ -139,9 +139,19 @@ do
     local unresolvedSys = currentSystem()
     unresolvedSys.valueMap = currentStubMap(2)
     unresolvedSys.valueMap.worldToPixel = function() return nil, nil end
-    unresolvedSys:applyWaterAtCell(1, 10, 10, 0.01)
-    T.eq("A14 current unresolved native pixel preserves no positional leaf",
-        unresolvedSys._mapWaterPending[1], nil)
+    local a14revBefore = unresolvedSys.moistureRevision
+    local a14accepted = unresolvedSys:applyWaterAtCell(1, 10, 10, 0.01)
+    T.eq("A14 BUILT: an unresolved native pixel accepts water instead of dropping it",
+        a14accepted, true)
+    local a14leaf = unresolvedSys._mapWaterPending[1] and unresolvedSys._mapWaterPending[1]["WORLD:10,10"]
+    T.eq("A14b BUILT: accepted water is held as an UNRESOLVED positional leaf",
+        a14leaf ~= nil and a14leaf.status or nil, "UNRESOLVED")
+    T.near("A14c BUILT: the unresolved leaf preserves the full accepted gain",
+        a14leaf and a14leaf.amount or -1, 0.01, 1e-12)
+    T.eq("A14d BUILT: the unresolved leaf records the source grain",
+        a14leaf and a14leaf.sourceWidth or nil, 2)
+    T.eq("A14e BUILT: unresolved pending-only water mints no readable revision",
+        unresolvedSys.moistureRevision, a14revBefore)
 end
 
 local Ref = {}

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -1,0 +1,1683 @@
+-- SCS-039 One Ground provider-conformance bar v10.
+--
+-- GROUP A loads the real current SCS provider and proves the correction is not
+-- built at source tip 55da7b8f87de2d9e6d77751e548be2833e9a95aa. When the
+-- implementation lands, Group A is expected to go red and instruct Stage 6A to
+-- re-point the bar at the shipped surfaces.
+--
+-- GROUPS B through P model the pure contract fixed by SCS-039-SDS.md v2.1.
+-- They cannot prove engine bit-vector behavior, save-file atomicity, rendering,
+-- multiplayer delivery, frame time, memory, or runtime event ordering.
+--
+-- All decimal values, field IDs, pixel keys, row counts and work budgets below
+-- are synthetic branch-distinguishing probes, not production constants. The
+-- governing invariants are cited to the SDS beside each group.
+--!load: src/maps/CropStressValueMap.lua, src/SoilMoistureSystem.lua
+
+local function currentStubMap(grain)
+    local m = {
+        available = true,
+        grain = grain,
+        painted = {},
+        deleted = 0,
+    }
+    function m:getGrainMetres() return self.grain end
+    function m:paintPolygon(_vx, _vz, _n, value)
+        self.painted[#self.painted + 1] = value
+        return true
+    end
+    function m:readValueAtWorld(_x, _z)
+        return nil, self.grain
+    end
+    function m:worldToPixel(_x, _z) return 1, 1 end
+    function m:writeValueAtWorld(_x, _z, _value, _radius) return true end
+    function m:delete()
+        self.deleted = self.deleted + 1
+        self.available = false
+    end
+    return m
+end
+
+local function currentSystem()
+    local sys = SoilMoistureSystem.new({})
+    sys.isInitialized = true
+    sys.fieldData[1] = {
+        fieldId = 1,
+        moisture = 0.60,
+        soilType = "loamy",
+        cells = {},
+        cellSum = 0,
+        cellCount = 0,
+        reliefScan = true,
+    }
+    sys._fieldVerts[1] = {
+        vx = {0, 100, 100, 0},
+        vz = {0, 0, 100, 100},
+        n = 4,
+    }
+    sys._mapSeeded[1] = true
+    return sys
+end
+
+-- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
+-- Slice 1 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A7, A9, A11 and A13 are
+-- re-pointed from absence to PRESENCE against the built SCS-039 surfaces. A6, A8,
+-- A12 and A14 remain absence assertions for the still-unbuilt later slices, so
+-- the tripwire keeps tracking what has not landed yet.
+-- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
+-- 893-943, 1038-1064, 1364-1366. Design corrections: SDS 3.2-3.11.
+do
+    local sys = currentSystem()
+    T.eq("A1 BUILT: provider persists a moistureRevision starting at 1", sys.moistureRevision, 1)
+
+    sys.valueMap = currentStubMap(2)
+    sys._mapWaterPending[1] = { [4097] = 0.001 }
+    T.eq("A2 current whole-field replacement is accepted", sys:setMoisture(1, 0.80), true)
+    T.eq("A3 BUILT: whole-field replacement clears the positional pending store",
+        sys._mapWaterPending[1], nil)
+
+    local readSys = currentSystem()
+    readSys.valueMap = currentStubMap(2)
+    local v, grain = readSys:getMoisture(1, 10, 10)
+    T.near("A4 current unwritten map point falls back to aggregate", v, 0.60, 1e-12)
+    T.eq("A5 BUILT: unwritten map pixel falls back to aggregate at nil grain", grain, nil)
+
+    local aggregateSys = currentSystem()
+    aggregateSys.valueMap = currentStubMap(2)
+    aggregateSys.fieldData[1].moisture = 0.80
+    aggregateSys.fieldData[1].cells = { [0] = { [0] = { moisture = 0.20 } } }
+    aggregateSys.fieldData[1].cellSum = 0.20
+    aggregateSys.fieldData[1].cellCount = 1
+    T.near("A6 current active-map aggregate still prefers retained cells",
+        aggregateSys:getMoisture(1), 0.20, 1e-12)
+
+    local deleteSys = currentSystem()
+    deleteSys.valueMap = currentStubMap(2)
+    deleteSys:delete()
+    T.eq("A7 BUILT: teardown releases the native map", deleteSys.valueMap.deleted, 1)
+
+    local capSys = currentSystem()
+    capSys.fieldData[1].cellCount = SoilMoistureSystem.CELL_BACKSTOP_CAP
+    capSys.fieldData[1].cellSum = SoilMoistureSystem.CELL_BACKSTOP_CAP * 0.60
+    capSys:applyWaterAtCell(1, 10, 10, 0.10)
+    T.eq("A8 current ZONE event water stops at the relief backstop",
+        capSys.fieldData[1].cellCount, SoilMoistureSystem.CELL_BACKSTOP_CAP)
+    T.eq("A9 BUILT: currentness getter exists and is false without a current TRUTH map",
+        capSys:isMoistureMapCurrent(), false)
+    T.eq("A10 current source exposes the 400-operation technical precedent",
+        SoilMoistureSystem.MAP_DRAIN_MAX_BLOCKS, 400)
+
+    -- SCS-039 slice 1 re-point: saveToSavegame now requires the engine's inner
+    -- true, so a non-throwing false native return is reported as a failed save
+    -- rather than silently mistaken for a written file.
+    local originalNativeSave = saveBitVectorMapToFile
+    saveBitVectorMapToFile = function() return false end
+    local nativeSaveMap = setmetatable({ available = true, bvm = 1 }, { __index = CropStressValueMap })
+    T.eq("A11 BUILT: native save reports the engine's false result rather than faking success",
+        nativeSaveMap:saveToSavegame("synthetic-save-root"), false)
+    saveBitVectorMapToFile = originalNativeSave
+
+    -- SoilMoistureSystem.lua:978-982 retains the old scalar for every nil mean,
+    -- while CropStressValueMap.lua:376-391 collapses invalid, empty and refusal.
+    local meanSys = currentSystem()
+    meanSys.valueMap = currentStubMap(2)
+    meanSys._drainFieldOnMap = function() return false end
+    meanSys.valueMap.readAverageOfPolygon = function() return nil, nil end
+    meanSys.fieldData[1].moisture = 0.61
+    meanSys:settleDaily(1)
+    T.near("A12 current polygon refusal silently retains the prior field scalar",
+        meanSys.fieldData[1].moisture, 0.61, 1e-12)
+
+    local acceptedSys = currentSystem()
+    acceptedSys.valueMap = currentStubMap(2)
+    T.eq("A13 BUILT: map-path acceptance returns a literal accept receipt",
+        acceptedSys:applyWaterAtCell(1, 10, 10, 0.001), true)
+
+    local unresolvedSys = currentSystem()
+    unresolvedSys.valueMap = currentStubMap(2)
+    unresolvedSys.valueMap.worldToPixel = function() return nil, nil end
+    unresolvedSys:applyWaterAtCell(1, 10, 10, 0.01)
+    T.eq("A14 current unresolved native pixel preserves no positional leaf",
+        unresolvedSys._mapWaterPending[1], nil)
+end
+
+local Ref = {}
+
+function Ref.new(revision)
+    return {
+        revision = revision,
+        mapPending = {},
+        pixelPending = {},
+        deltas = {},
+        values = {},
+    }
+end
+
+function Ref.pendingOnly(state, fieldId, amount)
+    state.mapPending[fieldId] = (state.mapPending[fieldId] or 0) + amount
+    return state.revision
+end
+
+function Ref.readableWrite(state, key, value)
+    state.values[key] = value
+    state.revision = state.revision + 1
+    return state.revision
+end
+
+function Ref.adoptServerRevision(state, revision)
+    state.revision = revision
+    return state.revision
+end
+
+function Ref.read(kind, localValue, aggregateValue, grain, revision)
+    if kind == "outside" or kind == "unavailable" then
+        return nil, nil, revision
+    elseif kind == "local" then
+        return localValue, grain, revision
+    end
+    return aggregateValue, nil, revision
+end
+
+-- GROUP B: ADDITIVE READ AND REVISION CONTRACT.
+-- SDS v2.1 sections 3.2 and 3.3.
+do
+    local state = Ref.new(7)
+    T.eq("B1 pending-only input keeps readable revision", Ref.pendingOnly(state, 1, 0.001), 7)
+    T.eq("B2 readable mutation advances once", Ref.readableWrite(state, 101, 0.42), 8)
+    T.eq("B3 client receipt adopts and does not mint", Ref.adoptServerRevision(state, 23), 23)
+
+    local v, grain, revision = Ref.read("local", 0.42, 0.60, 2, 23)
+    T.near("B4 local read keeps value", v, 0.42, 1e-12)
+    T.eq("B5 local read keeps positive carrier grain", grain, 2)
+    T.eq("B6 local read carries provider revision", revision, 23)
+
+    v, grain, revision = Ref.read("aggregate", nil, 0.60, 2, 23)
+    T.near("B7 aggregate read keeps value", v, 0.60, 1e-12)
+    T.eq("B8 aggregate read carries no false local grain", grain, nil)
+    T.eq("B9 aggregate read carries provider revision", revision, 23)
+
+    v, grain, revision = Ref.read("outside", 0.42, 0.60, 2, 23)
+    T.eq("B10 outside read is unavailable value", v, nil)
+    T.eq("B11 outside read is unavailable grain", grain, nil)
+    T.eq("B12 unavailable read may still identify current provider revision", revision, 23)
+end
+
+local function clearForReplacement(state, fieldId, replacement)
+    state.mapPending[fieldId] = nil
+    state.pixelPending[fieldId] = nil
+    state.deltas[fieldId] = nil
+    state.values[fieldId] = replacement
+    state.revision = state.revision + 1
+end
+
+local function packPixelPending(pixelPending)
+    local rows = {}
+    for fieldId, pixels in pairs(pixelPending) do
+        for pixelKey, amount in pairs(pixels) do
+            if amount ~= 0 then
+                rows[#rows + 1] = { fieldId = fieldId, pixelKey = pixelKey, amount = amount }
+            end
+        end
+    end
+    table.sort(rows, function(a, b)
+        if a.fieldId ~= b.fieldId then return a.fieldId < b.fieldId end
+        return a.pixelKey < b.pixelKey
+    end)
+    return rows
+end
+
+local function unpackPixelPending(rows)
+    local out = {}
+    for _, row in ipairs(rows) do
+        out[row.fieldId] = out[row.fieldId] or {}
+        out[row.fieldId][row.pixelKey] = row.amount
+    end
+    return out
+end
+
+local function pendingTotal(pixelPending)
+    local total = 0
+    for _, pixels in pairs(pixelPending) do
+        for _, amount in pairs(pixels) do total = total + amount end
+    end
+    return total
+end
+
+-- GROUP C: BOTH PENDING STORES SURVIVE OR CLEAR TOGETHER.
+-- SDS v2.1 sections 3.5 and 3.6.
+do
+    local state = Ref.new(40)
+    state.mapPending[3] = 0.002
+    state.pixelPending[3] = { [9] = 0.001, [2] = 0.003 }
+    state.deltas[3] = { old = 0.40 }
+    clearForReplacement(state, 3, 0.75)
+    T.eq("C1 replacement clears field-wide pending", state.mapPending[3], nil)
+    T.eq("C2 replacement clears positional pending", state.pixelPending[3], nil)
+    T.eq("C3 replacement publishes one revision", state.revision, 41)
+    T.eq("C3b replacement supersedes queued older field deltas", state.deltas[3], nil)
+
+    local source = {
+        [2] = { [11] = 0.00125, [4] = 0.00250 },
+        [1] = { [8] = -0.00075 },
+    }
+    local packed = packPixelPending(source)
+    T.eq("C4 sparse packing keeps every non-zero entry", #packed, 3)
+    T.eq("C5 sparse packing is deterministic by field", packed[1].fieldId, 1)
+    T.eq("C6 sparse packing is deterministic by pixel", packed[2].pixelKey, 4)
+    local restored = unpackPixelPending(packed)
+    T.near("C7 sparse round trip conserves exact pending total",
+        pendingTotal(restored), pendingTotal(source), 1e-12)
+
+    local wide = { [1] = {} }
+    for i = 1, 1025 do wide[1][i] = i / 10000000 end
+    T.eq("C8 sparse persistence has no hidden 1024-entry ceiling",
+        #packPixelPending(wide), 1025)
+end
+
+local function newSaveState(generation)
+    return {
+        current = {
+            generation = generation, digest = "g" .. generation, nativeOk = true,
+            revision = 40, lastSettledMonotonicDay = 20,
+        },
+        previous = {
+            generation = generation - 1, digest = "g" .. (generation - 1), nativeOk = true,
+            revision = 39, lastSettledMonotonicDay = 19,
+        },
+    }
+end
+
+local function commitGeneration(state, mapWriteOk, metadataWriteOk)
+    if not mapWriteOk or not metadataWriteOk then
+        return state.current.generation, state.previous.generation
+    end
+    state.previous = state.current
+    state.current = {
+        generation = state.previous.generation + 1,
+        digest = "g" .. (state.previous.generation + 1),
+        nativeOk = true,
+        revision = state.previous.revision,
+        lastSettledMonotonicDay = state.previous.lastSettledMonotonicDay,
+    }
+    return state.current.generation, state.previous.generation
+end
+
+local function selectGeneration(candidates)
+    local byGeneration = {}
+    for _, c in ipairs(candidates) do
+        if c.payloadKind ~= "PENDING_ONLY" and c.compactOk and type(c.generation) == "number" then
+            local g = byGeneration[c.generation] or { digests = {}, rows = {} }
+            g.digests[c.digest] = true
+            g.rows[#g.rows + 1] = c
+            byGeneration[c.generation] = g
+        end
+    end
+    local generations = {}
+    for generation in pairs(byGeneration) do generations[#generations + 1] = generation end
+    table.sort(generations, function(a, b) return a > b end)
+    for _, generation in ipairs(generations) do
+        local g = byGeneration[generation]
+        local digestCount = 0
+        for _ in pairs(g.digests) do digestCount = digestCount + 1 end
+        if digestCount == 1 then
+            local row = g.rows[1]
+            if row.nativeOk then
+                return "TRUTH", generation, row.digest,
+                    row.lastSettledMonotonicDay, row.revision
+            end
+            return "ZONE", generation, row.digest,
+                row.lastSettledMonotonicDay, row.revision
+        end
+    end
+    return "NONE", nil, nil, nil, nil
+end
+
+local function selectPendingOnly(candidates, baseGeneration, baseRevision, baseCursor)
+    local digests, rows = {}, {}
+    for _, c in ipairs(candidates) do
+        if c.payloadKind == "PENDING_ONLY" and c.compactOk
+            and c.baseGeneration == baseGeneration then
+            digests[c.digest] = true
+            rows[#rows + 1] = c
+        end
+    end
+    local digestCount = 0
+    for _ in pairs(digests) do digestCount = digestCount + 1 end
+    if digestCount == 0 then return nil, "NONE" end
+    if digestCount > 1 then return nil, "CONFLICT" end
+    local row = rows[1]
+    if baseRevision ~= nil and row.baseRevision ~= baseRevision then
+        return nil, "BASE_MISMATCH"
+    end
+    if baseCursor ~= nil and row.baseLastSettledMonotonicDay ~= baseCursor then
+        return nil, "BASE_MISMATCH"
+    end
+    return row, "APPLIED"
+end
+
+local function selectPersistence(candidates)
+    local mode, generation, digest, cursor, revision = selectGeneration(candidates)
+    if mode ~= "NONE" then
+        local pending, pendingStatus = selectPendingOnly(candidates, generation, revision, cursor)
+        return mode, generation, digest, pending ~= nil and pending.digest or nil,
+            pendingStatus, cursor, revision
+    end
+
+    local bases = {}
+    for _, c in ipairs(candidates) do
+        if c.payloadKind == "PENDING_ONLY" and c.compactOk and c.zoneOk
+            and type(c.baseGeneration) == "number" then
+            bases[c.baseGeneration] = true
+        end
+    end
+    local ordered = {}
+    for base in pairs(bases) do ordered[#ordered + 1] = base end
+    table.sort(ordered, function(a, b) return a > b end)
+    for _, base in ipairs(ordered) do
+        local pending, pendingStatus = selectPendingOnly(candidates, base, nil, nil)
+        if pending ~= nil and pending.zoneOk then
+            return "ZONE", base, nil, pending.digest, pendingStatus,
+                pending.baseLastSettledMonotonicDay, pending.baseRevision
+        end
+    end
+    return "NONE", nil, nil, nil, "NONE", nil, nil
+end
+
+-- GROUP D: TWO COMPLETE SAVE GENERATIONS AND MIRROR RECONCILIATION.
+-- SDS 3.7 and 5.6 after the R1 structural fold.
+do
+    local state = newSaveState(5)
+    local current, previous = commitGeneration(state, false, false)
+    T.eq("D1 failed native write keeps current pair", current, 5)
+    T.eq("D2 failed native write keeps previous pair", previous, 4)
+
+    current, previous = commitGeneration(state, true, false)
+    T.eq("D3 failed compact write keeps current pair", current, 5)
+    T.eq("D4 failed compact write keeps previous pair", previous, 4)
+
+    current, previous = commitGeneration(state, true, true)
+    T.eq("D5 complete pair advances current generation", current, 6)
+    T.eq("D6 complete pair retains prior generation", previous, 5)
+
+    local mode, generation, digest = selectGeneration({
+        { generation = 6, digest = "six", compactOk = true, nativeOk = false },
+        { generation = 5, digest = "five", compactOk = true, nativeOk = true },
+    })
+    T.eq("D7 newest valid compact without map degrades on its own", mode, "ZONE")
+    T.eq("D8 ZONE degrade keeps newest compact generation", generation, 6)
+    T.eq("D9 ZONE degrade keeps its own compact payload", digest, "six")
+
+    mode, generation = selectGeneration({
+        { generation = 6, digest = "sixA", compactOk = true, nativeOk = true },
+        { generation = 6, digest = "sixB", compactOk = true, nativeOk = true },
+        { generation = 5, digest = "five", compactOk = true, nativeOk = true },
+    })
+    T.eq("D10 conflicting mirrors at one generation are rejected", mode, "TRUTH")
+    T.eq("D11 conflict falls to the next complete pair", generation, 5)
+
+    mode, generation = selectGeneration({
+        { generation = 6, digest = "six", compactOk = true, nativeOk = true },
+        { generation = 6, digest = "six", compactOk = true, nativeOk = true },
+    })
+    T.eq("D12 identical mirror candidates deduplicate", mode, "TRUTH")
+    T.eq("D13 identical mirrors retain their generation", generation, 6)
+
+    local pendingDigest, pendingStatus
+    mode, generation, digest, pendingDigest, pendingStatus = selectPersistence({
+        { payloadKind = "COMPLETE", generation = 6, digest = "six", compactOk = true, nativeOk = true },
+        { payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6", compactOk = true, zoneOk = true },
+        { payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6", compactOk = true, zoneOk = true },
+    })
+    T.eq("D14 complete pair remains the selected fine authority", mode, "TRUTH")
+    T.eq("D15 pending-only overlay binds to the selected base generation", generation, 6)
+    T.eq("D16 identical pending-only mirrors deduplicate", pendingDigest, "p6")
+    T.eq("D17 matching pending-only overlay is applied", pendingStatus, "APPLIED")
+
+    mode, generation, digest, pendingDigest, pendingStatus = selectPersistence({
+        { payloadKind = "COMPLETE", generation = 6, digest = "six", compactOk = true, nativeOk = true },
+        { payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6a", compactOk = true, zoneOk = true },
+        { payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6b", compactOk = true, zoneOk = true },
+    })
+    T.eq("D18 conflicting pending-only mirrors do not displace fine truth", mode, "TRUTH")
+    T.eq("D19 conflicting pending-only mirrors are not applied", pendingDigest, nil)
+    T.eq("D20 pending-only mirror conflict is explicit", pendingStatus, "CONFLICT")
+
+    mode, generation, digest, pendingDigest, pendingStatus = selectPersistence({
+        { payloadKind = "COMPLETE", generation = 6, digest = "six", compactOk = true, nativeOk = true },
+        { payloadKind = "PENDING_ONLY", baseGeneration = 5, digest = "p5", compactOk = true, zoneOk = true },
+    })
+    T.eq("D21 mismatched pending-only base is not overlaid", pendingDigest, nil)
+    T.eq("D22 mismatched pending-only base leaves selected generation unchanged", generation, 6)
+
+    mode, generation, digest, pendingDigest, pendingStatus = selectPersistence({
+        { payloadKind = "PENDING_ONLY", baseGeneration = 7, digest = "p7", compactOk = true, zoneOk = true },
+    })
+    T.eq("D23 pending-only recovery may supply only its explicit ZONE state", mode, "ZONE")
+    T.eq("D24 ZONE recovery retains its recorded base generation", generation, 7)
+    T.eq("D25 ZONE recovery retains its own pending payload", pendingDigest, "p7")
+
+    local selectedCursor, selectedRevision
+    mode, generation, digest, pendingDigest, pendingStatus, selectedCursor, selectedRevision =
+        selectPersistence({
+            {
+                payloadKind = "COMPLETE", generation = 6, digest = "six-cursor",
+                compactOk = true, nativeOk = true, revision = 60,
+                lastSettledMonotonicDay = 20,
+            },
+            {
+                payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6-cursor",
+                compactOk = true, zoneOk = true, baseRevision = 60,
+                baseLastSettledMonotonicDay = 20,
+            },
+        })
+    T.eq("D26 matching pending overlay preserves selected carrier cursor", selectedCursor, 20)
+    T.eq("D27 matching pending overlay preserves selected carrier revision", selectedRevision, 60)
+    T.eq("D28 matching carrier coordinates permit pending overlay", pendingStatus, "APPLIED")
+
+    mode, generation, digest, pendingDigest, pendingStatus, selectedCursor =
+        selectPersistence({
+            {
+                payloadKind = "COMPLETE", generation = 6, digest = "six-cursor",
+                compactOk = true, nativeOk = true, revision = 60,
+                lastSettledMonotonicDay = 20,
+            },
+            {
+                payloadKind = "PENDING_ONLY", baseGeneration = 6, digest = "p6-wrong-cursor",
+                compactOk = true, zoneOk = true, baseRevision = 60,
+                baseLastSettledMonotonicDay = 21,
+            },
+        })
+    T.eq("D29 matching generation with wrong base cursor is not overlaid", pendingDigest, nil)
+    T.eq("D30 wrong base cursor is an explicit mismatch", pendingStatus, "BASE_MISMATCH")
+    T.eq("D31 wrong pending cursor cannot replace selected carrier cursor", selectedCursor, 20)
+
+    mode, generation, digest, selectedCursor = selectGeneration({
+        { generation = 6, digest = "sixA", compactOk = true, nativeOk = true,
+            revision = 60, lastSettledMonotonicDay = 20 },
+        { generation = 6, digest = "sixB", compactOk = true, nativeOk = true,
+            revision = 60, lastSettledMonotonicDay = 20 },
+        { generation = 5, digest = "five", compactOk = true, nativeOk = true,
+            revision = 50, lastSettledMonotonicDay = 17 },
+    })
+    T.eq("D32 complete-pair fallback restores previous carrier", generation, 5)
+    T.eq("D33 complete-pair fallback restores previous carrier cursor", selectedCursor, 17)
+
+    mode, generation, digest, pendingDigest, pendingStatus, selectedCursor = selectPersistence({
+        {
+            payloadKind = "PENDING_ONLY", baseGeneration = 7, digest = "p7-zone-cursor",
+            compactOk = true, zoneOk = true, baseRevision = 70,
+            baseLastSettledMonotonicDay = 14,
+        },
+    })
+    T.eq("D34 pending-only ZONE recovery uses its own copied cursor", selectedCursor, 14)
+end
+
+local function newRestoreBarrier()
+    return { compact = false, fields = false, map = false, applyCount = 0 }
+end
+
+local function tryRestore(barrier)
+    if barrier.compact and barrier.fields and barrier.map and barrier.applyCount == 0 then
+        barrier.applyCount = 1
+        return true
+    end
+    return false
+end
+
+-- GROUP E: POST-ENUMERATION RESTORE IS ORDER-INDEPENDENT AND EXACTLY ONCE.
+-- SDS v2.1 section 3.8.
+do
+    local a = newRestoreBarrier()
+    a.compact = true; T.eq("E1 compact alone does not restore", tryRestore(a), false)
+    a.fields = true;  T.eq("E2 fields without map decision do not restore", tryRestore(a), false)
+    a.map = true;     T.eq("E3 third prerequisite restores", tryRestore(a), true)
+    T.eq("E4 restore applies once", a.applyCount, 1)
+    T.eq("E5 repeated callback is idempotent", tryRestore(a), false)
+    T.eq("E6 repeated callback keeps one application", a.applyCount, 1)
+
+    local b = newRestoreBarrier()
+    b.map = true; b.fields = true; b.compact = true
+    T.eq("E7 alternate prerequisite order still restores", tryRestore(b), true)
+    T.eq("E8 alternate order still applies once", b.applyCount, 1)
+end
+
+local function newSnapshot(totalRows, baseRevision, snapshotGeneration, carrierGeneration, aggregateKeys)
+    return {
+        totalRows = totalRows,
+        baseRevision = baseRevision,
+        snapshotGeneration = snapshotGeneration or (baseRevision + 1000),
+        carrierGeneration = carrierGeneration or 1,
+        aggregateKeys = aggregateKeys,
+    }
+end
+
+local function newConnection(snapshot)
+    return {
+        snapshot = snapshot,
+        rows = {},
+        rowCount = 0,
+        staging = {},
+        live = {},
+        deltas = {},
+        compactFull = nil,
+        current = false,
+        currentRevision = snapshot.baseRevision,
+        resnapshot = false,
+        completeCount = 0,
+    }
+end
+
+local SNAPSHOT_ROWS_PER_FRAME = 8
+local REDISTRIBUTION_OPS_PER_FRAME = 400
+
+local function receiveRow(connection, rowIndex, values)
+    if connection.rows[rowIndex] == nil then
+        connection.rows[rowIndex] = true
+        connection.rowCount = connection.rowCount + 1
+        for key, value in pairs(values or {}) do connection.staging[key] = value end
+    end
+end
+
+local function applyValues(target, values)
+    for key, value in pairs(values or {}) do target[key] = value end
+end
+
+local function valuesAgree(target, values)
+    for key, value in pairs(values or {}) do
+        if target[key] == nil or math.abs(target[key] - value) > 1e-12 then return false end
+    end
+    return true
+end
+
+local function deriveBaseAggregate(snapshot, staging)
+    if type(snapshot.aggregateKeys) ~= "table" then return nil end
+    local total, count = 0, 0
+    for _, key in ipairs(snapshot.aggregateKeys) do
+        local value = staging[key]
+        if type(value) == "number" then
+            total = total + value
+            count = count + 1
+        end
+    end
+    if count == 0 then return nil end
+    return total / count
+end
+
+local function receiveCompactFull(connection, generation, revision, values)
+    if generation ~= connection.snapshot.snapshotGeneration then
+        connection.resnapshot = true
+        return false
+    end
+    if connection.current then
+        if revision < connection.currentRevision then return true end
+        if revision > connection.currentRevision then
+            connection.resnapshot = true
+            return false
+        end
+        if not valuesAgree(connection.live, values) then
+            connection.resnapshot = true
+            return false
+        end
+        return true
+    end
+    connection.compactFull = { generation = generation, revision = revision, values = values }
+    return true
+end
+
+local function receiveDelta(connection, fromRevision, toRevision, values)
+    if connection.current and toRevision <= connection.currentRevision then
+        return true
+    end
+    if connection.current then
+        if fromRevision ~= connection.currentRevision then
+            connection.resnapshot = true
+            return false
+        end
+        applyValues(connection.live, values)
+        connection.currentRevision = toRevision
+        return true
+    end
+    connection.deltas[#connection.deltas + 1] = {
+        fromRevision = fromRevision,
+        toRevision = toRevision,
+        values = values,
+    }
+    return true
+end
+
+local function finishSnapshot(connection)
+    if connection.resnapshot then return false end
+    if connection.current then return true end
+    local snapshot = connection.snapshot
+    if connection.rowCount ~= snapshot.totalRows then
+        connection.resnapshot = true
+        return false
+    end
+    if connection.compactFull ~= nil
+        and connection.compactFull.generation ~= snapshot.snapshotGeneration then
+        connection.resnapshot = true
+        return false
+    end
+    local compact = connection.compactFull
+    local compactApplied = false
+    local baseAggregate = deriveBaseAggregate(snapshot, connection.staging)
+    if baseAggregate ~= nil then connection.staging.aggregate = baseAggregate end
+    if compact ~= nil and compact.revision < snapshot.baseRevision then
+        compactApplied = true
+    elseif compact ~= nil and compact.revision == snapshot.baseRevision then
+        if not valuesAgree(connection.staging, compact.values) then
+            connection.resnapshot = true
+            return false
+        end
+        compactApplied = true
+    end
+    table.sort(connection.deltas, function(a, b) return a.fromRevision < b.fromRevision end)
+    local revision = snapshot.baseRevision
+    for _, delta in ipairs(connection.deltas) do
+        if delta.toRevision > revision then
+            if delta.fromRevision ~= revision then
+                connection.resnapshot = true
+                return false
+            end
+            applyValues(connection.staging, delta.values)
+            revision = delta.toRevision
+            if compact ~= nil and not compactApplied then
+                if compact.revision == revision then
+                    if not valuesAgree(connection.staging, compact.values) then
+                        connection.resnapshot = true
+                        return false
+                    end
+                    compactApplied = true
+                elseif compact.revision < revision then
+                    connection.resnapshot = true
+                    return false
+                end
+            end
+        end
+    end
+    if compact ~= nil and not compactApplied then
+        connection.resnapshot = true
+        return false
+    end
+    connection.live = connection.staging
+    connection.staging = {}
+    connection.deltas = {}
+    connection.compactFull = nil
+    connection.currentRevision = revision
+    connection.current = true
+    connection.completeCount = 1
+    return true
+end
+
+local function restartFromFreshSnapshot(connection, snapshot)
+    if connection.resnapshot ~= true then return connection, false end
+    return newConnection(snapshot), true
+end
+
+-- GROUP F: STAGING BARRIER, CLIENT CURRENTNESS, LIVE DELTA AND FRESH RESNAPSHOT.
+-- SDS v2.0 sections 3.9 and 5.7. Reliable-ordered transport needs no ACK,
+-- missing-row retransmission, acknowledged-revision table or progress lease.
+do
+    local snapshot = newSnapshot(2, 10, 1001, 6, { 1, 2 })
+    local first = newConnection(snapshot)
+    local second = newConnection(snapshot)
+    T.eq("F0a transport snapshot ID is distinct from provider revision",
+        snapshot.snapshotGeneration == snapshot.baseRevision, false)
+    T.eq("F0b transport snapshot ID is distinct from save generation",
+        snapshot.snapshotGeneration == snapshot.carrierGeneration, false)
+    T.eq("F0c save generation is retained independently", snapshot.carrierGeneration, 6)
+    receiveCompactFull(first, 1001, 10, { aggregate = 0.25 })
+    receiveDelta(first, 10, 12, { [44] = 0.70 })
+    T.eq("F1 delta before row completion remains buffered", first.current, false)
+    receiveRow(first, 0, { [1] = 0.20 })
+    T.eq("F2 partial row staging is not live", first.live[1], nil)
+    receiveRow(first, 1, { [2] = 0.30 })
+    T.eq("F3 complete rows plus contiguous delta cross barrier", finishSnapshot(first), true)
+    T.eq("F4 COMPLETE publishes currentness without an ACK", first.current, true)
+    T.eq("F5 completed connection reaches delta revision", first.currentRevision, 12)
+    T.near("F6 absolute buffered delta installs final value", first.live[44], 0.70, 1e-12)
+    T.near("F7 base compact FULL corroborates the fine-derived aggregate",
+        first.live.aggregate, 0.25, 1e-12)
+    T.eq("F8 one connection completing does not complete its peer", second.current, false)
+
+    T.eq("F9 contiguous post-completion delta applies immediately",
+        receiveDelta(first, 12, 13, { [44] = 0.75 }), true)
+    T.eq("F10 live delta advances current revision", first.currentRevision, 13)
+    T.near("F11 live delta updates the live map", first.live[44], 0.75, 1e-12)
+    T.eq("F12 duplicate completion is idempotent", finishSnapshot(first), true)
+    T.eq("F13 duplicate completion never reapplies", first.completeCount, 1)
+    receiveDelta(first, 10, 12, { [44] = 0.70 })
+    T.near("F14 duplicate old absolute delta is ignored", first.live[44], 0.75, 1e-12)
+    T.eq("F15 duplicate old delta does not request a resnapshot", first.resnapshot, false)
+
+    local missing = newSnapshot(2, 20)
+    local missingConn = newConnection(missing)
+    receiveRow(missingConn, 0, {})
+    T.eq("F16 missing snapshot row refuses completion", finishSnapshot(missingConn), false)
+    T.eq("F17 incomplete completion requests one fresh full snapshot", missingConn.resnapshot, true)
+
+    local gap = newSnapshot(1, 30)
+    local gapConn = newConnection(gap)
+    receiveRow(gapConn, 0, {})
+    receiveDelta(gapConn, 31, 32, { [1] = 0.25 })
+    T.eq("F18 revision gap refuses currentness", finishSnapshot(gapConn), false)
+    T.eq("F19 revision gap requests one fresh full snapshot", gapConn.resnapshot, true)
+
+    local mismatch = newConnection(newSnapshot(1, 40, 4001, 9))
+    receiveRow(mismatch, 0, {})
+    receiveCompactFull(mismatch, 4002, 41, {})
+    T.eq("F20 compact FULL from another generation refuses completion",
+        finishSnapshot(mismatch), false)
+    T.eq("F21 compact generation mismatch requests one fresh snapshot", mismatch.resnapshot, true)
+
+    local ordered = newConnection(newSnapshot(1, 60, 6001, 10))
+    receiveRow(ordered, 0, { [1] = 0.20 })
+    receiveCompactFull(ordered, 6001, 61, { aggregate = 0.50 })
+    receiveDelta(ordered, 60, 61, { [44] = 0.70, aggregate = 0.50 })
+    receiveDelta(ordered, 61, 62, { [45] = 0.80 })
+    T.eq("F22 later compact FULL waits for its exact fine revision",
+        finishSnapshot(ordered), true)
+    T.eq("F23 later compact FULL preserves the following fine revision",
+        ordered.currentRevision, 62)
+    T.near("F24 matching compact FULL corroborates without overwriting fine staging",
+        ordered.live.aggregate, 0.50, 1e-12)
+    T.near("F25 fine delta after compact FULL remains present", ordered.live[45], 0.80, 1e-12)
+
+    local contentMismatch = newConnection(newSnapshot(1, 63, 6301, 10))
+    receiveRow(contentMismatch, 0, { [1] = 0.20 })
+    receiveCompactFull(contentMismatch, 6301, 64, { aggregate = 0.65 })
+    receiveDelta(contentMismatch, 63, 64, { aggregate = 0.50 })
+    T.eq("F26 equal-revision compact disagreement refuses currentness",
+        finishSnapshot(contentMismatch), false)
+    T.eq("F27 equal-revision compact disagreement requests fresh snapshot",
+        contentMismatch.resnapshot, true)
+
+    local compactGap = newConnection(newSnapshot(1, 70, 7001, 11))
+    receiveRow(compactGap, 0, {})
+    receiveCompactFull(compactGap, 7001, 72, { aggregate = 0.70 })
+    T.eq("F28 compact FULL ahead of the fine chain refuses currentness",
+        finishSnapshot(compactGap), false)
+    T.eq("F29 compact FULL revision gap requests fresh snapshot", compactGap.resnapshot, true)
+
+    local currentCompact = newConnection(newSnapshot(1, 80, 8001, 12))
+    receiveRow(currentCompact, 0, { aggregate = 0.72 })
+    T.eq("F30 base snapshot becomes current before live compact FULL",
+        finishSnapshot(currentCompact), true)
+    T.eq("F31 matching live compact FULL is accepted as a witness",
+        receiveCompactFull(currentCompact, 8001, 80, { aggregate = 0.72 }), true)
+    T.near("F32 matching live compact FULL leaves fine aggregate unchanged",
+        currentCompact.live.aggregate, 0.72, 1e-12)
+    T.eq("F33 disagreeing live compact FULL requests fresh snapshot",
+        receiveCompactFull(currentCompact, 8001, 80, { aggregate = 0.73 }), false)
+    T.eq("F34 disagreeing live compact FULL sets resnapshot", currentCompact.resnapshot, true)
+
+    local aheadCompact = newConnection(newSnapshot(1, 82, 8201, 12))
+    receiveRow(aheadCompact, 0, {})
+    finishSnapshot(aheadCompact)
+    T.eq("F35 ahead live compact FULL requests fresh snapshot",
+        receiveCompactFull(aheadCompact, 8201, 84, {}), false)
+    T.eq("F36 ahead live compact FULL sets resnapshot", aheadCompact.resnapshot, true)
+
+    local baseMatch = newConnection(newSnapshot(1, 85, 8501, 12, { 1, 2 }))
+    receiveRow(baseMatch, 0, { [1] = 0.20, [2] = 0.40 })
+    receiveCompactFull(baseMatch, 8501, 85, { aggregate = 0.30 })
+    T.eq("F37 matching base compact aggregate permits currentness",
+        finishSnapshot(baseMatch), true)
+    T.near("F38 base aggregate is derived from completed fine rows",
+        baseMatch.live.aggregate, 0.30, 1e-12)
+
+    local baseMismatch = newConnection(newSnapshot(1, 86, 8601, 12, { 1, 2 }))
+    receiveRow(baseMismatch, 0, { [1] = 0.20, [2] = 0.40 })
+    receiveCompactFull(baseMismatch, 8601, 86, { aggregate = 0.31 })
+    T.eq("F39 mismatched base compact aggregate refuses currentness",
+        finishSnapshot(baseMismatch), false)
+    T.eq("F40 mismatched base compact aggregate requests fresh snapshot",
+        baseMismatch.resnapshot, true)
+
+    local restarted, didRestart = restartFromFreshSnapshot(missingConn,
+        newSnapshot(2, 21, 2101, 14))
+    T.eq("F41 semantic mismatch starts one fresh snapshot", didRestart, true)
+    T.eq("F42 fresh snapshot carries none of the old partial rows", restarted.rowCount, 0)
+    T.eq("F43 fresh snapshot begins non-current", restarted.current, false)
+    T.eq("F44 fresh snapshot does not inherit the prior mismatch", restarted.resnapshot, false)
+end
+
+local function runBudgeted(totalItems, budget)
+    if budget <= 0 then return 0, 0, 0, "PAUSED" end
+    local processed, frames, maxStep = 0, 0, 0
+    while processed < totalItems do
+        local step = math.min(budget, totalItems - processed)
+        processed = processed + step
+        frames = frames + 1
+        if step > maxStep then maxStep = step end
+    end
+    return processed, frames, maxStep, "COMPLETE"
+end
+
+-- GROUP G: FRAME BUDGET DELAYS WORK AND NEVER CAPS TOTAL WORK.
+-- SDS v2.1 section 3.10.
+do
+    local processed, frames, maxStep = runBudgeted(23, 4)
+    T.eq("G1 small queue visits every item", processed, 23)
+    T.eq("G2 small queue respects per-frame budget", maxStep, 4)
+    T.eq("G3 small queue takes the derived frame count", frames, math.ceil(23 / 4))
+
+    processed, frames, maxStep = runBudgeted(230, 4)
+    T.eq("G4 larger queue still visits every item", processed, 230)
+    T.eq("G5 larger queue keeps the same per-frame ceiling", maxStep, 4)
+    T.eq("G6 larger queue takes more frames rather than dropping work", frames, math.ceil(230 / 4))
+
+    processed, frames, maxStep = runBudgeted(401, 4)
+    T.eq("G7 work beyond the old 400-item ceiling is all visited", processed, 401)
+    T.eq("G8 work beyond the old ceiling keeps the frame budget", maxStep, 4)
+    T.eq("G9 work beyond the old ceiling takes derived extra frames", frames, math.ceil(401 / 4))
+
+    local state
+    processed, frames, maxStep, state = runBudgeted(10, 0)
+    T.eq("G10 zero budget performs no hidden work", processed, 0)
+    T.eq("G11 zero budget does not claim completion", state, "PAUSED")
+end
+
+local function applyZoneWater(zone, cellKey, gain)
+    if zone.cells[cellKey] == nil then
+        zone.cells[cellKey] = zone.seed
+        zone.cellCount = zone.cellCount + 1
+    end
+    zone.cells[cellKey] = zone.cells[cellKey] + gain
+    zone.totalAccepted = zone.totalAccepted + gain
+end
+
+local function revalidatePending(entries, resolver)
+    local mapped, unresolved = {}, {}
+    for _, entry in ipairs(entries) do
+        local fieldId = resolver(entry.worldX, entry.worldZ)
+        if type(fieldId) == "number" then
+            mapped[fieldId] = (mapped[fieldId] or 0) + entry.amount
+        else
+            unresolved[#unresolved + 1] = entry
+        end
+    end
+    return mapped, unresolved
+end
+
+-- GROUP H: EVENT WATER OUTLIVES RELIEF CAP AND FIELD CONTEXT IS REVALIDATED.
+-- SDS 3.5, 3.6, 3.10 and 5.8 after the R1 structural fold.
+do
+    local zone = {
+        seed = 0.50,
+        cells = {},
+        cellCount = 1000,
+        totalAccepted = 0,
+    }
+    applyZoneWater(zone, "new-cell", 0.10)
+    T.eq("H1 real ZONE water materializes beyond relief backstop", zone.cellCount, 1001)
+    T.near("H2 real ZONE water is preserved", zone.cells["new-cell"], 0.60, 1e-12)
+    T.near("H3 accepted ZONE total is not silently dropped", zone.totalAccepted, 0.10, 1e-12)
+
+    local pending = {
+        { worldX = 10, worldZ = 20, amount = 0.001 },
+        { worldX = 30, worldZ = 40, amount = 0.002 },
+    }
+    local mapped, unresolved = revalidatePending(pending, function(x, _z)
+        if x == 10 then return 7 end
+        return nil
+    end)
+    T.near("H4 uniquely resolved pending rekeys to current field", mapped[7], 0.001, 1e-12)
+    T.eq("H5 ambiguous pending remains unresolved", #unresolved, 1)
+    T.near("H6 unresolved pending keeps its accepted amount", unresolved[1].amount, 0.002, 1e-12)
+end
+
+local EventFamily = {
+    INIT = "CropStressMoistureInitEvent",
+    ROW = "CropStressMoistureRowEvent",
+    DELTA = "CropStressMoistureDeltaEvent",
+    CONTROL = "CropStressMoistureControlEvent",
+}
+
+local function queueFieldDelta(queues, fieldId, pixelKey, fromRevision, toRevision, value)
+    queues[fieldId] = queues[fieldId] or {}
+    local prior = queues[fieldId][pixelKey]
+    queues[fieldId][pixelKey] = {
+        fieldId = fieldId,
+        pixelKey = pixelKey,
+        fromRevision = prior ~= nil and prior.fromRevision or fromRevision,
+        toRevision = toRevision,
+        value = value,
+    }
+end
+
+local function clearFieldDeltaQueue(queues, fieldId)
+    queues[fieldId] = nil
+end
+
+local function deltaEntryCount(queues)
+    local count = 0
+    for _, pixels in pairs(queues) do
+        for _ in pairs(pixels) do count = count + 1 end
+    end
+    return count
+end
+
+local function shouldRestartSnapshot(deltaCount, fullSnapshotEntryCount)
+    return deltaCount >= fullSnapshotEntryCount
+end
+
+local function fieldGeometryChanged(savedFingerprint, currentFingerprint)
+    return savedFingerprint ~= currentFingerprint
+end
+
+-- GROUP I: EVENT OWNERSHIP, FIELD-PARTITIONED DELTAS AND INITIAL DEFAULTS.
+-- SDS 3.6, 3.9 and 3.10 after the R2 structural fold.
+do
+    T.eq("I1 init and row events remain logically distinct",
+        EventFamily.INIT == EventFamily.ROW, false)
+    T.eq("I2 row and delta events remain logically distinct",
+        EventFamily.ROW == EventFamily.DELTA, false)
+    T.eq("I3 delta and control events remain logically distinct",
+        EventFamily.DELTA == EventFamily.CONTROL, false)
+
+    local queues = {}
+    queueFieldDelta(queues, 3, 11, 90, 91, 0.44)
+    queueFieldDelta(queues, 4, 12, 90, 91, 0.55)
+    queueFieldDelta(queues, 3, 11, 91, 92, 0.46)
+    T.eq("I4 repeated pixel dirties coalesce to one final entry per field pixel",
+        deltaEntryCount(queues), 2)
+    T.eq("I5 coalesced entry retains its field identity", queues[3][11].fieldId, 3)
+    T.eq("I6 coalesced entry retains its original base revision", queues[3][11].fromRevision, 90)
+    T.eq("I7 coalesced entry retains its newest provider revision", queues[3][11].toRevision, 92)
+    T.near("I8 coalesced entry retains its final value", queues[3][11].value, 0.46, 1e-12)
+    clearFieldDeltaQueue(queues, 3)
+    T.eq("I9 field replacement clears only that field's delta partition", queues[3], nil)
+    T.near("I10 another field's queued value survives", queues[4][12].value, 0.55, 1e-12)
+
+    T.eq("I11 delta history equal to one full snapshot requests restart",
+        shouldRestartSnapshot(20, 20), true)
+    T.eq("I12 shorter delta history may remain attached to its base",
+        shouldRestartSnapshot(19, 20), false)
+    T.eq("I13 unchanged field polygon fingerprint keeps membership",
+        fieldGeometryChanged("abc", "abc"), false)
+    T.eq("I14 changed field polygon fingerprint requests rebuild",
+        fieldGeometryChanged("abc", "def"), true)
+
+    T.eq("I15 current source supplies the initial snapshot row budget",
+        SoilMoistureSystem.SYNC_ROWS_PER_FRAME, SNAPSHOT_ROWS_PER_FRAME)
+    T.eq("I16 current source supplies the initial redistribution work value",
+        SoilMoistureSystem.MAP_DRAIN_MAX_BLOCKS, REDISTRIBUTION_OPS_PER_FRAME)
+end
+
+local function newDailyState(cursor, revision)
+    return {
+        cursor = cursor, revision = revision, liveTotal = 0, plan = nil,
+        commits = 0, fieldPending = 0, positionalPending = 0, pendingFlushes = 0,
+    }
+end
+
+local function dueBoundaries(cursor, currentDay)
+    if type(cursor) ~= "number" or type(currentDay) ~= "number" then return 0 end
+    if cursor ~= cursor or currentDay ~= currentDay then return 0 end
+    if math.abs(cursor) == math.huge or math.abs(currentDay) == math.huge then return 0 end
+    local due = currentDay - cursor
+    if due <= 0 then return 0 end
+    return math.floor(due)
+end
+
+local function wakeDaily(state, currentDay, fingerprint, totalOps)
+    if type(currentDay) ~= "number" or currentDay ~= currentDay
+        or math.abs(currentDay) == math.huge then return "INVALID" end
+    if state.cursor == nil then
+        state.cursor = currentDay
+        return "SEEDED"
+    end
+    local due = dueBoundaries(state.cursor, currentDay)
+    if due == 0 then return "IDLE" end
+    if state.plan == nil then
+        state.plan = {
+            due = due, targetDay = currentDay, baseRevision = state.revision,
+            fingerprint = fingerprint, cursor = 0, totalOps = totalOps,
+            stagedTotal = 0, complete = false,
+        }
+        return "PENDING"
+    end
+    return "PENDING"
+end
+
+local function advanceDailyPlan(state, budget, currentDay, fingerprint)
+    local plan = state.plan
+    if plan == nil then return 0, "IDLE" end
+    if plan.targetDay ~= currentDay
+        or plan.baseRevision ~= state.revision
+        or plan.fingerprint ~= fingerprint then
+        state.plan = nil
+        return 0, "ABORTED"
+    end
+    if budget <= 0 then return 0, "PAUSED" end
+    local step = math.min(math.max(0, budget), plan.totalOps - plan.cursor)
+    plan.cursor = plan.cursor + step
+    plan.stagedTotal = plan.due
+    plan.complete = plan.cursor == plan.totalOps
+    if not plan.complete then return step, "PENDING" end
+    state.liveTotal = state.liveTotal + plan.stagedTotal
+    state.revision = state.revision + 1
+    state.cursor = plan.targetDay
+    state.plan = nil
+    state.commits = state.commits + 1
+    return step, "COMMITTED"
+end
+
+local function acceptAdditiveDuringDailyPlan(state, fieldGain, positionalGain)
+    state.fieldPending = state.fieldPending + math.max(0, fieldGain or 0)
+    state.positionalPending = state.positionalPending + math.max(0, positionalGain or 0)
+    return "BUFFERED"
+end
+
+local function flushPostPlanPending(state)
+    if state.plan ~= nil then return "HELD" end
+    local moved = state.fieldPending + state.positionalPending
+    if moved <= 0 then return "IDLE" end
+    state.liveTotal = state.liveTotal + moved
+    state.fieldPending = 0
+    state.positionalPending = 0
+    state.revision = state.revision + 1
+    state.pendingFlushes = state.pendingFlushes + 1
+    return "FLUSHED"
+end
+
+local function timeGuardAccrualWouldAdvance(pcallOk, _callbackReturn)
+    return pcallOk == true
+end
+
+local function usableTimeGuardWake(isServer, synced, monotonicDay)
+    return isServer == true and synced == true and type(monotonicDay) == "number"
+        and monotonicDay == monotonicDay and math.abs(monotonicDay) < math.huge
+end
+
+-- GROUP J: SCS OWNS DAILY CURSOR, STAGING AND COMMIT; TIME GUARD ONLY WAKES IT.
+-- SDS v2.1 sections 3.10 and 5.5. TimeGuardScheduler.lua:145-179 advances
+-- after any non-throwing callback, while TimeGuard.lua:273-337 exposes a day tick
+-- and monotonic-day context that do not claim SCS completion.
+do
+    local state = newDailyState(5, 20)
+    T.eq("J1 first due wake opens SCS-owned staging",
+        wakeDaily(state, 8, "poly-a", 900), "PENDING")
+    T.eq("J2 SCS cursor stays at the last committed day", state.cursor, 5)
+    T.eq("J3 first frame advances only the positive operation budget",
+        select(1, advanceDailyPlan(state, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")),
+        REDISTRIBUTION_OPS_PER_FRAME)
+    T.eq("J4 partial staging never mutates live moisture", state.liveTotal, 0)
+    T.eq("J5 second frame remains incomplete",
+        select(2, advanceDailyPlan(state, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")), "PENDING")
+    local finalStep, finalStatus = advanceDailyPlan(state, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")
+    T.eq("J6 final frame performs only the remaining work", finalStep, 100)
+    T.eq("J7 final frame commits without another calendar callback", finalStatus, "COMMITTED")
+    T.eq("J8 successful commit advances the SCS cursor", state.cursor, 8)
+    T.eq("J9 one complete candidate commits exactly once", state.commits, 1)
+    T.eq("J10 three crossed days settle exactly once as one transaction", state.liveTotal, 3)
+    T.eq("J11 one complete field act advances readable revision once", state.revision, 21)
+    T.eq("J12 duplicate day wake opens no second work",
+        wakeDaily(state, 8, "poly-a", 900), "IDLE")
+
+    local savedMidPlan = newDailyState(5, 20)
+    wakeDaily(savedMidPlan, 8, "poly-a", 900)
+    advanceDailyPlan(savedMidPlan, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")
+    local reloaded = newDailyState(savedMidPlan.cursor, savedMidPlan.revision)
+    T.eq("J13 save and reload discard non-authoritative staging", reloaded.plan, nil)
+    T.eq("J14 unadvanced SCS cursor reoffers the same three due days",
+        dueBoundaries(reloaded.cursor, 8), 3)
+
+    local invalidated = newDailyState(5, 20)
+    wakeDaily(invalidated, 8, "poly-a", 900)
+    advanceDailyPlan(invalidated, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")
+    invalidated.revision = 21
+    T.eq("J15 authoritative replacement invalidates the pinned daily candidate",
+        select(2, advanceDailyPlan(invalidated, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")),
+        "ABORTED")
+    T.eq("J16 replacement-invalidated staging is discarded", invalidated.plan, nil)
+    T.eq("J17 replacement invalidation leaves the SCS cursor unchanged", invalidated.cursor, 5)
+
+    local additive = newDailyState(5, 20)
+    wakeDaily(additive, 8, "poly-a", 900)
+    advanceDailyPlan(additive, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")
+    T.eq("J31 additive water is accepted into existing pending during daily work",
+        acceptAdditiveDuringDailyPlan(additive, 0.01, 0.02), "BUFFERED")
+    T.eq("J32 additive pending does not advance the pinned readable revision",
+        additive.revision, 20)
+    T.ok("J33 additive pending leaves the daily candidate live", additive.plan ~= nil)
+    advanceDailyPlan(additive, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")
+    T.eq("J34 daily work commits despite repeated foreground acceptance",
+        select(2, advanceDailyPlan(additive, REDISTRIBUTION_OPS_PER_FRAME, 8, "poly-a")),
+        "COMMITTED")
+    T.eq("J35 daily commit advances the cursor before pending flush", additive.cursor, 8)
+    T.eq("J36 post-plan pending flushes through one provider transaction",
+        flushPostPlanPending(additive), "FLUSHED")
+    T.near("J37 daily result and accepted foreground water both remain visible",
+        additive.liveTotal, 3.03, 1e-12)
+    T.eq("J38 one post-plan readable flush advances revision once", additive.revision, 22)
+    T.eq("J39 flushed field pending clears", additive.fieldPending, 0)
+    T.eq("J40 flushed positional pending clears", additive.positionalPending, 0)
+    T.eq("J41 repeated post-plan flush is idle", flushPostPlanPending(additive), "IDLE")
+
+    local firstInstall = newDailyState(nil, 1)
+    T.eq("J18 missing cursor seeds the current day without invented history",
+        wakeDaily(firstInstall, 12, "poly-a", 10), "SEEDED")
+    T.eq("J19 first seed records the current monotonic day", firstInstall.cursor, 12)
+    T.eq("J20 first seed performs no settlement", firstInstall.liveTotal, 0)
+    T.eq("J21 rewind creates no negative or duplicate due work", dueBoundaries(8, 7), 0)
+
+    local paused = newDailyState(5, 20)
+    wakeDaily(paused, 8, "poly-a", 900)
+    T.eq("J22 zero budget visibly pauses instead of completing",
+        select(2, advanceDailyPlan(paused, 0, 8, "poly-a")), "PAUSED")
+    T.eq("J23 zero budget leaves the due cursor unchanged", paused.cursor, 5)
+
+    local present = newDailyState(10, 30)
+    local absent = newDailyState(10, 30)
+    wakeDaily(present, 12, "poly-b", 800)
+    wakeDaily(absent, 12, "poly-b", 800)
+    advanceDailyPlan(present, REDISTRIBUTION_OPS_PER_FRAME, 12, "poly-b")
+    advanceDailyPlan(absent, REDISTRIBUTION_OPS_PER_FRAME, 12, "poly-b")
+    advanceDailyPlan(present, REDISTRIBUTION_OPS_PER_FRAME, 12, "poly-b")
+    advanceDailyPlan(absent, REDISTRIBUTION_OPS_PER_FRAME, 12, "poly-b")
+    T.eq("J24 Time Guard present and absent paths commit the same due count",
+        present.liveTotal, absent.liveTotal)
+    T.eq("J25 Time Guard present and absent paths retain the same SCS cursor",
+        present.cursor, absent.cursor)
+    T.eq("J26 Time Guard present and absent paths retain the same revision",
+        present.revision, absent.revision)
+
+    T.eq("J27 a false callback return would still advance current Time Guard accrual",
+        timeGuardAccrualWouldAdvance(true, false), true)
+    T.eq("J28 client peer never opens the SCS daily transaction",
+        usableTimeGuardWake(false, true, 8), false)
+    T.eq("J29 unsynchronized Time Guard context is neutral absence",
+        usableTimeGuardWake(true, false, 0), false)
+    T.eq("J30 synchronized finite day zero remains a valid server coordinate",
+        usableTimeGuardWake(true, true, 0), true)
+end
+
+local function newPersistenceState(generation, revision, fieldPending, positionalPending, cursor)
+    local committedCursor = cursor or 20
+    return {
+        current = {
+            generation = generation, revision = revision,
+            fieldPending = fieldPending, positionalPending = positionalPending,
+            lastSettledMonotonicDay = committedCursor,
+        },
+        previous = {
+            generation = generation - 1, revision = revision - 1,
+            fieldPending = 0, positionalPending = 0,
+            lastSettledMonotonicDay = committedCursor - 1,
+        },
+        revision = revision,
+        lastSettledMonotonicDay = committedCursor,
+        fieldPending = fieldPending,
+        positionalPending = positionalPending,
+        pendingOnly = nil,
+        framePackingSteps = 0,
+    }
+end
+
+local function exactNativeSaveSuccess(pcallOk, returned)
+    return pcallOk == true and returned == true
+end
+
+local function synchronousSave(state, packOk, nativePcallOk, nativeReturned, compactOk)
+    local capture = {
+        revision = state.revision,
+        lastSettledMonotonicDay = state.lastSettledMonotonicDay,
+        fieldPending = state.fieldPending,
+        positionalPending = state.positionalPending,
+    }
+    if not packOk then return false, capture, "PACK_FAILED" end
+    if not exactNativeSaveSuccess(nativePcallOk, nativeReturned) then
+        if compactOk then
+            state.pendingOnly = {
+                payloadKind = "PENDING_ONLY",
+                baseGeneration = state.current.generation,
+                baseRevision = state.current.revision,
+                baseLastSettledMonotonicDay = state.current.lastSettledMonotonicDay,
+                fieldPending = capture.fieldPending,
+                positionalPending = capture.positionalPending,
+                digest = string.format("p:%d:%d:%d:%.6f:%.6f", state.current.generation,
+                    state.current.revision, state.current.lastSettledMonotonicDay,
+                    capture.fieldPending, capture.positionalPending),
+                zoneOk = true,
+            }
+        end
+        return false, capture, "NATIVE_FAILED"
+    end
+    if not compactOk then return false, capture, "COMPACT_FAILED" end
+    state.previous = state.current
+    state.current = {
+        generation = state.current.generation + 1,
+        revision = capture.revision,
+        lastSettledMonotonicDay = capture.lastSettledMonotonicDay,
+        fieldPending = capture.fieldPending,
+        positionalPending = capture.positionalPending,
+    }
+    state.pendingOnly = nil
+    return true, capture, "COMPLETE"
+end
+
+-- GROUP K: SAVE CAPTURE IS SYNCHRONOUS; COMPLETE PAIRS AND PENDING-ONLY RECOVERY
+-- HAVE DIFFERENT COMMIT RULES. SDS v2.1 sections 3.7 and 5.6.
+-- CropStressValueMap.lua:233-241 currently drops the native false return.
+do
+    local failed = newPersistenceState(7, 41, 0.020, 0.003)
+    failed.lastSettledMonotonicDay = 23
+    local oldCurrent = failed.current
+    local oldPrevious = failed.previous
+    T.eq("K1 failed native write refuses a new moisture generation",
+        select(1, synchronousSave(failed, true, true, false, true)), false)
+    T.eq("K2 failed save keeps the current complete pair", failed.current, oldCurrent)
+    T.eq("K3 failed save keeps the previous complete pair", failed.previous, oldPrevious)
+    T.eq("K4 native failure records one pending-only payload",
+        failed.pendingOnly.payloadKind, "PENDING_ONLY")
+    T.eq("K5 pending-only payload binds to the last complete generation",
+        failed.pendingOnly.baseGeneration, 7)
+    T.near("K6 pending-only payload keeps field-wide accepted water",
+        failed.pendingOnly.fieldPending, 0.020, 1e-12)
+    T.near("K7 pending-only payload keeps positional accepted water",
+        failed.pendingOnly.positionalPending, 0.003, 1e-12)
+    T.eq("K8 non-throwing native false is failure",
+        exactNativeSaveSuccess(true, false), false)
+    T.eq("K9 thrown native save is failure", exactNativeSaveSuccess(false, nil), false)
+    T.eq("K9a pending-only copies the base carrier cursor, not newer RAM cursor",
+        failed.pendingOnly.baseLastSettledMonotonicDay, 20)
+    T.eq("K9b pending-only copies the base carrier revision",
+        failed.pendingOnly.baseRevision, 41)
+
+    local failedRecovery = newPersistenceState(7, 41, 0.020, 0.003)
+    synchronousSave(failedRecovery, true, true, false, false)
+    T.eq("K10 failed compact recovery claims no pending-only durability",
+        failedRecovery.pendingOnly, nil)
+
+    local saved = newPersistenceState(7, 41, 0.020, 0.003)
+    saved.lastSettledMonotonicDay = 22
+    local ok, capture = synchronousSave(saved, true, true, true, true)
+    T.eq("K11 synchronous capture commits after every required act succeeds", ok, true)
+    T.eq("K12 committed generation advances once", saved.current.generation, 8)
+    T.eq("K13 committed pair carries the frozen provider revision", saved.current.revision, 41)
+    T.near("K14 committed pair carries frozen field pending",
+        saved.current.fieldPending, 0.020, 1e-12)
+    T.near("K15 committed pair carries frozen positional pending",
+        saved.current.positionalPending, 0.003, 1e-12)
+    T.eq("K16 capture revision is immutable inside the save act", capture.revision, 41)
+    T.eq("K17 persistence packing consumes no ordinary frame budget", saved.framePackingSteps, 0)
+    T.eq("K17a committed pair carries the captured carrier cursor",
+        saved.current.lastSettledMonotonicDay, 22)
+
+    local compactFailed = newPersistenceState(7, 41, 0.020, 0.003)
+    local compactOldCurrent = compactFailed.current
+    local compactOldPrevious = compactFailed.previous
+    T.eq("K18 compact failure refuses the candidate generation",
+        select(1, synchronousSave(compactFailed, true, true, true, false)), false)
+    T.eq("K19 compact failure keeps current pair byte-object stable",
+        compactFailed.current, compactOldCurrent)
+    T.eq("K20 compact failure keeps previous pair byte-object stable",
+        compactFailed.previous, compactOldPrevious)
+end
+
+local function newProviderFailureState()
+    return {
+        mode = "TRUTH", current = true, revision = 12, valueMap = {},
+        retainedCellsPromoted = false, fieldPending = 0, positionalPending = 0,
+        aggregate = 0.55, aggregateCurrent = true, geometryInvalid = false,
+    }
+end
+
+local function failNative(state)
+    state.mode = "UNAVAILABLE_PENDING_RELOAD"
+    state.current = false
+    state.valueMap = nil
+end
+
+local function acceptUnavailable(state, fieldGain, positionalGain)
+    state.fieldPending = state.fieldPending + fieldGain
+    state.positionalPending = state.positionalPending + positionalGain
+end
+
+local function classifyPolygonAverage(inputValid, mapAvailable, executeGetAvailable,
+    pcallOk, accumulator, numPixels)
+    if not inputValid then return "INVALID_FIELD_GEOMETRY", nil end
+    if not mapAvailable or not executeGetAvailable or not pcallOk then
+        return "PROVIDER_REFUSAL", nil
+    end
+    if type(accumulator) ~= "number" or accumulator ~= accumulator
+        or math.abs(accumulator) == math.huge
+        or type(numPixels) ~= "number" or numPixels ~= numPixels
+        or math.abs(numPixels) == math.huge or numPixels < 0 then
+        return "PROVIDER_REFUSAL", nil
+    end
+    if numPixels == 0 then return "EMPTY", nil end
+    return "OK", accumulator / numPixels
+end
+
+local function handlePolygonAverage(state, inputValid, mapAvailable, executeGetAvailable,
+    pcallOk, accumulator, numPixels)
+    local outcome, mean = classifyPolygonAverage(inputValid, mapAvailable,
+        executeGetAvailable, pcallOk, accumulator, numPixels)
+    if outcome == "INVALID_FIELD_GEOMETRY" then
+        state.geometryInvalid = true
+        state.aggregateCurrent = false
+    elseif outcome == "EMPTY" then
+        state.aggregate = nil
+        state.aggregateCurrent = false
+    elseif outcome == "PROVIDER_REFUSAL" then
+        failNative(state)
+        state.aggregateCurrent = false
+    else
+        state.aggregate = mean
+        state.aggregateCurrent = true
+    end
+    return outcome, mean
+end
+
+-- GROUP L: ACTIVE NATIVE FAILURE IS ONE-WAY; INVALID, EMPTY AND REFUSAL ARE
+-- DISTINCT POLYGON-MEAN OUTCOMES. SDS v2.1 sections 3.3, 3.9A and 5.8A.
+-- CropStressValueMap.lua:376-391 and SoilMoistureSystem.lua:978-982 currently
+-- collapse and silently retain these cases.
+do
+    local state = newProviderFailureState()
+    failNative(state)
+    T.eq("L1 native failure selects the explicit unavailable mode",
+        state.mode, "UNAVAILABLE_PENDING_RELOAD")
+    T.eq("L2 native failure removes fine currentness", state.current, false)
+    T.eq("L3 failing native handle is detached", state.valueMap, nil)
+    T.eq("L4 retained fallback evidence is not promoted", state.retainedCellsPromoted, false)
+    acceptUnavailable(state, 0.02, 0.003)
+    T.near("L5 field-wide accepted water remains pending", state.fieldPending, 0.02, 1e-12)
+    T.near("L6 positional accepted water remains pending", state.positionalPending, 0.003, 1e-12)
+    T.eq("L7 unavailable pending does not mint readable revision", state.revision, 12)
+
+    local invalid = newProviderFailureState()
+    T.eq("L8 malformed field polygon has its own outcome",
+        select(1, handlePolygonAverage(invalid, false, true, true, true, 10, 5)),
+        "INVALID_FIELD_GEOMETRY")
+    T.eq("L9 malformed field polygon does not poison native provider", invalid.mode, "TRUTH")
+    T.eq("L10 malformed field polygon requests context rebuild", invalid.geometryInvalid, true)
+
+    local empty = newProviderFailureState()
+    T.eq("L11 valid polygon with zero written pixels is EMPTY",
+        select(1, handlePolygonAverage(empty, true, true, true, true, 0, 0)), "EMPTY")
+    T.eq("L12 empty polygon does not poison native provider", empty.mode, "TRUTH")
+    T.eq("L13 empty polygon refuses stale aggregate currentness", empty.aggregateCurrent, false)
+    T.eq("L14 empty polygon does not retain the old scalar as current", empty.aggregate, nil)
+
+    local refused = newProviderFailureState()
+    T.eq("L15 valid native polygon read refusal is explicit",
+        select(1, handlePolygonAverage(refused, true, true, true, false, nil, nil)),
+        "PROVIDER_REFUSAL")
+    T.eq("L16 valid native polygon refusal fails the provider closed",
+        refused.mode, "UNAVAILABLE_PENDING_RELOAD")
+
+    local valid = newProviderFailureState()
+    local outcome, mean = handlePolygonAverage(valid, true, true, true, true, 3, 6)
+    T.eq("L17 successful polygon mean is OK", outcome, "OK")
+    T.near("L18 successful polygon mean publishes the derived value", mean, 0.50, 1e-12)
+    T.eq("L19 successful polygon mean remains current", valid.aggregateCurrent, true)
+
+    local persisted = newPersistenceState(7, state.revision,
+        state.fieldPending, state.positionalPending)
+    synchronousSave(persisted, true, true, false, true)
+    local pending = persisted.pendingOnly
+    local mode, generation, _digest, pendingDigest, pendingStatus, selectedCursor = selectPersistence({
+        {
+            payloadKind = "COMPLETE", generation = 7, digest = "g7",
+            compactOk = true, nativeOk = true, revision = persisted.current.revision,
+            lastSettledMonotonicDay = persisted.current.lastSettledMonotonicDay,
+        },
+        {
+            payloadKind = pending.payloadKind,
+            baseGeneration = pending.baseGeneration,
+            baseRevision = pending.baseRevision,
+            baseLastSettledMonotonicDay = pending.baseLastSettledMonotonicDay,
+            digest = pending.digest,
+            compactOk = true,
+            zoneOk = pending.zoneOk,
+        },
+    })
+    T.eq("L20 reload keeps the complete pair as fine authority", mode, "TRUTH")
+    T.eq("L21 reload binds recovery only to its exact base generation", generation, 7)
+    T.eq("L22 reload restores the matching pending-only payload", pendingDigest, pending.digest)
+    T.eq("L23 pending-only reload disposition is explicit", pendingStatus, "APPLIED")
+    T.eq("L24 matching pending-only reload preserves selected carrier cursor",
+        selectedCursor, persisted.current.lastSettledMonotonicDay)
+end
+
+local function exactRegistrationActive(pcallOk, returned)
+    return pcallOk == true and returned == true
+end
+
+-- GROUP M: OPTIONAL SERVICE REGISTRATION REQUIRES EXACT BOOLEAN SUCCESS.
+-- StateLedger.lua:51-77 and NetworkSync.lua:92-118 return true only after
+-- registration. Current SCS bridges incorrectly treat any non-throwing call as active.
+do
+    T.eq("M1 exact true registration activates a bridge", exactRegistrationActive(true, true), true)
+    T.eq("M2 false registration is neutral absence", exactRegistrationActive(true, false), false)
+    T.eq("M3 nil registration is neutral absence", exactRegistrationActive(true, nil), false)
+    T.eq("M4 thrown registration is neutral absence", exactRegistrationActive(false, nil), false)
+end
+
+local function canMarkFineCurrent(carrier)
+    return carrier == "SCS_EVENTS"
+end
+
+-- GROUP N: GENERATION-QUALIFIED MAP TRANSPORT REMAINS SCS-OWNED.
+-- RealisticFarmingSyncEvent.lua:101-136 and NetworkSync.lua:362-391 expose no
+-- generation discriminator. SDS v2.1 section 3.9 keeps fine currentness on SCS events.
+do
+    T.eq("N1 SCS event family may carry fine currentness", canMarkFineCurrent("SCS_EVENTS"), true)
+    T.eq("N2 NetworkSync aggregate mirror cannot mark fine currentness",
+        canMarkFineCurrent("NETWORKSYNC_AGGREGATE"), false)
+    T.eq("N3 StateLedger persistence never marks fine transport current",
+        canMarkFineCurrent("STATELEDGER"), false)
+end
+
+local function newConservationState()
+    return {
+        revision = 10,
+        fieldPending = 0,
+        positionalPending = {},
+        writes = 0,
+    }
+end
+
+local function positionalPendingTotal(state)
+    local total = 0
+    for _, row in pairs(state.positionalPending) do total = total + row.amount end
+    return total
+end
+
+local function acceptPositional(state, validTarget, pixelKey, worldKey, sourceWidth,
+    gain, writeOk)
+    if not validTarget or type(gain) ~= "number" or gain <= 0 then
+        return false, "INVALID_TARGET"
+    end
+    local key = pixelKey ~= nil and ("PIXEL:" .. tostring(pixelKey))
+        or ("WORLD:" .. tostring(worldKey))
+    local prior = state.positionalPending[key]
+    local pending = (prior ~= nil and prior.amount or 0) + gain
+    state.positionalPending[key] = {
+        status = pixelKey ~= nil and "RESOLVED" or "UNRESOLVED",
+        pixelKey = pixelKey,
+        worldKey = worldKey,
+        sourceWidth = sourceWidth,
+        amount = pending,
+    }
+    if pixelKey == nil then return true, "PENDING_UNRESOLVED" end
+    local applied, remainder = CropStressValueMap.quantiseDelta(pending)
+    if applied == 0 then return true, "PENDING_SUBSTEP" end
+    if writeOk ~= true then return true, "PENDING_WRITE_REFUSAL" end
+    state.positionalPending[key].amount = remainder
+    state.revision = state.revision + 1
+    state.writes = state.writes + 1
+    return true, "APPLIED"
+end
+
+local function revalidatePositional(state, worldKey, pixelKey)
+    local oldKey = "WORLD:" .. tostring(worldKey)
+    local row = state.positionalPending[oldKey]
+    if row == nil or pixelKey == nil then return false end
+    local newKey = "PIXEL:" .. tostring(pixelKey)
+    local existing = state.positionalPending[newKey]
+    state.positionalPending[newKey] = {
+        status = "RESOLVED", pixelKey = pixelKey, worldKey = row.worldKey,
+        sourceWidth = row.sourceWidth,
+        amount = row.amount + (existing ~= nil and existing.amount or 0),
+    }
+    state.positionalPending[oldKey] = nil
+    return true
+end
+
+local function packPositional(rows)
+    local out = {}
+    for key, row in pairs(rows) do
+        out[#out + 1] = {
+            key = key, status = row.status, pixelKey = row.pixelKey,
+            worldKey = row.worldKey, sourceWidth = row.sourceWidth, amount = row.amount,
+        }
+    end
+    table.sort(out, function(a, b) return a.key < b.key end)
+    return out
+end
+
+local function unpackPositional(rows)
+    local out = {}
+    for _, row in ipairs(rows) do
+        out[row.key] = {
+            status = row.status, pixelKey = row.pixelKey,
+            worldKey = row.worldKey, sourceWidth = row.sourceWidth, amount = row.amount,
+        }
+    end
+    return out
+end
+
+local function spendFieldPending(state, incoming, geometryValid, writeOk)
+    local pending = state.fieldPending + incoming
+    if not geometryValid then
+        state.fieldPending = pending
+        return "INVALID_FIELD_GEOMETRY"
+    end
+    local applied, remainder = CropStressValueMap.quantiseDelta(pending)
+    if applied == 0 then
+        state.fieldPending = remainder
+        return "PENDING_SUBSTEP"
+    end
+    if writeOk ~= true then
+        state.fieldPending = pending
+        return "PROVIDER_REFUSAL"
+    end
+    state.fieldPending = remainder
+    state.revision = state.revision + 1
+    state.writes = state.writes + 1
+    return "APPLIED"
+end
+
+-- GROUP O: ACCEPTED WATER ENTERS ONE EXISTING PENDING NAMESPACE BEFORE
+-- DESTINATION SPEND. SDS v2.1 sections 3.5, 3.6, 5.2 and 5.3.
+do
+    local invalid = newConservationState()
+    T.eq("O1 invalid positional target is not accepted",
+        select(1, acceptPositional(invalid, false, nil, "10,10", 2, 0.01, false)), false)
+    T.eq("O2 invalid target creates no positional pending", positionalPendingTotal(invalid), 0)
+
+    local unresolved = newConservationState()
+    T.eq("O3 valid position with unresolved pixel is accepted into pending",
+        select(1, acceptPositional(unresolved, true, nil, "10,10", 2, 0.01, false)), true)
+    T.near("O4 unresolved pixel preserves the full accepted gain",
+        positionalPendingTotal(unresolved), 0.01, 1e-12)
+    T.eq("O5 unresolved pixel mints no readable revision", unresolved.revision, 10)
+    local packed = packPositional(unresolved.positionalPending)
+    local restored = newConservationState()
+    restored.positionalPending = unpackPositional(packed)
+    T.eq("O6 unresolved positional status survives compact round trip",
+        restored.positionalPending["WORLD:10,10"].status, "UNRESOLVED")
+    T.eq("O7 unresolved positional source width survives compact round trip",
+        restored.positionalPending["WORLD:10,10"].sourceWidth, 2)
+    T.eq("O8 unique revalidation resolves the existing leaf",
+        revalidatePositional(restored, "10,10", 4101), true)
+    T.near("O9 revalidation conserves the exact positional total",
+        positionalPendingTotal(restored), 0.01, 1e-12)
+
+    local refused = newConservationState()
+    acceptPositional(refused, true, 4101, "10,10", 2, 0.01, false)
+    T.near("O10 native write refusal keeps the pre-spend positional amount",
+        positionalPendingTotal(refused), 0.01, 1e-12)
+    T.eq("O11 native write refusal mints no revision", refused.revision, 10)
+
+    local field = newConservationState()
+    T.eq("O12 invalid field geometry retains full pre-quantisation pending",
+        spendFieldPending(field, 0.01, false, false), "INVALID_FIELD_GEOMETRY")
+    T.near("O13 invalid geometry keeps the field-wide amount", field.fieldPending, 0.01, 1e-12)
+    T.eq("O14 geometry retry applies once after rebuild",
+        spendFieldPending(field, 0, true, true), "APPLIED")
+    T.eq("O15 geometry retry advances revision once", field.revision, 11)
+    T.eq("O16 field-wide refusal never enters positional pending",
+        positionalPendingTotal(field), 0)
+end
+
+local function forwardHourEdge(lastKey, currentKey, cap)
+    if type(currentKey) ~= "number" then return 0, lastKey, "INVALID" end
+    if lastKey == nil or lastKey < 0 then return 1, currentKey, "FIRST" end
+    if currentKey <= lastKey then return 0, lastKey, "REJECTED" end
+    local elapsed = math.floor(currentKey - lastKey)
+    if elapsed <= 0 then return 0, lastKey, "REJECTED" end
+    return math.min(elapsed, cap), currentKey, "FORWARD"
+end
+
+local function scheduledDisposition(machineryAvailable, supportedType, acceptedTargets)
+    if not machineryAvailable then return "LEGACY_FIELD_FALLBACK" end
+    if supportedType and acceptedTargets > 0 then return "POSITIONAL_ACCEPTED" end
+    return "POSITIONAL_REFUSED"
+end
+
+local function fieldFallbackGain(disposition, incumbentGain)
+    if disposition == "LEGACY_FIELD_FALLBACK" then return incumbentGain end
+    return 0
+end
+
+local function committedService(disposition, plannedHours)
+    return plannedHours
+end
+
+-- GROUP P: SCS-037 OWNS THE FORWARD HOUR EDGE AND SCS-023 OWNS ACTUAL
+-- PER-FIELD SCHEDULED DELIVERY. SDS v2.1 sections 4 and 5.2.
+do
+    local hours, baseline, status = forwardHourEdge(40, 43, 168)
+    T.eq("P1 forward hour edge supplies the exact elapsed span", hours, 3)
+    T.eq("P2 forward hour edge advances its baseline", baseline, 43)
+    T.eq("P3 forward hour edge is explicit", status, "FORWARD")
+
+    hours, baseline, status = forwardHourEdge(40, 39, 168)
+    T.eq("P4 backward hour edge supplies no moisture work", hours, 0)
+    T.eq("P5 backward hour edge retains the prior forward baseline", baseline, 40)
+    T.eq("P6 backward hour edge is rejected before the provider", status, "REJECTED")
+
+    hours, baseline, status = forwardHourEdge(40, 40.5, 168)
+    T.eq("P6a fractional sub-hour input supplies no whole hourly work", hours, 0)
+    T.eq("P6b fractional sub-hour input retains the prior frontier", baseline, 40)
+
+    local accepted = scheduledDisposition(true, true, 4)
+    local refused = scheduledDisposition(true, false, 0)
+    local legacy = scheduledDisposition(false, true, 0)
+    T.eq("P7 actual target acceptance selects positional delivery", accepted, "POSITIONAL_ACCEPTED")
+    T.eq("P8 unsupported or empty coverage is explicit refusal", refused, "POSITIONAL_REFUSED")
+    T.eq("P9 unavailable positional machinery selects incumbent fallback", legacy, "LEGACY_FIELD_FALLBACK")
+    T.eq("P10 accepted positional field suppresses only its own fallback",
+        fieldFallbackGain(accepted, 0.02), 0)
+    T.eq("P11 refused positional coverage invents no field-wide fallback",
+        fieldFallbackGain(refused, 0.02), 0)
+    T.near("P12 unavailable machinery preserves incumbent field-wide fallback",
+        fieldFallbackGain(legacy, 0.02), 0.02, 1e-12)
+    T.eq("P13 scheduled refusal still commits the immutable planned service",
+        committedService(refused, 2), 2)
+    T.eq("P14 accepted targets commit the same planned service once",
+        committedService(accepted, 2), 2)
+    T.eq("P15 coverage refusal never reallocates a peer's planned share",
+        committedService(accepted, 2), committedService(refused, 2))
+    T.eq("P16 legacy fallback still commits the represented scheduled service",
+        committedService(legacy, 2), 2)
+end
+
+T.summary()
+

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -32,7 +32,7 @@ local function currentStubMap(grain)
         return nil, self.grain, "EMPTY"
     end
     function m:worldToPixel(_x, _z) return 1, 1 end
-    function m:writeValueAtWorld(_x, _z, _value, _radius) return true end
+    function m:writeValueAtWorld(_x, _z, _value, _radius) return true, "OK" end
     function m:delete()
         self.deleted = self.deleted + 1
         self.available = false
@@ -62,14 +62,14 @@ local function currentSystem()
 end
 
 -- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
--- Slices 1-6 (Fred): every Group A assertion A1-A15 is now re-pointed from
+-- Slices 1-7 (Fred): every Group A assertion A1-A16 is now re-pointed from
 -- absence to PRESENCE against the built SCS-039 surfaces. Slice 4 lands the
--- polygon-aggregate fail-closed path (A12); slice 6 lands the point-read
--- fail-closed path (A15). No Group A tripwire remains on absence. (The member
--- is not complete: SDS 3.5-3.9 live wiring, atomic save generations, daily
--- plan + Time Guard subscribeTick, snapshot/delta events, NetworkSync compat
--- and the overlay gate, are still later slices, modelled by the pure-contract
--- Groups B-P.)
+-- polygon-aggregate fail-closed path (A12); slice 6 the point-read fail-closed
+-- path (A15); slice 7 the region-write fail-closed path (A16). No Group A
+-- tripwire remains on absence. (The member is not complete: SDS 3.5-3.9 live
+-- wiring, atomic save generations, daily plan + Time Guard subscribeTick,
+-- snapshot/delta events, NetworkSync compat and the overlay gate, are still
+-- later slices, modelled by the pure-contract Groups B-P.)
 -- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
 -- 893-943, 1038-1064, 1364-1366. Design corrections: SDS 3.2-3.11.
 do
@@ -183,6 +183,28 @@ do
         a14leaf and a14leaf.sourceWidth or nil, 2)
     T.eq("A14e BUILT: unresolved pending-only water mints no readable revision",
         unresolvedSys.moistureRevision, a14revBefore)
+
+    -- SCS-039 slice 7 re-point: a genuine native REGION-WRITE refusal at the
+    -- positional spend (applyWaterAtCell destination write, SDS 3.3/3.4) fails
+    -- the provider closed AND conserves the full pre-spend accepted amount.
+    -- Pending is debited and the readable revision advances only after the
+    -- destination read and write both succeed exactly (Group O O10/O11).
+    local writeSys = currentSystem()
+    writeSys.valueMap = currentStubMap(2)
+    writeSys.providerMode = "TRUTH"
+    writeSys.valueMap.writeValueAtWorld = function() return false, "PROVIDER_REFUSAL" end
+    local a16revBefore = writeSys.moistureRevision
+    local a16accepted = writeSys:applyWaterAtCell(1, 10, 10, 0.02)
+    T.eq("A16 BUILT: a native region-write refusal fails the provider closed",
+        writeSys.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+    T.eq("A16b BUILT: the write failed-closed provider is no longer current",
+        writeSys:isMoistureMapCurrent(), false)
+    T.eq("A16c BUILT: write-refusal fail-closed holds the readable revision",
+        writeSys.moistureRevision, a16revBefore)
+    T.eq("A16d BUILT: water whose destination write refused is still accepted",
+        a16accepted, true)
+    T.near("A16e BUILT: the refused spend conserves the full pre-spend amount",
+        writeSys._mapWaterPending[1][4097], 0.02, 1e-12)
 end
 
 local Ref = {}

--- a/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
+++ b/tools/test/lua/SCS-039-grid_concordance_spec_test.lua
@@ -60,10 +60,13 @@ local function currentSystem()
 end
 
 -- GROUP A: PROVIDER CONFORMANCE TRIPWIRE (re-pointed as slices land).
--- Slices 1-3 (Fred, PENDING DESIGN REVIEW): A1, A3, A5, A6, A7, A8, A9, A11, A13
--- and A14 are re-pointed from absence to PRESENCE against the built SCS-039
--- surfaces. A12 alone remains an absence assertion for the still-unbuilt native
--- refusal fail-closed slice, so the tripwire keeps tracking what has not landed yet.
+-- Slices 1-4 (Fred, PENDING DESIGN REVIEW): every Group A assertion A1-A14 is now
+-- re-pointed from absence to PRESENCE against the built SCS-039 surfaces. Slice 4
+-- lands the native-refusal fail-closed path (A12), so no Group A tripwire remains
+-- on absence. (The member is not complete: SDS 3.5-3.9 live wiring -- atomic save
+-- generations, daily plan + Time Guard subscribeTick, snapshot/delta events,
+-- NetworkSync compat, overlay gate -- are still later slices, modelled by the
+-- pure-contract Groups B-P.)
 -- Source coordinates: SoilMoistureSystem.lua:69, 178-190, 680-712, 748-768,
 -- 893-943, 1038-1064, 1364-1366. Design corrections: SDS 3.2-3.11.
 do
@@ -120,16 +123,23 @@ do
         nativeSaveMap:saveToSavegame("synthetic-save-root"), false)
     saveBitVectorMapToFile = originalNativeSave
 
-    -- SoilMoistureSystem.lua:978-982 retains the old scalar for every nil mean,
-    -- while CropStressValueMap.lua:376-391 collapses invalid, empty and refusal.
+    -- SCS-039 slice 4 re-point: after TRUTH is the current authority, a native
+    -- polygon-aggregate refusal on the daily settle fails the provider CLOSED
+    -- (SDS 3.3) instead of silently retaining the prior field scalar as current.
     local meanSys = currentSystem()
     meanSys.valueMap = currentStubMap(2)
+    meanSys.providerMode = "TRUTH"
     meanSys._drainFieldOnMap = function() return false end
-    meanSys.valueMap.readAverageOfPolygon = function() return nil, nil end
+    meanSys.valueMap.readAverageOfPolygon = function() return "PROVIDER_REFUSAL", nil, nil end
     meanSys.fieldData[1].moisture = 0.61
+    local a12revBefore = meanSys.moistureRevision
     meanSys:settleDaily(1)
-    T.near("A12 current polygon refusal silently retains the prior field scalar",
-        meanSys.fieldData[1].moisture, 0.61, 1e-12)
+    T.eq("A12 BUILT: a native polygon-read refusal after TRUTH fails the provider closed",
+        meanSys.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+    T.eq("A12b BUILT: the failed-closed provider is no longer current",
+        meanSys:isMoistureMapCurrent(), false)
+    T.eq("A12c BUILT: failing closed holds the readable revision",
+        meanSys.moistureRevision, a12revBefore)
 
     local acceptedSys = currentSystem()
     acceptedSys.valueMap = currentStubMap(2)

--- a/tools/test/lua/scs039_capture_persistence_test.lua
+++ b/tools/test/lua/scs039_capture_persistence_test.lua
@@ -1,0 +1,95 @@
+-- scs039_capture_persistence_test.lua
+-- SCS-039 / GRID-1 (SDS 3.5 capture groundwork): the provider revision, the
+-- settled-day cursor and the field-wide pending carry are persisted on both
+-- save surfaces. They are what the SDS 3.5 COMPLETE envelope carries at the
+-- capture revision; until then they were simply lost on save and reload
+-- (revision reset to 1, mapPending dropped).
+--
+-- These tests round-trip the REAL SaveLoadHandler against the REAL
+-- SoilMoistureSystem seams, once through the own-XML path (in-memory handle
+-- driven by the prelude XML mocks) and once through the StateLedger table path
+-- (buildStateTable / applyStateTable).
+--!load: src/SoilMoistureSystem.lua, src/SaveLoadHandler.lua
+
+local function soilWithFields()
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.62, soilType = "loamy", mapPending = 0.002 }
+  soil.fieldData[2] = { fieldId = 2, moisture = 0.40, soilType = "sandy", mapPending = 0 }
+  soil.moistureRevision = 34
+  soil._lastSettledDay = 12
+  soil._mapWaterPending[1] = { [5] = 0.001 }
+  return soil
+end
+
+local function emptySoilWithFields()
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.50, soilType = "loamy" }
+  soil.fieldData[2] = { fieldId = 2, moisture = 0.50, soilType = "sandy" }
+  return soil
+end
+
+local function newSaveLoad(soil)
+  local stressModifier = { fieldStress = {}, getStress = function() return 0.0 end }
+  local handler = SaveLoadHandler.new({ soilSystem = soil, stressModifier = stressModifier })
+  handler:initialize()
+  return handler
+end
+
+-- 1. OWN-XML ROUND TRIP: revision, cursor and both pending namespaces survive.
+do
+  local sourceSoil = soilWithFields()
+  local sh = newSaveLoad(sourceSoil)
+  local handle = {}
+  sh:saveToXMLFile(handle)
+
+  local targetSoil = emptySoilWithFields()
+  local sh2 = newSaveLoad(targetSoil)
+  sh2:loadFromXMLFile(handle)
+
+  T.eq("xml.revisionSurvives", targetSoil.moistureRevision, 34)
+  T.eq("xml.cursorSurvives", targetSoil._lastSettledDay, 12)
+  T.near("xml.fieldPendingSurvives", targetSoil.fieldData[1].mapPending, 0.002, 1e-12)
+  T.eq("xml.clearedPendingSurvives", targetSoil.fieldData[2].mapPending, 0)
+  T.near("xml.positionalSurvives", targetSoil._mapWaterPending[1][5], 0.001, 1e-12)
+  T.near("xml.scalarSurvives", targetSoil.fieldData[1].moisture, 0.62, 1e-12)
+end
+
+-- 2. LEDGER TABLE ROUND TRIP mirrors the own-XML carrier exactly.
+do
+  local sourceSoil = soilWithFields()
+  local sh = newSaveLoad(sourceSoil)
+  local state = sh:buildStateTable()
+
+  T.eq("ledger.revisionCarried", state.moistureRevision, 34)
+  T.eq("ledger.cursorCarried", state.lastSettledDay, 12)
+  T.near("ledger.fieldPendingCarried", state.fields[1].mapPending, 0.002, 1e-12)
+  T.eq("ledger.clearedPendingAbsent", state.fields[2].mapPending, nil)
+
+  local targetSoil = emptySoilWithFields()
+  local sh2 = newSaveLoad(targetSoil)
+  sh2:applyStateTable(state)
+
+  T.eq("ledger.revisionApplied", targetSoil.moistureRevision, 34)
+  T.eq("ledger.cursorApplied", targetSoil._lastSettledDay, 12)
+  T.near("ledger.fieldPendingApplied", targetSoil.fieldData[1].mapPending, 0.002, 1e-12)
+  T.near("ledger.positionalApplied", targetSoil._mapWaterPending[1][5], 0.001, 1e-12)
+  T.near("ledger.scalarApplied", targetSoil.fieldData[1].moisture, 0.62, 1e-12)
+end
+
+-- 3. A FRESH SAVE (no keys present) does not invent a revision or a cursor:
+--    the defaults from SoilMoistureSystem.new stand.
+do
+  local sourceSoil = SoilMoistureSystem.new({})
+  sourceSoil.fieldData[1] = { fieldId = 1, moisture = 0.50, soilType = "loamy" }
+  local sh = newSaveLoad(sourceSoil)
+  local handle = {}
+  sh:saveToXMLFile(handle)
+  local targetSoil = emptySoilWithFields()
+  local sh2 = newSaveLoad(targetSoil)
+  sh2:loadFromXMLFile(handle)
+  T.eq("fresh.keepsDefaultRevision", targetSoil.moistureRevision, 1)
+  T.eq("fresh.keepsNilCursor", targetSoil._lastSettledDay, nil)
+  T.eq("fresh.noPositional", type(targetSoil._mapWaterPending[1]), "nil")
+end
+
+T.summary()

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -195,6 +195,33 @@ do
   T.near("set.survivesSettle", sys.fieldData[1].moisture, 0.80, 1e-9)
 end
 
+-- 8b. NATIVE SAVE REFUSAL FAILS THE PROVIDER CLOSED (SDS 3.3). A native save that
+--     never reached disk must not leave the mission still trusting the fine map;
+--     the scalar rows become the honest degrade layer and the next load re-selects.
+do
+  local sys = newSystem()
+  sys.valueMap = stubMap(2)
+  sys.providerMode = "TRUTH"
+  sys.valueMap.saveToSavegame = function() return false end
+  local ok = sys:saveNativeMap("/nowhere")
+  T.eq("save.refusalReportsFalse", ok, false)
+  T.eq("save.refusalFailsClosed", sys.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+  T.eq("save.refusalDetachesReads", sys:mapActive(), false)
+end
+
+-- 8c. A SUCCESSFUL NATIVE SAVE keeps TRUTH the current authority and never trips
+--     the one-way fail-closed transition.
+do
+  local sys = newSystem()
+  sys.valueMap = stubMap(2)
+  sys.providerMode = "TRUTH"
+  sys.valueMap.saveToSavegame = function() return true end
+  local ok = sys:saveNativeMap("/nowhere")
+  T.eq("save.successReportsTrue", ok, true)
+  T.eq("save.successKeepsTruth", sys.providerMode, "TRUTH")
+  T.eq("save.successKeepsMapActive", sys:mapActive(), true)
+end
+
 
 -- 9. MAP DRAINAGE: conserved by construction, and it runs downhill.
 --    Water must MOVE between places without the field total changing, and it

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -75,10 +75,12 @@ do
   T.eq("absent.mapNotActive", sys:mapActive(), false)
   T.eq("absent.migrateRefuses", sys:migrateFieldToMap(1), false)
 
-  -- The positional getter falls back to the cell path and reports CELL grain.
+  -- The positional getter falls back to the cell path and reports CELL grain
+  -- when a cell exists, NIL grain for an absent-zone-cell aggregate fallback
+  -- (SCS-039 v2.1, Iris fix 3: no fabricated zone-cell grain).
   local v, grain = sys:getMoisture(1, 10, 10)
   T.near("absent.readsAggregate", v, 0.50, 1e-9)
-  T.eq("absent.reportsCellGrain", grain, sys:getCellSize())
+  T.eq("absent.aggregateGrainNil", grain, nil)
 
   -- Field-level read is unchanged and reports no grain.
   local fv, fgrain = sys:getMoisture(1)

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -44,7 +44,10 @@ local function stubMap(grain)
     return delta            -- pretend the engine applied it in full
   end
   function m:readAverageOfPolygon(_vx, _vz, _n)
-    return self.meanToReturn, self.grain
+    -- SCS-039 v2.1 typed contract: a nil meanToReturn models a valid-but-EMPTY
+    -- polygon (not a provider refusal), so the daily settle leaves the scalar.
+    if self.meanToReturn == nil then return "EMPTY", nil, self.grain end
+    return "OK", self.meanToReturn, self.grain
   end
   return m
 end

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -32,9 +32,10 @@ local function stubMap(grain)
     return true
   end
   function m:writeValueAtWorld(x, z, value, _r)
+    -- SCS-039 v2.1 typed contract: a non-throwing stub write is OK.
     self.writes[#self.writes + 1] = { x = x, z = z, v = value }
     self.pixels[string.format("%d:%d", math.floor(x), math.floor(z))] = value
-    return true
+    return true, "OK"
   end
   function m:readValueAtWorld(x, z)
     -- SCS-039 v2.1 typed contract: an unwritten pixel is EMPTY (benign), a

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -24,6 +24,9 @@ local function stubMap(grain)
     meanToReturn = nil,
   }
   function m:getGrainMetres() return self.grain end
+  -- worldToPixel is part of the sanctioned map interface (the SCS-039 authority
+  -- bar's stub provides it too); the positional water path keys pending by pixel.
+  function m:worldToPixel(x, z) return math.floor(x), math.floor(z) end
   function m:paintPolygon(_vx, _vz, _n, value)
     self.painted[#self.painted + 1] = value
     return true
@@ -101,7 +104,10 @@ do
   T.ok("present.mapWasWritten", #sys.valueMap.writes > 0)
 
   local v, grain = sys:getMoisture(1, 10, 10)
-  T.near("present.readsMapValue", v, 0.70, 1e-6)
+  -- SCS-039 quantisation law: a positional write lands on whole raw steps, so the
+  -- read-back is the semantic amount floored to the nearest raw step (a 0.20 gain
+  -- becomes 50 of the 254 steps), always within one raw step of 0.70.
+  T.near("present.readsMapValue", v, 0.70, 1 / CropStressValueMap.RAW_SPAN)
   T.eq("present.reportsMapGrain", grain, 2)
 end
 

--- a/tools/test/lua/scs039_delegation_test.lua
+++ b/tools/test/lua/scs039_delegation_test.lua
@@ -37,7 +37,11 @@ local function stubMap(grain)
     return true
   end
   function m:readValueAtWorld(x, z)
-    return self.pixels[string.format("%d:%d", math.floor(x), math.floor(z))], self.grain
+    -- SCS-039 v2.1 typed contract: an unwritten pixel is EMPTY (benign), a
+    -- written one is OK; only a throw would be a PROVIDER_REFUSAL.
+    local v = self.pixels[string.format("%d:%d", math.floor(x), math.floor(z))]
+    if v == nil then return nil, self.grain, "EMPTY" end
+    return v, self.grain, "OK"
   end
   function m:applyDeltaToPolygon(_vx, _vz, _n, delta)
     self.deltas[#self.deltas + 1] = delta

--- a/tools/test/lua/scs039_geometry_rekey_test.lua
+++ b/tools/test/lua/scs039_geometry_rekey_test.lua
@@ -1,0 +1,210 @@
+-- scs039_geometry_rekey_test.lua
+-- SCS-039 / GRID-1 (SDS 3.4 tail, slice 9): on a farmland ownership/geometry
+-- change every pending positional leaf is revalidated against CURRENT field
+-- geometry. Accepted water is never lost and never moves by identifier
+-- accident: a leaf re-keys only when exactly one current field owns its world
+-- position; ambiguous or missing membership stays an UNRESOLVED leaf.
+--
+-- The pure contract is modelled by the bar: Group H (unique resolution rekeys,
+-- ambiguous stays unresolved, amount preserved) and Group I (ordered polygon
+-- fingerprint change detection). These live tests drive the real re-key seam.
+--!load: src/SoilMoistureSystem.lua
+
+local function newSystem()
+  local sys = SoilMoistureSystem.new({})
+  sys._mapWaterPending = {}
+  sys._fieldVerts = {}
+  sys.fieldData = {}
+  return sys
+end
+
+local function addField(sys, fid, minX, maxX, minZ, maxZ)
+  sys.fieldData[fid] = { fieldId = fid }
+  sys._fieldVerts[fid] = {
+    vx = { minX, maxX, maxX, minX },
+    vz = { minZ, minZ, maxZ, maxZ },
+    n  = 4,
+  }
+end
+
+local function worldLeaf(worldX, worldZ, grain, amount)
+  return { status = "UNRESOLVED", worldX = worldX, worldZ = worldZ,
+           sourceWidth = grain, amount = amount }
+end
+
+local function pendingTotal(sys)
+  local total = 0
+  for _, acc in pairs(sys._mapWaterPending) do
+    for key, value in pairs(acc) do
+      if type(key) == "number" then total = total + value
+      else total = total + (value.amount or 0) end
+    end
+  end
+  return total
+end
+
+-- Locate an unresolved leaf by world coordinates. Key text is intentionally not
+-- matched: numeric-to-string rendering of a computed world centre can differ
+-- across Lua runtimes (an integer-valued double prints "150" under Lua 5.1 but
+-- "150.0" under fengari's number subtype), so the canonical test is the leaf's
+-- own stored worldX/worldZ, never a literal key guess.
+local function findWorldLeaf(sys, fieldId, worldX, worldZ)
+  local acc = sys._mapWaterPending[fieldId]
+  if acc == nil then return nil end
+  for key, leaf in pairs(acc) do
+    if type(key) == "string" and type(leaf) == "table"
+       and leaf.worldX == worldX and leaf.worldZ == worldZ then
+      return leaf
+    end
+  end
+  return nil
+end
+
+-- 1. UNIQUE RE-KEY: a leaf now uniquely owned by another field moves to that
+--    field with its amount, status and source width intact (Group H H4/H6).
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  addField(sys, 7, 150, 250, 150, 250)
+  sys._mapWaterPending[3] = {
+    ["WORLD:10,20"]   = worldLeaf(10, 20, 2, 0.01),
+    ["WORLD:180,200"] = worldLeaf(180, 200, 2, 0.02),
+  }
+  local totalBefore = pendingTotal(sys)
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("rekey.movedToUniqueOwner", moved, 1)
+  T.near("rekey.staysInOwnField", sys._mapWaterPending[3]["WORLD:10,20"].amount, 0.01, 1e-12)
+  T.eq("rekey.missingFromOldField", sys._mapWaterPending[3]["WORLD:180,200"], nil)
+  local leaf = sys._mapWaterPending[7] and sys._mapWaterPending[7]["WORLD:180,200"]
+  T.eq("rekey.arrivesAtNewField", leaf ~= nil, true)
+  T.eq("rekey.keepsUnresolvedStatus", leaf and leaf.status or nil, "UNRESOLVED")
+  T.eq("rekey.keepsWorldCoords", leaf and leaf.worldX or nil, 180)
+  T.eq("rekey.keepsSourceWidth", leaf and leaf.sourceWidth or nil, 2)
+  T.near("rekey.keepsAmount", leaf and leaf.amount or -1, 0.02, 1e-12)
+  T.near("rekey.totalConserved", pendingTotal(sys), totalBefore, 1e-12)
+end
+
+-- 2. AMBIGUOUS MEMBERSHIP stays unresolved in its stored field and is never
+--    moved to another field (Group H H5/H6).
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  addField(sys, 5, 50, 150, 50, 150)
+  sys._mapWaterPending[3] = {
+    ["WORLD:75,75"] = worldLeaf(75, 75, 2, 0.004),
+  }
+  local totalBefore = pendingTotal(sys)
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("ambiguous.noMove", moved, 0)
+  T.eq("ambiguous.noOtherField", sys._mapWaterPending[5], nil)
+  local leaf = sys._mapWaterPending[3]["WORLD:75,75"]
+  T.eq("ambiguous.staysResolved", leaf ~= nil and leaf.status or nil, "UNRESOLVED")
+  T.near("ambiguous.amountKept", leaf and leaf.amount or -1, 0.004, 1e-12)
+  T.near("ambiguous.totalConserved", pendingTotal(sys), totalBefore, 1e-12)
+end
+
+-- 3. MISSING MEMBERSHIP (the point now belongs to no current field) stays
+--    unresolved in the stored field, water never dropped.
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  sys._mapWaterPending[3] = {
+    ["WORLD:1000,1000"] = worldLeaf(1000, 1000, 2, 0.02),
+  }
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("missing.noMove", moved, 0)
+  local leaf = sys._mapWaterPending[3]["WORLD:1000,1000"]
+  T.near("missing.amountKept", leaf and leaf.amount or -1, 0.02, 1e-12)
+end
+
+-- 4. RESOLVED pixel remainder re-keys by its reconstructed world centre when
+--    the pixel map is present. res=4 over terrainSize=400 gives 100 m pixels
+--    centred at x = 100*(px+0.5) - 200: px 2 -> (50,50), px 3 -> (150,150).
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  addField(sys, 7, 120, 220, 120, 220)
+  sys.valueMap = { available = true, resolution = 4, terrainSize = 400 }
+  sys._mapWaterPending[3] = {
+    [8194]  = 0.001,   -- px2,pz2 centre (50,50)  -> stays field 3
+    [12291] = 0.002,   -- px3,pz3 centre (150,150) -> moves to field 7
+  }
+  local totalBefore = pendingTotal(sys)
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("resolved.movedToOwner", moved, 1)
+  T.near("resolved.staysNumeric", sys._mapWaterPending[3][8194], 0.001, 1e-12)
+  T.eq("resolved.leftOldField", sys._mapWaterPending[3][12291], nil)
+  T.near("resolved.arrivesAtNewField", sys._mapWaterPending[7][12291], 0.002, 1e-12)
+  T.eq("resolved.arrivesResolved", type(sys._mapWaterPending[7][12291]), "number")
+  T.near("resolved.totalConserved", pendingTotal(sys), totalBefore, 1e-12)
+end
+
+-- 5. A RESOLVED remainder whose world centre is now inside two fields is
+--    demoted to an UNRESOLVED world leaf in its stored field, never applied to
+--    the wrong one and never lost.
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 200, 0, 200)
+  addField(sys, 5, 100, 300, 100, 300)
+  sys.valueMap = { available = true, resolution = 4, terrainSize = 400 }
+  sys._mapWaterPending[3] = { [12291] = 0.0015 }   -- centre (150,150) in both
+  local totalBefore = pendingTotal(sys)
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("demote.moved", moved, 1)
+  T.eq("demote.clearedResolved", sys._mapWaterPending[3][12291], nil)
+  local leaf = findWorldLeaf(sys, 3, 150, 150)
+  T.eq("demote.isUnresolvedLeaf", leaf ~= nil and leaf.status or nil, "UNRESOLVED")
+  T.near("demote.amountKept", leaf and leaf.amount or -1, 0.0015, 1e-12)
+  T.eq("demote.recordsGrain", leaf and leaf.sourceWidth or nil, 100)
+  T.near("demote.totalConserved", pendingTotal(sys), totalBefore, 1e-12)
+end
+
+-- 6. A RESOLVED remainder without a pixel map cannot be reconstructed, so it
+--    stays exactly where it is rather than being guessed to a field.
+do
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  addField(sys, 7, 150, 250, 150, 250)
+  sys.valueMap = nil
+  sys._mapWaterPending[3] = { [8194] = 0.001 }
+  local moved = sys:rekeyPositionalWaterForOwnership()
+  T.eq("noMap.noMove", moved, 0)
+  T.near("noMap.staysNumeric", sys._mapWaterPending[3][8194], 0.001, 1e-12)
+end
+
+-- 7. ORDERED POLYGON FINGERPRINT is stable for equal geometry and changes when
+--    the polygon moves (Group I I13/I14).
+do
+  local sys = newSystem()
+  addField(sys, 1, 0, 100, 0, 100)
+  local fp1 = sys:fieldGeometryFingerprint(1)
+  local fp2 = sys:fieldGeometryFingerprint(1)
+  T.eq("fingerprint.stable", fp1 == fp2, true)
+  T.ok("fingerprint.nonNil", fp1 ~= nil)
+  sys._fieldVerts[1].vx = { 5, 105, 105, 5 }
+  local fp3 = sys:fieldGeometryFingerprint(1)
+  T.eq("fingerprint.changesOnGeometry", fp1 ~= fp3, true)
+end
+
+-- 8. The handler (server) invalidates the cached vertices and never crashes;
+--    a load-time replay only invalidates and returns without re-keying.
+do
+  g_server = {}
+  local sys = newSystem()
+  addField(sys, 3, 0, 100, 0, 100)
+  sys._mapWaterPending[3] = { ["WORLD:10,20"] = worldLeaf(10, 20, 2, 0.01) }
+  sys:onFarmlandOwnerChanged(3, 1, true)
+  T.eq("handler.loadReplayInvalidates", sys._fieldVerts[3], nil)
+  T.eq("handler.loadReplayKeepsPending", sys._mapWaterPending[3]["WORLD:10,20"] ~= nil, true)
+  addField(sys, 3, 0, 100, 0, 100)
+  sys._fieldVerts[3] = { vx = { 0, 100, 100, 0 }, vz = { 0, 0, 100, 100 }, n = 4 }
+  sys:onFarmlandOwnerChanged(3, 2, false)
+  -- The square verts are dropped; the revalidation may re-cache a refusal marker
+  -- (no scene here) but must never keep the stale pre-change square.
+  local cached = sys._fieldVerts[3]
+  T.eq("handler.vertsDropped", cached == nil or cached.n ~= 4, true)
+  T.near("handler.keepsWater", pendingTotal(sys), 0.01, 1e-12)
+  g_server = nil
+end
+
+T.summary()

--- a/tools/test/lua/scs039_iris_review_fixes_test.lua
+++ b/tools/test/lua/scs039_iris_review_fixes_test.lua
@@ -1,0 +1,170 @@
+-- scs039_iris_review_fixes_test.lua
+-- Discriminating tests for the seven contract gaps from Iris's combined Design
+-- read on PR #172. Each fix keeps the behaviour the brief actually requires:
+-- fail-closed never promotes retained ZONE data, a refused whole-field
+-- replacement conserves pending and revision, positional reads validate and
+-- report nil grain on absent zone cells, readable hourly mutations advance the
+-- provider revision, the compact digest binds full leaf identity, save capture
+-- refreshes dirty aggregates, and PENDING_ONLY binds the retained COMPLETE base.
+--!load: src/SoilMoistureSystem.lua, src/SaveLoadHandler.lua, src/maps/CropStressValueMap.lua
+
+local UPR = 1 / CropStressValueMap.RAW_SPAN
+
+local function newSysWithCell()
+  local s = SoilMoistureSystem.new({})
+  s.isInitialized = true
+  s.fieldData[1] = {
+    fieldId = 1, moisture = 0.5, soilType = "loamy", mapPending = 0,
+    cells = { [0] = { [0] = { moisture = 0.9 } } }, cellSum = 0.9, cellCount = 1,
+  }
+  return s
+end
+
+-- FIX 1: a native failure never promotes retained ZONE data as current ground.
+do
+  local s = newSysWithCell()
+  s.valueMap = { available = true, readValueAtWorld = function() return nil, nil, "PROVIDER_REFUSAL" end }
+  s.providerMode = "TRUTH"
+  local v, grain = s:getMoisture(1, 10, 10)
+  T.eq('fix1.modeUnavailable', s.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+  T.eq('fix1.readNil', v, nil)
+  T.eq('fix1.readNilGrain', grain, nil)
+
+  -- A subsequent water call must not mutate the retained zone cell.
+  local accepted = s:applyWaterAtCell(1, 10, 10, 0.05)
+  T.eq('fix1.waterAcceptedIntoPending', accepted, true)
+  T.near('fix1.zoneCellUnchanged', s.fieldData[1].cells[0][0].moisture, 0.9, 1e-12)
+  T.near('fix1.fieldPendingGrew', s.fieldData[1].mapPending, 0.05, 1e-12)
+  -- The failed provider never answers the retained cell again.
+  v = s:getMoisture(1, 10, 10)
+  T.eq('fix1.neverPromoted', v, nil)
+end
+
+-- FIX 2: a refused whole-field replacement conserves pending and revision.
+do
+  local s = newSysWithCell()
+  s._mapWaterPending[1] = { [5] = 0.01 }
+  s.fieldData[1].mapPending = 0.002
+  s.fieldData[1].moisture = 0.6
+  s._mapSeeded[1] = true
+  s._fieldVerts[1] = { vx = { 0, 100, 100, 0 }, vz = { 0, 0, 100, 100 }, n = 4 }
+  s.providerMode = "TRUTH"
+  s.moistureRevision = 5
+  s.valueMap = { available = true, paintPolygon = function() return false end }
+  local ok = s:setMoisture(1, 0.8)
+  T.eq('fix2.receiptFalse', ok, false)
+  T.near('fix2.scalarKept', s.fieldData[1].moisture, 0.6, 1e-12)
+  T.near('fix2.fieldPendingKept', s.fieldData[1].mapPending, 0.002, 1e-12)
+  T.near('fix2.positionalKept', s._mapWaterPending[1][5], 0.01, 1e-12)
+  T.eq('fix2.revisionKept', s.moistureRevision, 5)
+end
+
+-- FIX 3: mixed nil coordinates and non-finite input are rejected; an absent
+-- zone cell reports the aggregate at nil grain.
+do
+  local s = SoilMoistureSystem.new({})
+  s.isInitialized = true
+  s.fieldData[1] = { fieldId = 1, moisture = 0.5, soilType = "loamy", cells = {} }
+  local v, grain = s:getMoisture(1, 10, nil)
+  T.eq('fix3.mixedNilValue', v, nil)
+  T.eq('fix3.mixedNilGrain', grain, nil)
+  v = s:getMoisture(1, math.huge, 10)
+  T.eq('fix3.nonFiniteValue', v, nil)
+  local nv, ng = s:getMoisture(1, 10, 10)
+  T.near('fix3.absentZoneAggregate', nv, 0.5, 1e-12)
+  T.eq('fix3.absentZoneNilGrain', ng, nil)
+end
+
+-- FIX 4: a readable hourly mutation advances the revision once; a pending-only
+-- sub-step remainder does not.
+do
+  local function fakeWeather(irrigate)
+    return {
+      getHourlyEvapMultiplier = function() return 0 end,
+      getHourlyRainAmount = function() return 0 end,
+    }
+  end
+  local read = SoilMoistureSystem.new({})
+  read.isInitialized = true
+  read.fieldData[1] = { fieldId = 1, moisture = 0.5, soilType = "loamy" }
+  read.irrigationGains[1] = 0.1
+  local revBefore = read.moistureRevision
+  read:hourlyUpdate(fakeWeather(), 1, 0, false, nil)
+  T.near('fix4.readableMoistureMoved', read.fieldData[1].moisture, 0.6, 1e-9)
+  T.eq('fix4.revisionAdvancedOnce', read.moistureRevision, revBefore + 1)
+
+  local sub = SoilMoistureSystem.new({})
+  sub.isInitialized = true
+  sub.fieldData[1] = { fieldId = 1, moisture = 0.5, soilType = "loamy", mapPending = UPR * 0.5 }
+  sub._mapSeeded[1] = true
+  sub._fieldVerts[1] = { vx = { 0, 100, 100, 0 }, vz = { 0, 0, 100, 100 }, n = 4 }
+  sub.providerMode = "TRUTH"
+  sub.valueMap = { available = true }
+  local revBefore2 = sub.moistureRevision
+  sub:hourlyUpdate(fakeWeather(), 1, 0, false, nil)
+  T.eq('fix4.subStepNoRevision', sub.moistureRevision, revBefore2)
+end
+
+-- FIX 5: the compact digest distinguishes equal-count/equal-total payloads with
+-- different positions.
+do
+  local sh = SaveLoadHandler.new({})
+  local function env(rows)
+    return {
+      schema = 2, payloadKind = "COMPLETE", generation = 1,
+      moistureRevision = 7, lastSettledMonotonicDay = 20,
+      aggregates = {}, fieldPending = {}, positionalRows = rows,
+    }
+  end
+  local a = sh:compactDigest(env({
+    { fieldId = 1, status = "RESOLVED", pixelKey = 5, amount = 0.01 },
+    { fieldId = 2, status = "RESOLVED", pixelKey = 9, amount = 0.01 },
+  }))
+  local b = sh:compactDigest(env({
+    { fieldId = 1, status = "RESOLVED", pixelKey = 9, amount = 0.01 },
+    { fieldId = 2, status = "RESOLVED", pixelKey = 5, amount = 0.01 },
+  }))
+  T.eq('fix5.equalTotalsDifferentPositions', a ~= b, true)
+  local c = sh:compactDigest(env({
+    { fieldId = 1, status = "UNRESOLVED", worldX = 10, worldZ = 10, sourceWidth = 2, amount = 0.01 },
+    { fieldId = 2, status = "UNRESOLVED", worldX = 20, worldZ = 20, sourceWidth = 2, amount = 0.01 },
+  }))
+  T.eq('fix5.resolvedVsUnresolvedDistinct', a ~= c, true)
+end
+
+-- FIX 6: save capture refreshes a dirty aggregate before freezing it.
+do
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.5, aggregateDirty = true, mapPending = 0 }
+  soil._refreshFieldAggregate = function(_self, _fieldId, d)
+    d.moisture = 0.7
+    d.aggregateDirty = false
+  end
+  soil.packMapWaterPending = function() return {} end
+  soil.valueMap = { available = true }
+  local sh = SaveLoadHandler.new({ soilSystem = soil })
+  local env = sh:captureMoistureEnvelope()
+  T.near('fix6.capturedFreshAggregate', env.aggregates[1], 0.7, 1e-12)
+end
+
+-- FIX 7: PENDING_ONLY binds the retained COMPLETE base, not current RAM.
+do
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.5 }
+  soil.packMapWaterPending = function() return {} end
+  local sh = SaveLoadHandler.new({ soilSystem = soil })
+  soil.moistureRevision = 7
+  soil._lastSettledDay = 20
+  local env1 = sh:captureMoistureEnvelope()
+  T.eq('fix7.firstCompletes', sh:commitMoistureEnvelope(env1, true, true), "COMPLETE")
+
+  soil.moistureRevision = 8
+  soil._lastSettledDay = 21
+  local env2 = sh:captureMoistureEnvelope()
+  T.eq('fix7.nativeFails', sh:commitMoistureEnvelope(env2, false, true), "PENDING_ONLY")
+  T.eq('fix7.baseGeneration', sh._pendingOnly.baseGeneration, 1)
+  T.eq('fix7.baseRevisionRetained', sh._pendingOnly.baseRevision, 7)
+  T.eq('fix7.baseCursorRetained', sh._pendingOnly.baseLastSettledMonotonicDay, 20)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_pending_persistence_test.lua
+++ b/tools/test/lua/scs039_pending_persistence_test.lua
@@ -1,0 +1,147 @@
+-- scs039_pending_persistence_test.lua
+-- SCS-039 / GRID-1 (SDS 3.4 tail, slice 8): the positional accepted-water store
+-- is persisted deterministically. Slice 3 preserved UNRESOLVED world leaves and
+-- resolved pixel remainders in-mission only; this locks the seams that carry
+-- them across save and reload so no accepted water is lost.
+--
+-- The pure contract is already modelled by the authoritative bar: Group C
+-- (sparse packing deterministic by field then pixel, every non-zero entry, no
+-- hidden 1024 ceiling, exact-total round trip) and Group O (unresolved status
+-- and source width survive a compact round trip). These live tests drive the
+-- real SoilMoistureSystem pack/unpack seams against that model.
+--!load: src/SoilMoistureSystem.lua
+
+local function newSystem()
+  local sys = SoilMoistureSystem.new({})
+  sys._mapWaterPending = {}
+  return sys
+end
+
+local function leafTotal(sys)
+  local total = 0
+  for _, acc in pairs(sys._mapWaterPending) do
+    for key, value in pairs(acc) do
+      if type(key) == "number" then
+        total = total + value
+      elseif type(value) == "table" then
+        total = total + (value.amount or 0)
+      end
+    end
+  end
+  return total
+end
+
+-- 1. DETERMINISTIC ORDER: resolved leaves ascend by field then pixel key
+--    (Group C C5/C6), zero amounts are skipped, negative remainders are kept.
+do
+  local sys = newSystem()
+  sys._mapWaterPending = {
+    [2] = { [11] = 0.00125, [4] = 0.00250 },
+    [1] = { [8] = -0.00075, [9] = 0 },
+  }
+  local rows = sys:packMapWaterPending()
+  T.eq("pack.keepsEveryNonZeroEntry", #rows, 3)
+  T.eq("pack.deterministicField", rows[1].fieldId, 1)
+  T.eq("pack.deterministicPixel", rows[2].pixelKey, 4)
+  T.eq("pack.fieldThenPixel", rows[1].pixelKey, 8)
+  T.eq("pack.statusResolved", rows[1].status, "RESOLVED")
+  T.eq("pack.keepsNegativeRemainder", rows[1].amount, -0.00075)
+  T.near("pack.preservesAmount", rows[3].amount, 0.00125, 1e-12)
+end
+
+-- 2. NO HIDDEN 1024-ENTRY CEILING (Group C C8).
+do
+  local sys = newSystem()
+  local acc = {}
+  for i = 1, 1025 do acc[i] = i / 10000000 end
+  sys._mapWaterPending = { [1] = acc }
+  local rows = sys:packMapWaterPending()
+  T.eq("pack.noCeiling", #rows, 1025)
+end
+
+-- 3. UNRESOLVED world leaves ride the pack AFTER the field's resolved leaves,
+--    preserving status, world coords and source width (Group O O6/O7).
+do
+  local sys = newSystem()
+  sys._mapWaterPending = {
+    [3] = {
+      [5] = 0.002,
+      ["WORLD:10,20"] = { status = "UNRESOLVED", worldX = 10, worldZ = 20, sourceWidth = 2, amount = 0.01 },
+    },
+  }
+  local rows = sys:packMapWaterPending()
+  T.eq("pack.unresolvedAfterResolved", #rows, 2)
+  T.eq("pack.unresolvedLast", rows[2].status, "UNRESOLVED")
+  T.eq("pack.unresolvedWorldX", rows[2].worldX, 10)
+  T.eq("pack.unresolvedWorldZ", rows[2].worldZ, 20)
+  T.eq("pack.unresolvedSourceWidth", rows[2].sourceWidth, 2)
+  T.near("pack.unresolvedAmount", rows[2].amount, 0.01, 1e-12)
+end
+
+-- 4. ROW ROUND TRIP onto a fresh store conserves the exact total and rebuilds
+--    both key kinds exactly (Group C C7, Group O O6/O7).
+do
+  local sys = newSystem()
+  sys._mapWaterPending = {
+    [1] = { [8] = 0.00125, [2] = 0.00250 },
+    [3] = {
+      [5] = 0.002,
+      ["WORLD:10,20"] = { status = "UNRESOLVED", worldX = 10, worldZ = 20, sourceWidth = 2, amount = 0.01 },
+    },
+  }
+  local totalBefore = leafTotal(sys)
+  local rows = sys:packMapWaterPending()
+  local fresh = newSystem()
+  local restored = fresh:unpackMapWaterPending(rows)
+  T.eq("rows.restoredCount", restored, 4)
+  T.near("rows.totalConserved", leafTotal(fresh), totalBefore, 1e-12)
+  T.near("rows.resolvedExact", fresh._mapWaterPending[1][8], 0.00125, 1e-12)
+  T.eq("rows.resolvedKeyIsNumber", type(fresh._mapWaterPending[1][8]), "number")
+  local leaf = fresh._mapWaterPending[3]["WORLD:10,20"]
+  T.eq("rows.unresolvedStatus", leaf ~= nil and leaf.status or nil, "UNRESOLVED")
+  T.eq("rows.unresolvedSourceWidth", leaf ~= nil and leaf.sourceWidth or nil, 2)
+  T.near("rows.unresolvedAmount", leaf ~= nil and leaf.amount or -1, 0.01, 1e-12)
+end
+
+-- 5. STRING ROUND TRIP (the own-XML path) returns the exact same doubles.
+do
+  local sys = newSystem()
+  sys._mapWaterPending = {
+    [2] = { [11] = 0.00125, [4] = 0.00250 },
+    [3] = {
+      ["WORLD:10,20"] = { status = "UNRESOLVED", worldX = 10, worldZ = 20, sourceWidth = 2, amount = 0.01 },
+    },
+  }
+  local totalBefore = leafTotal(sys)
+  local packed = sys:packMapWaterPendingString()
+  T.ok("string.packedWhenNonEmpty", packed ~= nil)
+  local fresh = newSystem()
+  local restored = fresh:unpackMapWaterPendingString(packed)
+  T.eq("string.restoredCount", restored, 3)
+  T.near("string.totalConserved", leafTotal(fresh), totalBefore, 1e-12)
+  T.near("string.resolvedExact", fresh._mapWaterPending[2][11], 0.00125, 1e-12)
+  local leaf = fresh._mapWaterPending[3]["WORLD:10,20"]
+  T.eq("string.unresolvedStatus", leaf ~= nil and leaf.status or nil, "UNRESOLVED")
+  T.near("string.unresolvedAmount", leaf ~= nil and leaf.amount or -1, 0.01, 1e-12)
+end
+
+-- 6. EMPTY store packs to nothing, and a missing string restores nothing.
+do
+  local sys = newSystem()
+  T.eq("empty.packRows", #sys:packMapWaterPending(), 0)
+  T.eq("empty.packStringNil", sys:packMapWaterPendingString(), nil)
+  T.eq("empty.unpackStringNil", sys:unpackMapWaterPendingString(nil), 0)
+  T.eq("empty.unpackStringEmpty", sys:unpackMapWaterPendingString(""), 0)
+  T.eq("empty.unpackRowsNil", sys:unpackMapWaterPending(nil), 0)
+end
+
+-- 7. An all-zero or all-empty store packs to nothing (only non-zero entries
+--    are ever emitted, so a cleared store round trips as an empty one).
+do
+  local sys = newSystem()
+  sys._mapWaterPending[1] = { [4097] = 0 }
+  T.eq("allZero.packRows", #sys:packMapWaterPending(), 0)
+  T.eq("allZero.packStringNil", sys:packMapWaterPendingString(), nil)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_quantisation_floor_test.lua
+++ b/tools/test/lua/scs039_quantisation_floor_test.lua
@@ -139,7 +139,9 @@ do
   T.eq("inert.readIsNil", (m:readValueAtWorld(0, 0)), nil)
   T.eq("inert.writeRefuses", m:writeValueAtWorld(0, 0, 0.5, 2), false)
   T.eq("inert.deltaAppliesNothing", m:applyDeltaToPolygon(nil, nil, 0, 0.5), 0)
-  T.eq("inert.averageIsNil", (m:readAverageOfPolygon(nil, nil, 0)), nil)
+  local inertOutcome, inertMean = m:readAverageOfPolygon(nil, nil, 0)
+  T.eq("inert.averageInvalidGeometry", inertOutcome, "INVALID_FIELD_GEOMETRY")
+  T.eq("inert.averageMeanIsNil", inertMean, nil)
   T.eq("inert.saveRefuses", m:saveToSavegame("/nowhere"), false)
 end
 

--- a/tools/test/lua/scs039_save_generations_test.lua
+++ b/tools/test/lua/scs039_save_generations_test.lua
@@ -1,0 +1,144 @@
+-- scs039_save_generations_test.lua
+-- SCS-039 / GRID-1 (SDS 3.5): the synchronous immutable capture and the
+-- two-generation commit/selection state machine. The COMPLETE generation
+-- advances only after the native write AND the compact write both succeed; a
+-- native failure with a usable compact write records one PENDING_ONLY bound to
+-- the base generation; identical mirrors deduplicate, conflicting digests
+-- reject a generation, and the highest valid COMPLETE native pair wins.
+--
+-- This is the engine-free core the file layer will drive (Group D and Group K
+-- model the same contract).
+--!load: src/SoilMoistureSystem.lua, src/SaveLoadHandler.lua
+
+local function soilAt(revision, cursor)
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.55, soilType = "loamy", mapPending = 0.02 }
+  soil.moistureRevision = revision
+  soil._lastSettledDay = cursor
+  soil._mapWaterPending[1] = { [5] = 0.001 }
+  return soil
+end
+
+local function newHandler(soil)
+  return SaveLoadHandler.new({ soilSystem = soil })
+end
+
+-- 1. CAPTURE freezes the revision, cursor, aggregates and both pending packs.
+do
+  local sh = newHandler(soilAt(7, 20))
+  local env = sh:captureMoistureEnvelope()
+  T.eq("capture.generation", env.generation, 0)
+  T.eq("capture.revision", env.moistureRevision, 7)
+  T.eq("capture.cursor", env.lastSettledMonotonicDay, 20)
+  T.eq("capture.payloadKind", env.payloadKind, "COMPLETE")
+  T.near("capture.aggregate", env.aggregates[1], 0.55, 1e-12)
+  T.near("capture.fieldPending", env.fieldPending[1], 0.02, 1e-12)
+  T.eq("capture.positionalCount", #env.positionalRows, 1)
+  T.near("capture.positionalAmount", env.positionalRows[1].amount, 0.001, 1e-12)
+  T.ok("capture.hasDigest", env.digest ~= nil)
+end
+
+-- 2. COMMIT mirrors Group K: both true advances, native-false + compact-true
+--    records a base-bound PENDING_ONLY, any compact failure keeps the pair.
+do
+  local sh = newHandler(soilAt(7, 20))
+  local env = sh:captureMoistureEnvelope()
+
+  T.eq("commit.bothTrueCompletes", sh:commitMoistureEnvelope(env, true, true), "COMPLETE")
+  T.eq("commit.generationAdvances", sh._completePair.current.generation, 1)
+  T.eq("commit.previousRetained", sh._completePair.previous.generation, 0)
+  T.eq("commit.currentDigest", sh._completePair.current.digest, env.digest)
+  T.eq("commit.currentRevision", sh._completePair.current.revision, 7)
+
+  local env2 = sh:captureMoistureEnvelope()
+  T.eq("commit.captureTracksCurrent", env2.generation, 1)
+  T.eq("commit.nativeFailPendingOnly", sh:commitMoistureEnvelope(env2, false, true), "PENDING_ONLY")
+  T.eq("commit.pairHeldOnNativeFail", sh._completePair.current.generation, 1)
+  local po = sh._pendingOnly
+  T.eq("commit.pendingBoundGeneration", po.baseGeneration, 1)
+  T.eq("commit.pendingBoundRevision", po.baseRevision, 7)
+  T.eq("commit.pendingZoneOk", po.zoneOk, true)
+  T.ok("commit.pendingHasDigest", po.digest ~= nil)
+  T.near("commit.pendingKeepsFieldWater", po.fieldPending[1], 0.02, 1e-12)
+
+  T.eq("commit.compactFailHoldsPair", sh:commitMoistureEnvelope(env2, true, false), "FAILED")
+  T.eq("commit.bothFailHoldsPair", sh:commitMoistureEnvelope(env2, false, false), "FAILED")
+  T.eq("commit.generationStillOne", sh._completePair.current.generation, 1)
+
+  T.eq("commit.nextCompleteClearsPending",
+    sh:commitMoistureEnvelope(env2, true, true), "COMPLETE")
+  T.eq("commit.advancesToTwo", sh._completePair.current.generation, 2)
+  T.eq("commit.previousNowOne", sh._completePair.previous.generation, 1)
+  T.eq("commit.pendingSuperseded", sh._pendingOnly, nil)
+end
+
+-- 3. SELECTION mirrors Group D: dedupe, conflict fallback, ZONE degrade and
+--    exact PENDING_ONLY binding.
+local function completeRow(gen, digest, nativeOk, revision, cursor)
+  return { payloadKind = "COMPLETE", generation = gen, digest = digest,
+           compactOk = true, nativeOk = nativeOk, revision = revision,
+           lastSettledMonotonicDay = cursor }
+end
+local function pendingRow(baseGen, digest, baseRev, baseCursor)
+  return { payloadKind = "PENDING_ONLY", baseGeneration = baseGen, digest = digest,
+           compactOk = true, zoneOk = true, baseRevision = baseRev,
+           baseLastSettledMonotonicDay = baseCursor }
+end
+
+do
+  local sh = newHandler(soilAt(7, 20))
+  local mode, gen, digest = sh:selectMoistureCarrier({
+    completeRow(6, "sixA", true, 60, 20),
+    completeRow(6, "sixB", true, 60, 20),
+    completeRow(5, "five", true, 50, 17),
+  })
+  T.eq("select.conflictFallsToNext", mode, "TRUTH")
+  T.eq("select.conflictGeneration", gen, 5)
+
+  mode, gen, digest = sh:selectMoistureCarrier({
+    completeRow(6, "six", true, 60, 20),
+    completeRow(6, "six", true, 60, 20),
+  })
+  T.eq("select.identicalMirrorsDedupe", mode, "TRUTH")
+  T.eq("select.dedupeGeneration", gen, 6)
+  T.eq("select.dedupeDigest", digest, "six")
+
+  mode, gen, digest = sh:selectMoistureCarrier({
+    completeRow(6, "six", false, 60, 20),
+    completeRow(5, "five", true, 50, 17),
+  })
+  T.eq("select.newestCompactDegrades", mode, "ZONE")
+  T.eq("select.zoneKeepsOwnGeneration", gen, 6)
+  T.eq("select.zoneKeepsOwnDigest", digest, "six")
+
+  local pendingDigest, pendingStatus
+  mode, gen, digest, pendingDigest, pendingStatus = sh:selectMoistureCarrier({
+    completeRow(6, "six", true, 60, 20),
+    pendingRow(6, "p6", 60, 20),
+    pendingRow(6, "p6", 60, 20),
+  })
+  T.eq("select.pendingBindKeepsTruth", mode, "TRUTH")
+  T.eq("select.pendingBindGeneration", gen, 6)
+  T.eq("select.identicalPendingDedupe", pendingDigest, "p6")
+  T.eq("select.pendingApplied", pendingStatus, "APPLIED")
+
+  mode, gen, digest, pendingDigest, pendingStatus = sh:selectMoistureCarrier({
+    completeRow(6, "six", true, 60, 20),
+    pendingRow(6, "p6-wrong", 60, 21),
+  })
+  T.eq("select.wrongCursorKeepsCarrier", mode, "TRUTH")
+  T.eq("select.wrongCursorRejected", pendingStatus, "BASE_MISMATCH")
+
+  mode, gen, digest, pendingDigest, pendingStatus = sh:selectMoistureCarrier({
+    pendingRow(7, "p7", 70, 14),
+  })
+  T.eq("select.zoneRecoveryOnly", mode, "ZONE")
+  T.eq("select.recoveryGeneration", gen, 7)
+  T.eq("select.recoveryDigest", pendingDigest, "p7")
+  T.eq("select.recoveryApplied", pendingStatus, "APPLIED")
+
+  mode = sh:selectMoistureCarrier({})
+  T.eq("select.none", mode, "NONE")
+end
+
+T.summary()


### PR DESCRIPTION
﻿## SCS-039 moisture truth grid, slices 1-11, checkpoint candidate

Travelled/certified irrigation-set card. **Built on-branch in verifiable slices**; the branch grows until SCS-039 is a coherent complete member, then it merges. This tip is the **consolidated checkpoint candidate** for the single combined Design read.

Release stays **LOCKED**; the remaining slices are runtime-dominated (native save-file generations, daily-plan scheduler restructure, snapshot/delta delivery, NetworkSync, overlay gate) and are in-game/MP-verifiable only, which cannot be claimed while the release gate is closed.

### Review model (corrected per Iris, 2026-09-04)
The authoritative bar (`SCS-039-grid_concordance_spec_test.lua` v10) is **spec-first / inverted**. Per Iris's ledger correction, **Implementation owns its branch, slices, bar re-points, harness runs, PR review and merge readiness, no slice waits on Design Seat.** A single combined Design read happens only when Tyson flags one finished checkpoint through the ledger; Iris then reviews that exact tip once and places the result on the PR. Independent Stage 8b conformance is a separate, later decision. **Tyson has chosen to stop slicing and consolidate this draft as the checkpoint candidate.**

---

### Slices 1-3 - provider revision + honest reads; field aggregate + over-cap ZONE water; unresolved-pixel TRUTH water
(`1c3d799`/`557e879`, `ca9b078`, `00b0b92`) Persisted `moistureRevision` + frozen `providerMode` (TRUTH/ZONE); the honest read surface (`getMoistureRevision`, `isMoistureMapCurrent`, `getMoistureDisplayMap`, additive revision on `getMoisture`) with nil-grain unwritten fallback; whole-field replacement clears both pending stores; `applyWaterAtCell` accept receipt; `delete()` releases the carrier; `saveToSavegame` requires inner `==true`. Field reads use the revisioned polygon aggregate (never the retained ZONE mean); ZONE over-cap water stays field-wide pending; unresolved native pixels keep water as an `UNRESOLVED` world leaf. Re-points **A1, A3, A5-A9, A11, A13, A14**.

### Slices 4-7 - the native-refusal fail-closed family (SDS 3.3 tail, complete)
(`c17eba7`, `244eddf`, `968cf95`, `9fef701`) Typed native outcomes across reads and writes, all routed through the one-way `_failNativeClosed` (`TRUTH -> UNAVAILABLE_PENDING_RELOAD`, holds revision, preserves pending, never promotes zone cells, detaches via `mapActive()`): polygon-aggregate read (A12), native save (via `saveNativeMap`), point read (A15), and region write (A16). The `applyWaterAtCell` spend path now debits and mints a revision only after the destination read and write both succeed exactly, conserving the full pre-spend amount on a refusal (Group O). Re-points **A12, A15, A16**.

### Slices 8-9 - the SDS 3.4 tail, complete
(`aedd597`, `e3ca185`) Deterministic persistence of the positional accepted-water store: `packMapWaterPending` (field then pixel / canonical world ordering, every non-zero entry, no 1024 ceiling) + string form through own-XML and the ledger table. Geometry-change re-key: a `MessageType.FARMLAND_OWNER_CHANGED` server handler invalidates the cached verts and re-keys each leaf only when exactly one current field owns its world position; ambiguous or missing membership stays/becomes an `UNRESOLVED` leaf, never moved by identifier accident. `fieldGeometryFingerprint` feeds the SDS 3.6 plan pinning. Locked by `scs039_pending_persistence_test.lua` and `scs039_geometry_rekey_test.lua`.

### Slice 10 - persist save-envelope carriers (`188a4f8`)
Start the SDS 3.5 capture: `moistureRevision`, the settled-day cursor (only once seeded) and the field-wide `mapPending` carry now round-trip through the own-XML and ledger surfaces; the revision was previously reset to 1 on reload and the carry dropped. Locked by `scs039_capture_persistence_test.lua` (18 assertions).

### Slice 11 - COMPLETE/PENDING_ONLY generation state machine (`7fe133a`)
The SDS 3.5 synchronous immutable capture and two-generation commit/selection core (Group D and Group K): `captureMoistureEnvelope` freezes schema, generation, revision, settled-day cursor, refreshed aggregates and both pending packs with a canonical `compactDigest`; `commitMoistureEnvelope` advances the retained current/previous pair only after the native write AND the compact write both succeed, records one base-bound `PENDING_ONLY` on native failure with a usable compact, and holds the pair on any compact failure; `selectMoistureCarrier` deduplicates identical mirrors, rejects conflicting generations, falls to the next lower valid COMPLETE pair, degrades a newer native-less compact to ZONE, and binds `PENDING_ONLY` only on exact base identity. The native-carrier save path commits against the recorded native receipt and persists the generation; load resumes the pair bookkeeping. Locked by `scs039_save_generations_test.lua` (48 assertions).

---

### Status at this checkpoint
**Every Group A assertion A1-A16 is on presence. SDS 3.3 and SDS 3.4 are fully implemented.** SDS 3.5 has its capture carriers and its commit/selection state machine; the runtime file layer (generation-qualified native file names, on-disk pair retention and interrupted-file cleanup, mirror-reconciliation load door) remains and is in-game-verifiable only. SDS 3.6-3.9 live wiring (daily plan + Time Guard `subscribeTick`, snapshot/delta events, NetworkSync compat, overlay gate) remains, modelled by the pure-contract Groups B-P. No in-game or multiplayer acceptance is claimed; release stays LOCKED.

### Verification
Full offline suite **1041 passed / 0 failed across 30 files, exit 0**: authoritative bar **302/0**, `scs039` delegation **52/0**, geometry-rekey 37/0, pending-persistence 34/0, save-generations 48/0, capture-persistence 18/0, delivery 30/0, quantisation-floor 88/0. Lua 5.1 syntax gate clean (48/48 src files).

### In-game verification owed (after unlock)
Save and reload equality of the COMPLETE envelope (generation, digest, revision, cursor, pending packs); interrupted-save recovery to the prior pair; native-refusal-after-current fail-closed; Time Guard present/absent daily cursor equivalence; additive-water during daily work; destructive-change plan abort; join/snapshot/delta/resnapshot; NetworkSync aggregate mirror; overlay data gate; csMapStats readouts.

### Review
Implementation owns the slices, re-points and harness runs. This tip is offered as the single combined checkpoint for Iris's one Design read. `sasha-rf` has approved the branch against the suite rules and the approval must be refreshed at this new tip. **Tyson merges** PR #172 into `development` after review; this PR is not yet merge-ready.
