### PR TITLE
feat(SCS-039): post-checkpoint slices 12-16 (daily plan, save generations, NetworkSync, overlay, fine snapshot)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -46,6 +46,11 @@ source(modDir .. "src/WeatherIntegration.lua")
 -- cell store when it is not.
 source(modDir .. "src/maps/CropStressValueMap.lua")
 
+-- Client fine-snapshot currentness (SCS-039 / SDS 3.7): engine-free staging
+-- and semantic currentness for the row/delta delivery. SoilMoistureSystem
+-- instantiates it at construction, so it must load before first use.
+source(modDir .. "src/SoilFineSnapshot.lua")
+
 -- Core simulation
 source(modDir .. "src/SoilMoistureSystem.lua")
 source(modDir .. "src/CropStressModifier.lua")
@@ -85,6 +90,8 @@ source(modDir .. "src/events/CropStressSettingsSyncEvent.lua")
 source(modDir .. "src/events/CropStressMoistureInitEvent.lua")
 source(modDir .. "src/events/CropStressIrrigateNowEvent.lua")
 source(modDir .. "src/events/CropStressMoistureRowEvent.lua")
+source(modDir .. "src/events/CropStressMoistureControlEvent.lua")
+source(modDir .. "src/events/CropStressMoistureDeltaEvent.lua")
 source(modDir .. "src/events/CropStressPivotRemoteEvent.lua")
 -- [BUILD 00:33] schedule + Auto/Manual sync (dialog Save -> server -> clients)
 source(modDir .. "src/events/CropStressScheduleSyncEvent.lua")

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -1050,7 +1050,8 @@ function CropStressManager:getIrrigationSchedule(fieldId)
     local irrMgr = self.irrigationManager
     if irrMgr == nil or irrMgr.systems == nil then return nil end
     for _, sys in pairs(irrMgr.systems) do
-        if sys.coveredFields ~= nil and sys.schedule ~= nil then
+        -- An INACTIVE system never reports an active schedule (facade contract).
+        if sys.isActive and sys.coveredFields ~= nil and sys.schedule ~= nil then
             for _, fid in ipairs(sys.coveredFields) do
                 if fid == fieldId then
                     local days = {}

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -79,12 +79,14 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
         local sgDir = g_currentMission ~= nil and g_currentMission.missionInfo ~= nil
             and g_currentMission.missionInfo.savegameDirectory or nil
         if sgDir ~= nil then
-            -- SCS-039 v2.1 (SDS 3.3): route the native save through the soil system
-            -- so a refusal fails the provider closed. The scalar rows written below
-            -- then carry the save as the honest degrade layer, and the next load
-            -- re-selects a readable carrier rather than trusting bytes that never
-            -- reached disk.
-            nativeSaveOk = soilSystemForMap:saveNativeMap(sgDir) == true
+            -- SCS-039 v2.1 (SDS 3.3/3.5): route the native save through the soil
+            -- system so a refusal fails the provider closed. The file is written
+            -- for the CANDIDATE generation (current + 1): the COMPLETE commit
+            -- advances to it only after this native write AND the compact write
+            -- both succeed, and the generation-qualified name never clobbers the
+            -- legacy baseline or either retained complete pair.
+            nativeSaveOk = soilSystemForMap:saveNativeMap(sgDir,
+                (self._completePair.current.generation or 0) + 1) == true
         end
     end
 

--- a/src/SoilFineSnapshot.lua
+++ b/src/SoilFineSnapshot.lua
@@ -1,0 +1,171 @@
+-- ============================================================
+-- SoilFineSnapshot.lua  (SCS-039 / GRID-1, SDS 3.7)
+--
+-- CLIENT SEMANTIC CURRENTNESS for the fine 2 m map. Rows, the aggregate FULL
+-- witness and deltas land in TRANSIENT STAGING keyed by snapshot generation;
+-- they NEVER write the live map directly. After the final row the engine
+-- validates base aggregates, applies any contiguous buffered deltas, then
+-- publishes the native map, aggregates and revision together exactly once.
+--
+-- This mirrors the bar's Group F contract and is engine-free so the bench can
+-- drive the full state machine. Two connections never share one currentness
+-- flag (each client creates its own instance).
+--
+-- A RESNAPSHOT_REQUEST is legal only for a named semantic mismatch (revision
+-- chain, dimensions, grain, schema, carrier or snapshot generation, compact
+-- witness disagreement, or a native application refusal). It discards staging
+-- and asks for one fresh full snapshot; it never resumes the old tuple.
+-- ============================================================
+
+SoilFineSnapshot = SoilFineSnapshot or {}
+SoilFineSnapshot.__index = SoilFineSnapshot
+
+function SoilFineSnapshot.new()
+    local self = setmetatable({}, SoilFineSnapshot)
+    self:reset()
+    return self
+end
+
+function SoilFineSnapshot:reset()
+    self.current          = false       -- a complete snapshot is published
+    self.currentRevision  = 0
+    self.snapshotGeneration = nil
+    self.baseRevision     = 0
+    self.totalRows        = 0
+    self.mapWidth         = 0
+    self.grain            = nil
+    self.schema           = nil
+    self.rowCount         = 0
+    self.rows             = {}          -- [index] -> raw packed row
+    self.aggregates       = {}          -- fieldId -> aggregate witness
+    self.deltas           = {}          -- ordered buffered deltas (pre-publish)
+    self.pixelValues      = {}          -- published absolute pixel values
+    self.resnapshot       = false
+    self.publishCount     = 0
+end
+
+-- ---------------------------------------------------------
+-- Control START: open a snapshot for one generation.
+-- A new generation while a snapshot is open discards staging.
+-- ---------------------------------------------------------
+function SoilFineSnapshot:beginSnapshot(snapshotGeneration, totalRows, baseRevision, mapWidth)
+    if self.snapshotGeneration ~= nil and self.snapshotGeneration ~= snapshotGeneration then
+        self:reset()
+    end
+    self.snapshotGeneration = snapshotGeneration
+    self.totalRows  = totalRows or 0
+    self.baseRevision = baseRevision or 0
+    self.mapWidth   = mapWidth or 0
+    self.rowCount   = 0
+    self.rows       = {}
+    self.deltas     = {}
+    return self.snapshotGeneration
+end
+
+-- ---------------------------------------------------------
+-- A raw row arrives for the open snapshot. Reliable-ordered, so a row for a
+-- generation that is not open (or already complete) is refused.
+-- ---------------------------------------------------------
+function SoilFineSnapshot:receiveRow(snapshotGeneration, rowIndex, packed)
+    if self.snapshotGeneration ~= snapshotGeneration then return false end
+    if self.current then return false end
+    if self.rows[rowIndex] == nil then
+        self.rows[rowIndex] = packed
+        self.rowCount = self.rowCount + 1
+    end
+    return true
+end
+
+-- The aggregate FULL witness (the compact corroboration). Accepted only when
+-- it names the open snapshot generation.
+function SoilFineSnapshot:receiveAggregateWitness(snapshotGeneration, revision, aggregates)
+    if self.snapshotGeneration ~= snapshotGeneration then
+        self.resnapshot = true
+        return false
+    end
+    if self.current then
+        if revision < self.currentRevision then return true end
+        self.resnapshot = true
+        return false
+    end
+    self.aggregates = aggregates or {}
+    self._witnessRevision = revision
+    return true
+end
+
+-- An absolute delta. While not current it is buffered; once current it applies
+-- immediately when contiguous (fromRevision == currentRevision) and requests a
+-- fresh snapshot when a gap or a stale revision arrives.
+function SoilFineSnapshot:receiveDelta(fromRevision, toRevision, pixelKey, value)
+    if self.current and toRevision <= self.currentRevision then
+        return true          -- duplicate / old delta ignored
+    end
+    if self.current then
+        if fromRevision ~= self.currentRevision then
+            self.resnapshot = true
+            return false
+        end
+        self.pixelValues[pixelKey] = value
+        self.currentRevision = toRevision
+        return true
+    end
+    self.deltas[#self.deltas + 1] = {
+        fromRevision = fromRevision,
+        toRevision   = toRevision,
+        pixelKey     = pixelKey,
+        value        = value,
+    }
+    return true
+end
+
+-- ---------------------------------------------------------
+-- COMPLETE barrier: publish exactly once when every row of the open snapshot
+-- has arrived and any buffered deltas form one contiguous chain from the base
+-- revision. Publish is a callback so the bench can capture it without an
+-- engine; the live caller passes the value map and aggregate setter.
+-- Returns true when the snapshot became current this call.
+-- ---------------------------------------------------------
+function SoilFineSnapshot:finishSnapshot(onPublish)
+    if self.resnapshot then return false end
+    if self.current then return true end
+    if self.snapshotGeneration == nil then return false end
+    if self.rowCount ~= self.totalRows then
+        self.resnapshot = true
+        return false
+    end
+
+    -- Sort buffered deltas into a contiguous chain from the base revision.
+    table.sort(self.deltas, function(a, b) return a.fromRevision < b.fromRevision end)
+    local revision = self.baseRevision
+    for i = 1, #self.deltas do
+        local d = self.deltas[i]
+        if d.toRevision > revision then
+            if d.fromRevision ~= revision then
+                self.resnapshot = true
+                return false
+            end
+            revision = d.toRevision
+        end
+    end
+    self.pixelValues = {}
+    for i = 1, #self.deltas do
+        local d = self.deltas[i]
+        self.pixelValues[d.pixelKey] = d.value
+    end
+
+    self.current = true
+    self.currentRevision = revision
+    self.publishCount = self.publishCount + 1
+    self.deltas = {}
+    if onPublish ~= nil then
+        onPublish(self)
+    end
+    return true
+end
+
+-- A semantic mismatch requests one fresh full snapshot and discards staging.
+function SoilFineSnapshot:requestResnapshot()
+    self.resnapshot = true
+    self:reset()
+    self.resnapshot = true
+end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -72,6 +72,10 @@ SoilMoistureSystem.CELL_DRAIN_NEIGHBOURS   = 4      -- downhill neighbours sampl
 SoilMoistureSystem.CELL_BATCH_SIZE         = 64     -- frame budget for the daily sweep
 SoilMoistureSystem.DAILY_ACCURAL_ID        = "SeasonalCropStress_moisture_daily"
 SoilMoistureSystem.DAILY_ACCURAL_PRIORITY  = 90     -- below 100: ground settles before any economy read
+-- SCS-039 v2.1 (SDS 3.6): the per-frame redistribution budget for an open daily
+-- plan. 400 is the same technical precedent as MAP_DRAIN_MAX_BLOCKS (Group A10
+-- / Group I16 pin it); it is a frame ceiling, never a total work cap.
+SoilMoistureSystem.DAILY_OPS_PER_FRAME     = 400
 
 -- ============================================================
 -- LOGGING HELPER
@@ -174,6 +178,13 @@ function SoilMoistureSystem.new(manager)
     -- otherwise driven by the fallback day-change hook inside hourlyUpdate.
     self._tgAccrualRegistered = false
     self._lastSettledDay = nil
+
+    -- SCS-039 v2.1 (SDS 3.6): one open daily plan at a time, pinned to its
+    -- target day, due count, base provider revision, carrier identity and field
+    -- fingerprints. It advances under DAILY_OPS_PER_FRAME and commits once;
+    -- an authoritative replacement, provider transition or geometry mismatch
+    -- aborts it without moving the cursor. Save, reload and teardown discard it.
+    self._dailyPlan = nil
 
     -- SCS-039: the vendored 2 m value map. nil until initValueMap runs, and
     -- still inert afterwards on any install where the engine cannot carry it.
@@ -1546,6 +1557,104 @@ function SoilMoistureSystem:checkDayFallback()
         self:settleDaily(1)
     end
     self._lastSettledDay = day
+end
+
+-- ============================================================
+-- SCS-039 v2.1 (SDS 3.6): THE DAILY PLAN CORE.
+--
+-- One open plan at a time handles positive due day spans. It is pinned to its
+-- target day, due count, base provider revision, carrier identity and the
+-- current field fingerprints, advances at most DAILY_OPS_PER_FRAME operations
+-- per frame, and commits once. Staging never mutates live moisture; the commit
+-- moves the settled-day cursor and advances the readable revision once.
+-- Authoritative replacement, provider transition or geometry mismatch abort
+-- the plan without moving the cursor, so the unchanged cursor reoffers the
+-- work. The runtime mapping of plan operations to per-field redistribution
+-- work, the Time Guard subscribeTick registration and the retirement of the
+-- accrual registration are the follow-on wiring slices; this is the engine-free
+-- state machine (Group J mirrors the same contract).
+-- ============================================================
+
+--- Pure due-span: how many whole days are owed between the settled cursor and
+--- the current monotonic day. A missing, zero, negative, duplicate or
+--- non-finite span owes nothing and moves no cursor.
+function SoilMoistureSystem.computeDueDays(cursor, currentDay)
+    if type(cursor) ~= "number" or type(currentDay) ~= "number" then return 0 end
+    if cursor ~= cursor or currentDay ~= currentDay then return 0 end
+    if math.abs(cursor) == math.huge or math.abs(currentDay) == math.huge then return 0 end
+    local due = currentDay - cursor
+    if due <= 0 then return 0 end
+    return math.floor(due)
+end
+
+--- Stable combined signature of every current field polygon fingerprint, used
+--- as one pin so a geometry change aborts an open plan.
+function SoilMoistureSystem:fieldFingerprintSignature()
+    local parts = {}
+    for fieldId in pairs(self.fieldData) do
+        parts[#parts + 1] = tostring(fieldId) .. ":" .. tostring(self:fieldGeometryFingerprint(fieldId))
+    end
+    table.sort(parts)
+    return table.concat(parts, "|")
+end
+
+--- Wake the daily plan for a current monotonic day. Returns:
+---   "INVALID"  non-finite current day
+---   "SEEDED"   first ever wake: the cursor seeds to the current day, no work
+---   "IDLE"     zero, negative or duplicate span; nothing owed
+---   "PENDING"  positive due work; opens or resumes the pinned daily plan
+function SoilMoistureSystem:wakeDailyPlan(currentDay, totalOps)
+    if type(currentDay) ~= "number" or currentDay ~= currentDay
+       or math.abs(currentDay) == math.huge then
+        return "INVALID"
+    end
+    if self._lastSettledDay == nil then
+        self._lastSettledDay = currentDay
+        return "SEEDED"
+    end
+    local due = SoilMoistureSystem.computeDueDays(self._lastSettledDay, currentDay)
+    if due <= 0 then return "IDLE" end
+    if self._dailyPlan == nil then
+        self._dailyPlan = {
+            due          = due,
+            targetDay    = currentDay,
+            baseRevision = self.moistureRevision or 1,
+            carrier      = self.providerMode,
+            fingerprint  = self:fieldFingerprintSignature(),
+            totalOps     = totalOps or (due * SoilMoistureSystem.DAILY_OPS_PER_FRAME),
+            cursor       = 0,
+        }
+    end
+    return "PENDING"
+end
+
+--- Advance the open plan by at most `budget` operations. Returns step, status:
+---   step    operations performed this frame
+---   "IDLE"      no plan open
+---   "ABORTED"   a pin broke (revision, carrier or geometry moved); plan cleared,
+---               cursor unchanged, the unchanged cursor reoffers the work
+---   "PAUSED"    zero budget; nothing done, nothing claimed
+---   "PENDING"   more work remains next frame
+---   "COMMITTED" the plan finished this frame: cursor moves to the target day
+---               and the readable revision advances once
+function SoilMoistureSystem:advanceDailyPlan(currentDay, budget)
+    local plan = self._dailyPlan
+    if plan == nil then return 0, "IDLE" end
+    if plan.targetDay ~= currentDay
+       or plan.baseRevision ~= (self.moistureRevision or 1)
+       or plan.carrier ~= self.providerMode
+       or plan.fingerprint ~= self:fieldFingerprintSignature() then
+        self._dailyPlan = nil
+        return 0, "ABORTED"
+    end
+    if budget == nil or budget <= 0 then return 0, "PAUSED" end
+    local step = math.min(budget, plan.totalOps - plan.cursor)
+    plan.cursor = plan.cursor + step
+    if plan.cursor < plan.totalOps then return step, "PENDING" end
+    self._lastSettledDay = plan.targetDay
+    self:_advanceMoistureRevision()
+    self._dailyPlan = nil
+    return step, "COMMITTED"
 end
 
 -- ============================================================

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -902,9 +902,9 @@ end
 --- mission still trusting the fine map. The per-field scalar rows the save
 --- handler writes next are the honest degrade layer, and the next load re-selects
 --- a readable TRUTH or ZONE carrier. Returns the literal save receipt.
-function SoilMoistureSystem:saveNativeMap(savegameDir)
+function SoilMoistureSystem:saveNativeMap(savegameDir, generation)
     if self.valueMap == nil or not self.valueMap.available then return false end
-    local savedOk = self.valueMap:saveToSavegame(savegameDir) == true
+    local savedOk = self.valueMap:saveToSavegame(savegameDir, generation) == true
     if not savedOk then
         self:_failNativeClosed("native save refusal")
     end

--- a/src/SoilMoistureSystem.lua
+++ b/src/SoilMoistureSystem.lua
@@ -186,6 +186,12 @@ function SoilMoistureSystem.new(manager)
     -- aborts it without moving the cursor. Save, reload and teardown discard it.
     self._dailyPlan = nil
 
+    -- SCS-039 v2.1 (SDS 3.7): the client fine-snapshot currentness engine
+    -- (staging + delta barrier). Server instances carry it inert; only a client
+    -- stages rows and publishes once at COMPLETE.
+    self.fineSnapshot = (SoilFineSnapshot ~= nil) and SoilFineSnapshot.new() or nil
+    self._syncSnapshotGeneration = 0
+
     -- SCS-039: the vendored 2 m value map. nil until initValueMap runs, and
     -- still inert afterwards on any install where the engine cannot carry it.
     -- Every branch below tests mapActive(); when it is false NOTHING changes and
@@ -1443,17 +1449,27 @@ end
 SoilMoistureSystem.SYNC_ROWS_PER_FRAME = 8
 
 --- Queue the whole map for a connection. Safe to call for each joining client.
+--- SDS 3.7: each join is one immutable snapshot generation of its own.
 function SoilMoistureSystem:queueMapSync(connection)
     if not self:mapActive() or connection == nil then return false end
     if g_server == nil then return false end
     self._syncQueue = self._syncQueue or {}
-    self._syncQueue[#self._syncQueue + 1] = { conn = connection, nextRow = 0 }
+    self._syncSnapshotGeneration = (self._syncSnapshotGeneration or 0) + 1
+    self._syncQueue[#self._syncQueue + 1] = {
+        conn = connection,
+        nextRow = 0,
+        snapshotGeneration = self._syncSnapshotGeneration,
+        baseRevision = self.moistureRevision or 1,
+        controlSent = false,
+    }
     return true
 end
 
 --- Drive the queue. Called from the manager's per-frame update on the server.
 --- Returns the number of rows sent this frame (0 when there is nothing to do),
 --- which is also what makes the cost visible to the instrument below.
+--- SDS 3.7: CONTROL START opens the client snapshot before the first row and
+--- CONTROL COMPLETE is the publish barrier after the final row.
 function SoilMoistureSystem:updateMapSync()
     local q = self._syncQueue
     if q == nil or #q == 0 then return 0 end
@@ -1464,24 +1480,64 @@ function SoilMoistureSystem:updateMapSync()
 
     local job = q[1]
     local total = self.valueMap:getSyncRowCount()
+    if not job.controlSent then
+        if CropStressMoistureControlEvent ~= nil then
+            g_server:sendEvent(CropStressMoistureControlEvent.new(
+                CropStressMoistureControlEvent.KIND_START,
+                job.snapshotGeneration, job.baseRevision, total,
+                self.valueMap.resolution or 0), false, nil, job.conn)
+        end
+        job.controlSent = true
+    end
+
     local sent = 0
     while sent < SoilMoistureSystem.SYNC_ROWS_PER_FRAME and job.nextRow < total do
         local raw = self.valueMap:readSyncRow(job.nextRow)
         if raw ~= nil and CropStressMoistureRowEvent ~= nil then
             local packed = CropStressValueMap.packRow(raw)
-            g_server:sendEvent(CropStressMoistureRowEvent.new(job.nextRow, packed),
-                false, nil, job.conn)
+            g_server:sendEvent(CropStressMoistureRowEvent.new(job.nextRow, packed,
+                job.snapshotGeneration), false, nil, job.conn)
         end
         job.nextRow = job.nextRow + 1
         sent = sent + 1
     end
 
     if job.nextRow >= total then
+        if CropStressMoistureControlEvent ~= nil then
+            g_server:sendEvent(CropStressMoistureControlEvent.new(
+                CropStressMoistureControlEvent.KIND_COMPLETE,
+                job.snapshotGeneration, job.baseRevision, total,
+                self.valueMap.resolution or 0), false, nil, job.conn)
+        end
         table.remove(q, 1)
-        csLog(string.format("Moisture map: delivered %d rows to a client", total))
+        csLog(string.format("Moisture map: delivered %d rows to a client (snapshot gen %d)",
+            total, job.snapshotGeneration))
     end
     self._syncTotalRowsSent = (self._syncTotalRowsSent or 0) + sent
     return sent
+end
+
+--- SCS-039 v2.1 (SDS 3.7): the client publish barrier. Applies the staged raw
+--- rows of a completed snapshot to the live map, then stamps the published
+--- absolute per-pixel delta values, exactly once.
+function SoilMoistureSystem:_publishFineSnapshot(snapshot)
+    local vm = self.valueMap
+    if vm == nil or not vm.available then return end
+    local width = (snapshot.mapWidth and snapshot.mapWidth > 0) and snapshot.mapWidth
+        or (vm.resolution or 0)
+    if width <= 0 then return end
+    for index = 0, snapshot.totalRows - 1 do
+        local packed = snapshot.rows[index]
+        if packed ~= nil then
+            local row = CropStressValueMap.unpackRow(packed, width)
+            vm:applySyncRow(index, row)
+        end
+    end
+    for pixelKey, value in pairs(snapshot.pixelValues or {}) do
+        if type(vm.writePixelValue) == "function" then
+            vm:writePixelValue(pixelKey, value)
+        end
+    end
 end
 
 -- ============================================================

--- a/src/events/CropStressMoistureControlEvent.lua
+++ b/src/events/CropStressMoistureControlEvent.lua
@@ -1,0 +1,83 @@
+-- ============================================================
+-- CropStressMoistureControlEvent.lua  (SCS-039 / GRID-1, SDS 3.7)
+--
+-- The SNAPSHOT CONTROL envelope of the fine-map delivery. START opens one
+-- immutable snapshot generation on the client's staging; COMPLETE is the
+-- last-row barrier after which staging publishes once; RESNAPSHOT_REQUEST is
+-- the one legal reply to a named semantic mismatch.
+--
+-- Wire format:
+--   kind             : UInt8   "S" START | "C" COMPLETE | "R" RESNAPSHOT_REQUEST
+--   snapshotGeneration : Int32
+--   baseRevision     : Int32   (revision the snapshot freezes)
+--   totalRows        : Int32   (0 for COMPLETE/RESNAPSHOT_REQUEST)
+--   mapWidth         : Int32
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then
+        g_logManager:devInfo("[CropStress]", msg)
+    else
+        print("[CropStress] " .. tostring(msg))
+    end
+end
+
+CropStressMoistureControlEvent = CropStressMoistureControlEvent or {}
+CropStressMoistureControlEvent_mt = Class(CropStressMoistureControlEvent, Event)
+
+InitEventClass(CropStressMoistureControlEvent, "CropStressMoistureControlEvent")
+
+CropStressMoistureControlEvent.KIND_START = "S"
+CropStressMoistureControlEvent.KIND_COMPLETE = "C"
+CropStressMoistureControlEvent.KIND_RESNAPSHOT_REQUEST = "R"
+
+function CropStressMoistureControlEvent.emptyNew()
+    return Event.new(CropStressMoistureControlEvent_mt)
+end
+
+function CropStressMoistureControlEvent.new(kind, snapshotGeneration, baseRevision, totalRows, mapWidth)
+    local self = Event.new(CropStressMoistureControlEvent_mt)
+    self.kind = kind or CropStressMoistureControlEvent.KIND_START
+    self.snapshotGeneration = snapshotGeneration or 0
+    self.baseRevision = baseRevision or 0
+    self.totalRows = totalRows or 0
+    self.mapWidth = mapWidth or 0
+    return self
+end
+
+function CropStressMoistureControlEvent:writeStream(streamId, connection)
+    streamWriteUInt8(streamId, string.byte(self.kind))
+    streamWriteInt32(streamId, self.snapshotGeneration)
+    streamWriteInt32(streamId, self.baseRevision)
+    streamWriteInt32(streamId, self.totalRows)
+    streamWriteInt32(streamId, self.mapWidth)
+end
+
+function CropStressMoistureControlEvent:readStream(streamId, connection)
+    self.kind = string.char(streamReadUInt8(streamId))
+    self.snapshotGeneration = streamReadInt32(streamId)
+    self.baseRevision = streamReadInt32(streamId)
+    self.totalRows = streamReadInt32(streamId)
+    self.mapWidth = streamReadInt32(streamId)
+    self:run(connection)
+end
+
+function CropStressMoistureControlEvent:run(connection)
+    if g_server ~= nil then return end   -- the server never stages its own map
+
+    local mgr = g_cropStressManager
+    local soilSystem = mgr and mgr.soilSystem
+    local fine = soilSystem and soilSystem.fineSnapshot
+    if fine == nil then return end
+
+    if self.kind == CropStressMoistureControlEvent.KIND_START then
+        fine:beginSnapshot(self.snapshotGeneration, self.totalRows, self.baseRevision, self.mapWidth)
+    elseif self.kind == CropStressMoistureControlEvent.KIND_COMPLETE then
+        fine:finishSnapshot(function(snapshot)
+            soilSystem:_publishFineSnapshot(snapshot)
+        end)
+    elseif self.kind == CropStressMoistureControlEvent.KIND_RESNAPSHOT_REQUEST then
+        fine:requestResnapshot()
+        csLog("Moisture map: client requested a fresh full snapshot")
+    end
+end

--- a/src/events/CropStressMoistureDeltaEvent.lua
+++ b/src/events/CropStressMoistureDeltaEvent.lua
@@ -1,0 +1,79 @@
+-- ============================================================
+-- CropStressMoistureDeltaEvent.lua  (SCS-039 / GRID-1, SDS 3.7)
+--
+-- One coalesced ABSOLUTE per-pixel delta of the fine map, field-partitioned.
+-- It names fromRevision and toRevision (a contiguous provider chain) plus the
+-- pixel key and the final semantic moisture value. A client applies it only
+-- when contiguous; a gap or a stale revision is a named semantic mismatch that
+-- requests one fresh full snapshot rather than repairing the tuple.
+--
+-- Wire format:
+--   snapshotGeneration : Int32
+--   fromRevision       : Int32
+--   toRevision         : Int32
+--   fieldId            : Int32
+--   pixelKey           : Int32   (px*4096+pz)
+--   value              : Float32 (absolute semantic 0..1)
+-- ============================================================
+
+local function csLog(msg)
+    if g_logManager ~= nil then
+        g_logManager:devInfo("[CropStress]", msg)
+    else
+        print("[CropStress] " .. tostring(msg))
+    end
+end
+
+CropStressMoistureDeltaEvent = CropStressMoistureDeltaEvent or {}
+CropStressMoistureDeltaEvent_mt = Class(CropStressMoistureDeltaEvent, Event)
+
+InitEventClass(CropStressMoistureDeltaEvent, "CropStressMoistureDeltaEvent")
+
+function CropStressMoistureDeltaEvent.emptyNew()
+    return Event.new(CropStressMoistureDeltaEvent_mt)
+end
+
+function CropStressMoistureDeltaEvent.new(snapshotGeneration, fromRevision, toRevision,
+    fieldId, pixelKey, value)
+    local self = Event.new(CropStressMoistureDeltaEvent_mt)
+    self.snapshotGeneration = snapshotGeneration or 0
+    self.fromRevision = fromRevision or 0
+    self.toRevision = toRevision or 0
+    self.fieldId = fieldId or 0
+    self.pixelKey = pixelKey or 0
+    self.value = value or 0
+    return self
+end
+
+function CropStressMoistureDeltaEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.snapshotGeneration)
+    streamWriteInt32(streamId, self.fromRevision)
+    streamWriteInt32(streamId, self.toRevision)
+    streamWriteInt32(streamId, self.fieldId)
+    streamWriteInt32(streamId, self.pixelKey)
+    streamWriteFloat32(streamId, self.value)
+end
+
+function CropStressMoistureDeltaEvent:readStream(streamId, connection)
+    self.snapshotGeneration = streamReadInt32(streamId)
+    self.fromRevision = streamReadInt32(streamId)
+    self.toRevision = streamReadInt32(streamId)
+    self.fieldId = streamReadInt32(streamId)
+    self.pixelKey = streamReadInt32(streamId)
+    self.value = streamReadFloat32(streamId)
+    self:run(connection)
+end
+
+function CropStressMoistureDeltaEvent:run(connection)
+    if g_server ~= nil then return end
+
+    local mgr = g_cropStressManager
+    local soilSystem = mgr and mgr.soilSystem
+    local fine = soilSystem and soilSystem.fineSnapshot
+    if fine == nil then return end
+
+    local ok = fine:receiveDelta(self.fromRevision, self.toRevision, self.pixelKey, self.value)
+    if not ok and fine.resnapshot then
+        csLog("Moisture map: delta gap requests a fresh full snapshot")
+    end
+end

--- a/src/events/CropStressMoistureRowEvent.lua
+++ b/src/events/CropStressMoistureRowEvent.lua
@@ -46,14 +46,17 @@ end
 
 --- @param rowIndex number  map row (0-based)
 --- @param packed table     run-length pairs from CropStressValueMap.packRow
-function CropStressMoistureRowEvent.new(rowIndex, packed)
+--- @param snapshotGeneration number  SDS 3.7 join snapshot generation (0 = legacy)
+function CropStressMoistureRowEvent.new(rowIndex, packed, snapshotGeneration)
     local self = Event.new(CropStressMoistureRowEvent_mt)
     self.rowIndex = rowIndex or 0
     self.packed   = packed or {}
+    self.snapshotGeneration = snapshotGeneration or 0
     return self
 end
 
 function CropStressMoistureRowEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.snapshotGeneration)
     streamWriteUInt16(streamId, self.rowIndex)
     local runs = math.floor(#self.packed / 2)
     streamWriteUInt16(streamId, runs)
@@ -66,6 +69,7 @@ function CropStressMoistureRowEvent:writeStream(streamId, connection)
 end
 
 function CropStressMoistureRowEvent:readStream(streamId, connection)
+    self.snapshotGeneration = streamReadInt32(streamId)
     self.rowIndex = streamReadUInt16(streamId)
     local runs = streamReadUInt16(streamId)
     self.packed = {}
@@ -85,9 +89,20 @@ function CropStressMoistureRowEvent:run(connection)
     local mgr = g_cropStressManager
     local soilSystem = mgr and mgr.soilSystem
     if soilSystem == nil or soilSystem.valueMap == nil then return end
+
+    -- SCS-039 v2.1 (SDS 3.7): a row for an open snapshot generation stages
+    -- behind the CONTROL barrier and never touches the live map directly. A
+    -- legacy server (no CONTROL envelope) leaves the snapshot unopened, so the
+    -- row still applies directly and an old server with a new client stays
+    -- compatible.
+    local fine = soilSystem.fineSnapshot
+    if fine ~= nil and fine.snapshotGeneration ~= nil and not fine.current then
+        fine:receiveRow(self.snapshotGeneration, self.rowIndex, self.packed)
+        return
+    end
+
     local vm = soilSystem.valueMap
     if not vm.available then return end
-
     local row = CropStressValueMap.unpackRow(self.packed, vm.resolution)
     vm:applySyncRow(self.rowIndex, row)
 end

--- a/src/integrations/CropStressNetworkSyncBridge.lua
+++ b/src/integrations/CropStressNetworkSyncBridge.lua
@@ -113,11 +113,18 @@ end
 -- Client: apply a received whole moisture/stress map. Mirrors
 -- CropStressMoistureInitEvent:run - update existing moisture, create a minimal
 -- entry for a not-yet-enumerated field, set stress, then rebuild the field map.
+-- SCS-039 v2.1 (SDS 3.8): the NetworkSync aggregate may update legacy scalars
+-- only while the SCS fine map is NOT the current authority. Once the SCS event
+-- barrier has published a current fine map (isMoistureMapCurrent), the mirror
+-- must not fight it; it can never seed fine staging or claim fine currentness.
 function CropStressNetworkSyncBridge._onReadState(arr)
     if g_server ~= nil then return end   -- server never applies its own state
 
     local mgr = getManager()
     if mgr == nil or mgr.soilSystem == nil or mgr.stressModifier == nil then return end
+    if mgr.soilSystem.isMoistureMapCurrent ~= nil and mgr.soilSystem:isMoistureMapCurrent() then
+        return   -- a current SCS fine map owns the ground; the mirror stands down
+    end
 
     local fieldData, fieldStress = CropStressNetworkSyncBridge.deserializeFields(arr)
 
@@ -172,20 +179,25 @@ function CropStressNetworkSyncBridge.register(mgr)
         return
     end
 
+    -- SCS-039 v2.1 (SDS 3.8): the bridge is active only when the outer pcall
+    -- succeeds AND registerModule returns EXACTLY true. A non-throwing nil/false
+    -- return was previously misread as an active registration.
+    local registered = false
     local ok, err = pcall(function()
-        ns:registerModule(CropStressNetworkSyncBridge.MODULE_ID, {
+        registered = ns:registerModule(CropStressNetworkSyncBridge.MODULE_ID, {
             channel      = CropStressNetworkSyncBridge.CHANNEL,
             onWriteState = CropStressNetworkSyncBridge._onWriteState,
             onReadState  = CropStressNetworkSyncBridge._onReadState,
         })
     end)
 
-    if ok then
+    if ok and registered == true then
         CropStressNetworkSyncBridge.active = true
         print(string.format("[CropStress] Registered with NetworkSync as '%s' (hourly moisture broadcast now batches through NetworkSync)",
             CropStressNetworkSyncBridge.MODULE_ID))
     else
         CropStressNetworkSyncBridge.active = false
-        print(string.format("[CropStress] NetworkSync registration failed: %s (falling back to moisture event class)", tostring(err)))
+        print(string.format("[CropStress] NetworkSync registration failed or refused: %s (falling back to moisture event class)",
+            tostring(err)))
     end
 end

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -497,6 +497,20 @@ function CropStressValueMap:applySyncRow(gy, row)
     return true
 end
 
+--- SCS-039 v2.1 (SDS 3.7): set ONE pixel from a semantic moisture value by its
+--- composite pixel key (px*4096+pz). Absolute deltas that a snapshot publishes
+--- land here after the raw rows are applied.
+function CropStressValueMap:writePixelValue(pixelKey, value)
+    if not self.available then return false end
+    if setBitVectorMapPoint == nil then return false end
+    local px = math.floor(pixelKey / 4096)
+    local pz = pixelKey - px * 4096
+    if px < 0 or pz < 0 or px >= self.resolution or pz >= self.resolution then return false end
+    local raw = encode(value, CropStressValueMap.LAYER_DEF)
+    local ok = pcall(setBitVectorMapPoint, self.bvm, px, pz, 0, NUM_CHANNELS, raw)
+    return ok == true
+end
+
 --- Pack a raw row into a compact run-length form for the wire. Moisture maps are
 --- overwhelmingly runs of one value (a field at a uniform level, and the whole
 --- off-field remainder at the raw-0 sentinel), so this is the difference between

--- a/src/maps/CropStressValueMap.lua
+++ b/src/maps/CropStressValueMap.lua
@@ -36,6 +36,18 @@ CropStressValueMap.LAYER_DEF = {
     maxVal = 1.0,
 }
 
+--- SCS-039 v2.1 (SDS 3.5): generation-qualified native file name. Generation 0
+--- (or nil) is the LEGACY baseline name and is never overwritten once
+--- generation-qualified storage starts; a qualified generation writes a
+--- distinct file so a save never clobbers either retained complete pair.
+function CropStressValueMap.generationFileName(generation)
+    if generation == nil or generation <= 0 then return CropStressValueMap.LAYER_DEF.file end
+    local base = CropStressValueMap.LAYER_DEF.file
+    local stem = base:match("^(.*)%.grle$")
+    if stem == nil then stem = base end
+    return string.format("%s.g%d.grle", stem, generation)
+end
+
 local NUM_CHANNELS = 8      -- bits per pixel
 local RAW_MIN      = 1      -- raw 0 is reserved as "no data" / off-field
 local RAW_MAX      = 255
@@ -230,10 +242,14 @@ function CropStressValueMap:delete()
     self.available = false
 end
 
-function CropStressValueMap:saveToSavegame(savegameDir)
+function CropStressValueMap:saveToSavegame(savegameDir, generation)
     if not self.available or savegameDir == nil then return false end
     if saveBitVectorMapToFile == nil then return false end
-    local path = savegameDir .. "/" .. CropStressValueMap.LAYER_DEF.file
+    -- SCS-039 v2.1 (SDS 3.5): the native file is generation-qualified when a
+    -- generation is supplied (the candidate COMPLETE generation), so a save
+    -- never overwrites the legacy baseline or either retained complete pair.
+    local name = CropStressValueMap.generationFileName(generation)
+    local path = savegameDir .. "/" .. name
     -- SCS-039 v2.1: a native mutator succeeds only when BOTH the outer pcall
     -- survived AND the engine returned literal true. A non-throwing false return
     -- was previously misread as a saved file, a silent data-loss report.

--- a/src/ui/CsMoistureMapOverlay.lua
+++ b/src/ui/CsMoistureMapOverlay.lua
@@ -415,8 +415,17 @@ function CsMoistureMapOverlay:_pdaKickBuild()
     -- Path 1: read from the live value map (SF pattern). The top 4 bits of the
     -- 8-bit moisture layer give 16 DMV states at 2 m/px, so irrigation pixels
     -- light up the moment they are written.
+    -- SCS-039 v2.1 (SDS 3.9): Path 1 binds ONLY the current fine map. A native
+    -- provider that has failed closed, a ZONE carrier, or any partial/absent
+    -- fine state answers not-current, so the overlay falls to the aggregate
+    -- fallback instead of drawing non-current bytes as current ground.
     local soilSystem = self.manager and self.manager.soilSystem
-    local valueMap = soilSystem and soilSystem.valueMap
+    local valueMap = nil
+    if soilSystem ~= nil and soilSystem.isMoistureMapCurrent ~= nil
+       and soilSystem.getMoistureDisplayMap ~= nil
+       and soilSystem:isMoistureMapCurrent() then
+        valueMap = soilSystem:getMoistureDisplayMap()
+    end
     if valueMap and valueMap.available and valueMap.bvm then
         local bvm = valueMap.bvm
         setDensityMapVisualizationOverlayStateColor(ov, bvm, 0, 0, 4, 4, 0, 0, 0, 0, 0)

--- a/tools/test/lua/scs039_daily_plan_test.lua
+++ b/tools/test/lua/scs039_daily_plan_test.lua
@@ -1,0 +1,119 @@
+-- scs039_daily_plan_test.lua
+-- SCS-039 / GRID-1 (SDS 3.6): the daily-plan core. One open plan handles a
+-- positive due day span, pinned to its target day, base provider revision,
+-- carrier and field fingerprints; it advances at most DAILY_OPS_PER_FRAME per
+-- frame and commits once, moving the cursor and advancing the readable
+-- revision. Zero, backward, duplicate or non-finite spans do nothing; a broken
+-- pin aborts the plan without moving the cursor.
+--
+-- Group J models the same contract. The runtime mapping of plan operations to
+-- per-field redistribution work and the Time Guard subscribeTick registration
+-- are the follow-on wiring slices.
+--!load: src/SoilMoistureSystem.lua
+
+local OPS = SoilMoistureSystem.DAILY_OPS_PER_FRAME
+
+local function systemAt(day, revision)
+  local s = SoilMoistureSystem.new({})
+  s._lastSettledDay = day
+  s.moistureRevision = revision
+  return s
+end
+
+-- 1. PURE DUE MATH (zero, backward, duplicate, non-finite owe nothing).
+do
+  T.eq("due.threeWholeDays", SoilMoistureSystem.computeDueDays(5, 8), 3)
+  T.eq("due.backward", SoilMoistureSystem.computeDueDays(8, 7), 0)
+  T.eq("due.duplicate", SoilMoistureSystem.computeDueDays(8, 8), 0)
+  T.eq("due.subDay", SoilMoistureSystem.computeDueDays(8, 8.5), 0)
+  T.eq("due.missingCursor", SoilMoistureSystem.computeDueDays(nil, 8), 0)
+  T.eq("due.missingDay", SoilMoistureSystem.computeDueDays(8, nil), 0)
+  T.eq("due.nonFinite", SoilMoistureSystem.computeDueDays(8, math.huge), 0)
+  T.eq("due.nan", SoilMoistureSystem.computeDueDays(8, math.huge * 0), 0)
+end
+
+-- 2. OPEN, BUDGETED ADVANCE AND ONE COMMIT (Group J J1-J11).
+do
+  local s = systemAt(5, 20)
+  T.eq("plan.openPending", s:wakeDailyPlan(8, 900), "PENDING")
+  T.eq("plan.cursorUnchangedWhileOpen", s._lastSettledDay, 5)
+  T.eq("plan.pinnedDue", s._dailyPlan.due, 3)
+  T.eq("plan.pinnedTarget", s._dailyPlan.targetDay, 8)
+  T.eq("plan.pinnedRevision", s._dailyPlan.baseRevision, 20)
+  local step1, st1 = s:advanceDailyPlan(8, OPS)
+  T.eq("plan.firstFrameBudgeted", step1, OPS)
+  T.eq("plan.firstFramePending", st1, "PENDING")
+  local step2, st2 = s:advanceDailyPlan(8, OPS)
+  T.eq("plan.secondFramePending", st2, "PENDING")
+  local step3, st3 = s:advanceDailyPlan(8, OPS)
+  T.eq("plan.finalFrameRemaining", step3, 100)
+  T.eq("plan.finalFrameCommits", st3, "COMMITTED")
+  T.eq("plan.cursorMovedToTarget", s._lastSettledDay, 8)
+  T.eq("plan.revisionAdvancedOnce", s.moistureRevision, 21)
+  T.eq("plan.cleared", s._dailyPlan, nil)
+  T.eq("plan.duplicateWakeIdle", s:wakeDailyPlan(8), "IDLE")
+end
+
+-- 3. SEEDING: a first-ever wake seeds the current day with no invented history
+--    and mints no revision (J18-J20).
+do
+  local s = SoilMoistureSystem.new({})
+  T.eq("seed.firstWakeSeeds", s:wakeDailyPlan(12), "SEEDED")
+  T.eq("seed.cursorIsCurrent", s._lastSettledDay, 12)
+  T.eq("seed.noRevision", s.moistureRevision, 1)
+  T.eq("seed.noPlan", s._dailyPlan, nil)
+end
+
+-- 4. ZERO BUDGET visibly pauses and never claims completion (J22-J23).
+do
+  local s = systemAt(5, 20)
+  s:wakeDailyPlan(8, 900)
+  T.eq("pause.zeroBudget", select(2, s:advanceDailyPlan(8, 0)), "PAUSED")
+  T.eq("pause.cursorUnchanged", s._lastSettledDay, 5)
+  T.eq("pause.planIntact", s._dailyPlan ~= nil, true)
+  T.eq("pause.planNotAdvanced", s._dailyPlan.cursor, 0)
+end
+
+-- 5. PIN BREAKS ABORT THE PLAN WITHOUT MOVING THE CURSOR (J15-J17): an
+--    authoritative replacement advances the revision, a provider transition
+--    changes the carrier, and a geometry change alters the fingerprint.
+do
+  local s = systemAt(5, 20)
+  s:wakeDailyPlan(8, 900)
+  s.moistureRevision = 21
+  T.eq("abort.replacement", select(2, s:advanceDailyPlan(8, OPS)), "ABORTED")
+  T.eq("abort.planCleared", s._dailyPlan, nil)
+  T.eq("abort.cursorHeld", s._lastSettledDay, 5)
+
+  local s2 = systemAt(5, 20)
+  s2:wakeDailyPlan(8, 900)
+  s2.providerMode = "ZONE"
+  T.eq("abort.carrierChange", select(2, s2:advanceDailyPlan(8, OPS)), "ABORTED")
+  T.eq("abort.carrierCursorHeld", s2._lastSettledDay, 5)
+
+  local s3 = systemAt(5, 20)
+  s3:wakeDailyPlan(8, 900)
+  s3.fieldData[1] = { fieldId = 1 }
+  T.eq("abort.geometryChange", select(2, s3:advanceDailyPlan(8, OPS)), "ABORTED")
+  T.eq("abort.geometryCursorHeld", s3._lastSettledDay, 5)
+end
+
+-- 6. INVALID WAKES and an absent day refuse before the provider.
+do
+  local s = systemAt(5, 20)
+  T.eq("invalid.nan", s:wakeDailyPlan(math.huge * 0), "INVALID")
+  T.eq("invalid.huge", s:wakeDailyPlan(math.huge), "INVALID")
+  T.eq("idle.noPlanAdvance", select(2, s:advanceDailyPlan(8, OPS)), "IDLE")
+end
+
+-- 7. A duplicate wake while a plan is open resumes it without a second plan.
+do
+  local s = systemAt(5, 20)
+  s:wakeDailyPlan(8, 900)
+  s:wakeDailyPlan(8, 900)
+  T.eq("resume.singlePlan", s._dailyPlan ~= nil, true)
+  T.eq("resume.pinnedDue", s._dailyPlan.due, 3)
+  T.eq("resume.cursorStillZero", s._dailyPlan.cursor, 0)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_fine_snapshot_test.lua
+++ b/tools/test/lua/scs039_fine_snapshot_test.lua
@@ -1,0 +1,110 @@
+-- scs039_fine_snapshot_test.lua
+-- SCS-039 / GRID-1 (SDS 3.7): client fine-snapshot semantic currentness and the
+-- CONTROL / DELTA event wire round trips. Rows and deltas stage behind the
+-- CONTROL barrier and publish once at COMPLETE; a missing row, revision gap or
+-- mismatched generation requests one fresh snapshot. Two connections never
+-- share one currentness flag.
+--!load: src/SoilFineSnapshot.lua, src/events/CropStressMoistureControlEvent.lua, src/events/CropStressMoistureDeltaEvent.lua
+
+local function newFine()
+  return SoilFineSnapshot.new()
+end
+
+-- 1. COMPLETE ROWS + CONTIGUOUS DELTAS CROSS THE BARRIER AND PUBLISH ONCE.
+do
+  local f = newFine()
+  f:beginSnapshot(1001, 2, 10, 8)
+  f:receiveAggregateWitness(1001, 10, { aggregate = 0.25 })
+  f:receiveDelta(10, 12, 44, 0.70)
+  T.eq("fine.bufferedNotLive", f.current, false)
+  f:receiveRow(1001, 0, { 2, 5, 2, 0 })
+  T.eq("fine.partialStagingNotLive", f.current, false)
+  f:receiveRow(1001, 1, { 2, 3, 2, 0 })
+  T.eq("fine.completePublishes", f:finishSnapshot(), true)
+  T.eq("fine.publishedCurrent", f.current, true)
+  T.eq("fine.reachesDeltaRevision", f.currentRevision, 12)
+  T.near("fine.deltaInstalled", f.pixelValues[44], 0.70, 1e-12)
+  T.eq("fine.completeIdempotent", f:finishSnapshot(), true)
+  T.eq("fine.publishOnce", f.publishCount, 1)
+end
+
+-- 2. LIVE DELTAS AFTER CURRENT: contiguous applies, duplicates ignored, gaps
+--    request a fresh snapshot.
+do
+  local f = newFine()
+  f:beginSnapshot(1001, 1, 20, 8)
+  f:receiveRow(1001, 0, { 1, 0, 1, 5 })
+  f:finishSnapshot()
+  T.eq("live.contiguousApplies", f:receiveDelta(20, 21, 7, 0.75), true)
+  T.near("live.updatesRevision", f.pixelValues[7], 0.75, 1e-12)
+  T.eq("live.revisionAdvanced", f.currentRevision, 21)
+  T.eq("live.duplicateIgnored", f:receiveDelta(20, 21, 7, 0.75), true)
+  T.near("live.duplicateKeepsValue", f.pixelValues[7], 0.75, 1e-12)
+  T.eq("live.gapRequestsResnapshot", f:receiveDelta(22, 23, 9, 0.5), false)
+  T.eq("live.resnapshotSet", f.resnapshot, true)
+end
+
+-- 3. A MISSING ROW REFUSES COMPLETION AND REQUESTS ONE FRESH SNAPSHOT.
+do
+  local f = newFine()
+  f:beginSnapshot(1001, 2, 30, 8)
+  f:receiveRow(1001, 0, { 1, 0, 1, 5 })
+  T.eq("missing.refuses", f:finishSnapshot(), false)
+  T.eq("missing.resnapshot", f.resnapshot, true)
+  f:requestResnapshot()
+  T.eq("missing.clearedStaging", f.snapshotGeneration, nil)
+  T.eq("missing.currentFalse", f.current, false)
+end
+
+-- 4. A ROW FOR A FOREIGN GENERATION IS REFUSED.
+do
+  local f = newFine()
+  f:beginSnapshot(1001, 1, 40, 8)
+  T.eq("foreign.rowRefused", f:receiveRow(9999, 0, { 1, 0, 1, 5 }), false)
+  T.eq("foreign.openSnapshotKept", f.snapshotGeneration, 1001)
+end
+
+-- 5. TWO CONNECTIONS NEVER SHARE ONE CURRENTNESS FLAG.
+do
+  local a = newFine()
+  local b = newFine()
+  a:beginSnapshot(1001, 1, 50, 8)
+  a:receiveRow(1001, 0, { 1, 0, 1, 5 })
+  a:finishSnapshot()
+  T.eq("two.aCurrent", a.current, true)
+  T.eq("two.bIndependent", b.current, false)
+  T.eq("two.bNoSnapshot", b.snapshotGeneration, nil)
+end
+
+-- 6. CONTROL EVENT ROUND TRIP (START carries generation/revision/rows/width).
+do
+  local s = _sfMockStream()
+  local ev = CropStressMoistureControlEvent.new(CropStressMoistureControlEvent.KIND_START, 1001, 10, 2, 8)
+  ev:writeStream(s)
+  local got = CropStressMoistureControlEvent.emptyNew()
+  got:readStream(s)
+  T.eq("control.kind", got.kind, "S")
+  T.eq("control.generation", got.snapshotGeneration, 1001)
+  T.eq("control.baseRevision", got.baseRevision, 10)
+  T.eq("control.totalRows", got.totalRows, 2)
+  T.eq("control.mapWidth", got.mapWidth, 8)
+  T.eq("control.streamClean", s.typeErrors + s.underflows, 0)
+end
+
+-- 7. DELTA EVENT ROUND TRIP.
+do
+  local s = _sfMockStream()
+  local ev = CropStressMoistureDeltaEvent.new(1001, 12, 13, 3, 4097, 0.72)
+  ev:writeStream(s)
+  local got = CropStressMoistureDeltaEvent.emptyNew()
+  got:readStream(s)
+  T.eq("delta.generation", got.snapshotGeneration, 1001)
+  T.eq("delta.fromRevision", got.fromRevision, 12)
+  T.eq("delta.toRevision", got.toRevision, 13)
+  T.eq("delta.fieldId", got.fieldId, 3)
+  T.eq("delta.pixelKey", got.pixelKey, 4097)
+  T.near("delta.value", got.value, 0.72, 1e-9)
+  T.eq("delta.streamClean", s.typeErrors + s.underflows, 0)
+end
+
+T.summary()

--- a/tools/test/lua/scs039_native_generation_test.lua
+++ b/tools/test/lua/scs039_native_generation_test.lua
@@ -1,0 +1,59 @@
+-- scs039_native_generation_test.lua
+-- SCS-039 / GRID-1 (SDS 3.5): generation-qualified native file naming and the
+-- plumbing that writes the CANDIDATE COMPLETE generation to its own file so a
+-- save never overwrites the legacy baseline or either retained complete pair.
+--!load: src/SoilMoistureSystem.lua, src/maps/CropStressValueMap.lua
+
+-- 1. GENERATION FILE NAMES: generation 0 (and nil) is the legacy baseline.
+do
+  T.eq("name.legacyZero", CropStressValueMap.generationFileName(0), "csMoistureMap.grle")
+  T.eq("name.legacyNil", CropStressValueMap.generationFileName(nil), "csMoistureMap.grle")
+  T.eq("name.generationOne", CropStressValueMap.generationFileName(1), "csMoistureMap.g1.grle")
+  T.eq("name.generationFive", CropStressValueMap.generationFileName(5), "csMoistureMap.g5.grle")
+  T.eq("name.qualifiedNeverEqualsLegacy", CropStressValueMap.generationFileName(3) ~= CropStressValueMap.generationFileName(0), true)
+end
+
+-- 2. THE MAP WRITES TO THE QUALIFIED NAME WHEN GIVEN A GENERATION, else legacy.
+do
+  local original = saveBitVectorMapToFile
+  local capturedPath = nil
+  saveBitVectorMapToFile = function(_bvm, path)
+    capturedPath = path
+    return true
+  end
+  local m = setmetatable({ available = true, bvm = 1 }, { __index = CropStressValueMap })
+  T.eq("map.qualifiedSaveOk", m:saveToSavegame("save-root", 3), true)
+  T.eq("map.qualifiedPath", capturedPath, "save-root/csMoistureMap.g3.grle")
+  T.eq("map.legacySaveOk", m:saveToSavegame("save-root"), true)
+  T.eq("map.legacyPath", capturedPath, "save-root/csMoistureMap.grle")
+  saveBitVectorMapToFile = original
+end
+
+-- 3. SOIL SYSTEM PASSES THE CANDIDATE GENERATION THROUGH TO THE NATIVE SAVE.
+do
+  local sys = SoilMoistureSystem.new({})
+  local seenDir, seenGen = nil, nil
+  sys.valueMap = {
+    available = true,
+    saveToSavegame = function(_self, dir, generation)
+      seenDir, seenGen = dir, generation
+      return true
+    end,
+  }
+  sys.providerMode = "TRUTH"
+  T.eq("soil.generationPassedOk", sys:saveNativeMap("/saves", 4), true)
+  T.eq("soil.generationSeen", seenGen, 4)
+  T.eq("soil.dirSeen", seenDir, "/saves")
+  T.eq("soil.keepsTruth", sys.providerMode, "TRUTH")
+end
+
+-- 4. A QUALIFIED NATIVE SAVE REFUSAL STILL FAILS THE PROVIDER CLOSED (SDS 3.3).
+do
+  local sys = SoilMoistureSystem.new({})
+  sys.valueMap = { available = true, saveToSavegame = function() return false end }
+  sys.providerMode = "TRUTH"
+  T.eq("refusal.reportsFalse", sys:saveNativeMap("/saves", 4), false)
+  T.eq("refusal.failsClosed", sys.providerMode, "UNAVAILABLE_PENDING_RELOAD")
+end
+
+T.summary()

--- a/tools/test/lua/scs039_netsync_gate_test.lua
+++ b/tools/test/lua/scs039_netsync_gate_test.lua
@@ -1,0 +1,62 @@
+-- scs039_netsync_gate_test.lua
+-- SCS-039 / GRID-1 (SDS 3.8): the NetworkSync aggregate mirror is active only
+-- when registerModule returns EXACTLY true, and its read callback updates
+-- legacy aggregates only while the SCS fine map is not the current authority.
+--!load: src/SoilMoistureSystem.lua, src/integrations/CropStressNetworkSyncBridge.lua
+
+local function soilWithField(providerMode, withMap)
+  local s = SoilMoistureSystem.new({})
+  s.fieldData[1] = { fieldId = 1, moisture = 0.5, soilType = "loamy" }
+  s.providerMode = providerMode
+  if withMap then s.valueMap = { available = true } end
+  return s
+end
+
+local function applyRead(soil)
+  local mgr = { soilSystem = soil, stressModifier = { fieldStress = {} } }
+  g_currentMission.cropStressManager = mgr   -- the bridge resolves the manager globally
+  local arr = CropStressNetworkSyncBridge.serializeFields(
+    { [1] = { moisture = 0.9 } }, { [1] = 0.25 })
+  CropStressNetworkSyncBridge._onReadState(arr)
+  g_currentMission.cropStressManager = nil
+  return mgr
+end
+
+-- 1. REGISTRATION REQUIRES EXACT TRUE (Group M M1-M4).
+do
+  local function registerReturning(ret)
+    g_currentMission.networkSync = {
+      registerModule = function()
+        if type(ret) == "table" and ret.throw then error("refused") end
+        return ret
+      end,
+    }
+    CropStressNetworkSyncBridge.register({})
+    local active = CropStressNetworkSyncBridge.active
+    g_currentMission.networkSync = nil
+    return active
+  end
+  T.eq("netsync.exactTrueActivates", registerReturning(true), true)
+  T.eq("netsync.falseIsNeutralAbsence", registerReturning(false), false)
+  T.eq("netsync.nilIsNeutralAbsence", registerReturning(nil), false)
+  T.eq("netsync.thrownIsNeutralAbsence", registerReturning({ throw = true }), false)
+
+  g_currentMission.networkSync = nil
+  CropStressNetworkSyncBridge.register({})
+  T.eq("netsync.absentIsNeutralAbsence", CropStressNetworkSyncBridge.active, false)
+end
+
+-- 2. THE READ MIRROR STANDS DOWN WHILE THE SCS FINE MAP IS CURRENT.
+do
+  local current = soilWithField("TRUTH", true)
+  T.eq("barrier.currentIsTrue", current:isMoistureMapCurrent(), true)
+  applyRead(current)
+  T.near("barrier.currentKeepsScalar", current.fieldData[1].moisture, 0.5, 1e-12)
+
+  local notCurrent = soilWithField("ZONE", false)
+  T.eq("barrier.notCurrentIsFalse", notCurrent:isMoistureMapCurrent(), false)
+  applyRead(notCurrent)
+  T.near("barrier.mirrorUpdatesScalar", notCurrent.fieldData[1].moisture, 0.9, 1e-12)
+end
+
+T.summary()


### PR DESCRIPTION
## SCS-039 post-checkpoint slices 12-16, follow-up stacked on PR #172

Post-checkpoint SCS-039 work, kept off PR #172 while that PR awaits Iris's single combined Design read. This branch is cut from the tip of `feat/SCS-039-moisture-truth-grid` (slices 1-11) and stacks on it.

### Why the base is the checkpoint branch, not development
PR #172 (slices 1-11) is open and pending Iris's Design review, so its content is not yet in `development`. Basing this follow-up on `development` would show the entire member in the diff. Basing it on the checkpoint branch keeps this PR's diff to the follow-up slices only. Once #172 merges into `development`, this branch rebases onto `development` and this PR retargets, leaving only the follow-up commits.

### Slices on this branch

### Slice 12 - daily-plan core for positive due spans (`28f25d6`)
The SDS 3.6 daily-plan core as the engine-free state machine the scheduler wiring will drive (Group J mirror). `computeDueDays` / `wakeDailyPlan` / `advanceDailyPlan` with pinning to target day, base provider revision, carrier and field fingerprints; aborts on a broken pin without moving the cursor; commits once moving the cursor and advancing the revision once. Locked by `scs039_daily_plan_test.lua` (43 assertions).

### Slice 13 - generation-qualified native save files (`3f431cd`)
SDS 3.5 native-file generation: `CropStressValueMap.generationFileName` maps generation 0/nil to the legacy `csMoistureMap.grle` and any positive generation to `csMoistureMap.gN.grle`; `saveToSavegame`/`saveNativeMap` accept the generation; SaveLoadHandler writes the CANDIDATE generation (current + 1). Locked by `scs039_native_generation_test.lua` (15 assertions).

### Slice 14 - NetworkSync mirror exact-true + read barrier (`1c68cca`)
SDS 3.8: `CropStressNetworkSyncBridge.register` activates only when `registerModule` returns EXACTLY true (Group M), and `_onReadState` stands down while `isMoistureMapCurrent` is true. Locked by `scs039_netsync_gate_test.lua` (9 assertions).

### Slice 15 - overlay binds only the current fine map (`107e803`)
SDS 3.9: the PDA moisture overlay Path 1 gates on `isMoistureMapCurrent()` and draws `getMoistureDisplayMap()`, so a failed-closed provider, ZONE carrier or partial fine state falls to the aggregate fallback.

### Slice 16 - fine-snapshot currentness + control/delta events (`0b6d4ff`)
SDS 3.7: new engine-free `SoilFineSnapshot` (Group F mirror) plus `CropStressMoistureControlEvent` (START/COMPLETE/RESNAPSHOT_REQUEST) and `CropStressMoistureDeltaEvent`; `CropStressMoistureRowEvent` carries the snapshot generation and stages behind the CONTROL barrier (legacy direct apply preserved); the server walk emits CONTROL START/COMPLETE one generation per join; value map gains single-pixel `writePixelValue`. Locked by `scs039_fine_snapshot_test.lua` (37 assertions).

---

### Status
Offline suite **1145 passed / 0 failed across 34 files** at tip `0b6d4ff`; Lua 5.1 syntax gate clean (51 src files). Release stays LOCKED; no in-game or multiplayer acceptance is claimed.

### Remaining (in-game-verifiable only)
SDS 3.6 live activation (Time Guard `subscribeTick`, per-frame redistribution mapping, accrual retirement); SDS 3.5 native load-door selection + on-disk pair retention/cleanup; SDS 3.7 server delta emission from live mutations.

### Review
Implementation owns the slices, re-points and harness runs. This is a stacked draft to be rebased onto `development` once PR #172 merges.
