### PR TITLE
feat(SCS-046): activity transport + command revision (A/B) + F200 settlement

### DIFF
--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -923,6 +923,12 @@ function CropStressManager:sendInitialClientState(connection)
         self.soilSystem:queueMapSync(connection)
     end
 
+    -- SCS-046 A / SDS 8: push this connection's farm's COMPLETE private
+    -- irrigation snapshot so a pure client's _clientFarmCurrent becomes current.
+    if self.irrigationManager ~= nil and self.irrigationManager.sendFarmPrivateState ~= nil then
+        self.irrigationManager:sendFarmPrivateState(connection)
+    end
+
     local fieldCount = 0
     for _ in pairs(self.soilSystem.fieldData) do fieldCount = fieldCount + 1 end
     csLog(string.format("MP: sent settings + moisture snapshot (%d fields) to new client", fieldCount))

--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -741,6 +741,10 @@ function CropStressManager:onHourlyTick(elapsedHours)
             for _, sys in pairs(self.irrigationManager.systems) do
                 if sys.rainKeyFitted == true and sys.isActive then
                     sys.activeGameHoursSinceSettle = (sys.activeGameHoursSinceSettle or 0) + hours
+                    -- SCS-046 F200: each admitted hour settles through the one
+                    -- continuous-interval path (water + cost), then the accumulator
+                    -- is cleared by settleFittedSystem.
+                    self.irrigationManager:settleFittedSystem(sys, "HOURLY")
                 end
             end
         end

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1184,6 +1184,15 @@ end
 function IrrigationManager:updateRainKeySensor(dt)
     if self.manager == nil or self.manager.weatherIntegration == nil then return {} end
     if g_server == nil then return {} end
+    -- SCS-046 A (F200): master-disabled or release-locked freezes the sensor
+    -- (no accumulation, no dry time, no trips). The release row is rain_key_pause.
+    if self.manager.settings ~= nil and self.manager.settings.enabled == false then
+        return {}
+    end
+    if ReleaseGate ~= nil and type(ReleaseGate.isSystemLive) == "function"
+       and ReleaseGate.isSystemLive("rain_key_pause") ~= true then
+        return {}
+    end
 
     -- The one current-rain read per tick. UNAVAILABLE when both routes fail.
     local readable, rainScale, isRaining = self.manager.weatherIntegration:getCurrentRainKey()

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1826,3 +1826,19 @@ function IrrigationManager:buildFarmPrivateSnapshot(farmId)
         sourceRows = self:getIrrigationWaterSources(farmId),
     }
 end
+
+--- SDS 8 / SCS-046 A: on a pure client join, push that connection's farm's
+--- COMPLETE private snapshot (systems + sources) so the client's
+--- _clientFarmCurrent flag becomes current together. The engine resolves the
+--- farm for the joining connection; a dedicated client only ever gets its own
+--- farm's private state.
+function IrrigationManager:sendFarmPrivateState(connection)
+    if g_server == nil then return false end
+    if CropStressIrrigationStateEvent == nil then return false end
+    local farmId = self:resolveRequesterFarmId(connection)
+    if farmId == nil or farmId <= 0 then return false end
+    local snapshot = self:buildFarmPrivateSnapshot(farmId)
+    connection:sendEvent(CropStressIrrigationStateEvent.new(
+        farmId, snapshot.systemRows, snapshot.sourceRows))
+    return true
+end

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -744,9 +744,17 @@ function IrrigationManager:activateSystem(id)
     return true, nil
 end
 
-function IrrigationManager:deactivateSystem(id)
+function IrrigationManager:deactivateSystem(id, reason)
     local system = self.systems[id]
     if system == nil or not system.isActive then return end
+
+    -- SCS-046 F200: a fitted pivot settles its already-run continuous interval
+    -- before it stops, so a trip or Stop never strands water and cost. The
+    -- reason travels to the settle for diagnostics; nil keeps legacy callers.
+    if system.rainKeyFitted == true and (system.activeGameHoursSinceSettle or 0) > 0
+       and self.settleFittedSystem ~= nil then
+        self:settleFittedSystem(system, reason or "DEACTIVATE")
+    end
 
     for _, fieldId in ipairs(system.coveredFields) do
         if self.manager ~= nil and self.manager.eventBus ~= nil then
@@ -1210,7 +1218,7 @@ function IrrigationManager:updateRainKeySensor(dt)
                     system.rainKeyTripped = true
                     system.rainKeyStateRevision = (system.rainKeyStateRevision or 0) + 1
                     if system.isActive then
-                        self:deactivateSystem(id)
+                        self:deactivateSystem(id, "RAIN_KEY_TRIPPED")
                     end
                     changes[id] = { publish = true, reason = "RAIN_KEY_TRIPPED" }
                 end
@@ -1349,7 +1357,7 @@ function IrrigationManager:applyRainKeyCommand(systemId, action, value, expected
            and (system.rainKeyAccumulatedMm or 0) >= v then
             system.rainKeyTripped = true
             system.rainKeyStateRevision = (system.rainKeyStateRevision or 0) + 1
-            if system.isActive then self:deactivateSystem(id) end
+            if system.isActive then self:deactivateSystem(id, "TRIP_DIAL_CROSS") end
             system._lastRainKeyPausePublished = true
         end
         system.rainKeyTripMm = v

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1291,13 +1291,27 @@ function IrrigationManager:getRainKeySnapshot(system)
 end
 
 --- Fit or remove a rain key, set the dial, all through the one server command path.
+--- SCS-046 B (F200): FIT and SET require the rain_key_pause release row live; a
+--- stale expected revision is rejected before any mutation; REMOVE settles the
+--- already-run interval first.
 ---@param systemId number
 ---@param action string  FIT | REMOVE | SET_TRIP_MM
 ---@param value number|nil
+---@param expectedRevision number|nil  rain-key state revision the requester saw
 ---@return boolean ok, string|nil error
-function IrrigationManager:applyRainKeyCommand(systemId, action, value)
+function IrrigationManager:applyRainKeyCommand(systemId, action, value, expectedRevision)
     local system = self.systems[systemId]
     if system == nil then return false, "UNKNOWN_SYSTEM" end
+    expectedRevision = expectedRevision or -1
+    if expectedRevision ~= -1 and (system.rainKeyStateRevision or 0) ~= expectedRevision then
+        return false, "STALE_CONFIRMATION"
+    end
+    if action == "FIT" or action == "SET_TRIP_MM" then
+        if ReleaseGate ~= nil and type(ReleaseGate.isSystemLive) == "function"
+           and ReleaseGate.isSystemLive("rain_key_pause") ~= true then
+            return false, "RELEASE_LOCKED"
+        end
+    end
     if action == "FIT" then
         if system.type ~= "pivot" then return false, "NOT_A_PIVOT" end
         system.rainKeyFitted = true
@@ -1310,6 +1324,10 @@ function IrrigationManager:applyRainKeyCommand(systemId, action, value)
         system._lastRainKeyPausePublished = false
         return true, nil
     elseif action == "REMOVE" then
+        -- F200: REMOVE settles the already-run continuous interval first.
+        if system.rainKeyFitted == true then
+            self:settleFittedSystem(system, "REMOVE")
+        end
         system.rainKeyFitted = false
         system.rainKeyTripMm = 2.5
         system.rainKeyAccumulatedMm = 0

--- a/src/SaveLoadHandler.lua
+++ b/src/SaveLoadHandler.lua
@@ -215,6 +215,17 @@ function SaveLoadHandler:saveToXMLFile(xmlFile)
                 table.insert(dayStrs, v and "1" or "0")
             end
             setString(key .. "#activeDays", table.concat(dayStrs, ","))
+            -- SCS-046: persist a fitted pivot's rain-key latch and dial so a
+            -- reload restores the fitted state before any activity resumes.
+            if system.rainKeyFitted == true then
+                setBool(  key .. "#rkFitted",  true)
+                setFloat( key .. "#rkTripMm",  system.rainKeyTripMm or 2.5)
+                setFloat( key .. "#rkAccMm",   system.rainKeyAccumulatedMm or 0)
+                setFloat( key .. "#rkDryMin",  system.rainKeyDryElapsedMinutes or 0)
+                setBool(  key .. "#rkTripped", system.rainKeyTripped or false)
+                setInt(   key .. "#rkRev",     system.rainKeyStateRevision or 0)
+                setString(key .. "#rkInput",   system.rainKeyInputState or "UNAVAILABLE")
+            end
             i = i + 1
         end
     end
@@ -393,6 +404,18 @@ function SaveLoadHandler:loadFromXMLFile(xmlFile)
                 if wasActive and not system.isActive then
                     irrMgr:activateSystem(sysId)
                 end
+                -- SCS-046: restore a fitted pivot's rain-key latch and dial
+                -- before any activity resumes.
+                if getBool(key .. "#rkFitted", false) then
+                    system.rainKeyFitted = true
+                    system.rainKeyTripMm = getFloat(key .. "#rkTripMm", system.rainKeyTripMm or 2.5)
+                    system.rainKeyAccumulatedMm = getFloat(key .. "#rkAccMm", 0)
+                    system.rainKeyDryElapsedMinutes = getFloat(key .. "#rkDryMin", 0)
+                    system.rainKeyTripped = getBool(key .. "#rkTripped", false)
+                    system.rainKeyStateRevision = getInt(key .. "#rkRev", 0)
+                    system.rainKeyInputState = getString(key .. "#rkInput", "UNAVAILABLE")
+                    system._lastRainKeyPausePublished = nil
+                end
                 restored = restored + 1
             end
             i = i + 1
@@ -472,13 +495,24 @@ function SaveLoadHandler:buildStateTable()
         for sysId, system in pairs(irrMgr.systems) do
             local days = {}
             for _, v in ipairs(system.schedule.activeDays) do days[#days + 1] = v and 1 or 0 end
-            out.irrigation[sysId] = {
+            local entry = {
                 startHour  = system.schedule.startHour,
                 endHour    = system.schedule.endHour,
                 isActive   = system.isActive or false,
                 manualMode = system.manualMode == true,
                 activeDays = days,
             }
+            -- SCS-046: carry a fitted pivot's rain-key latch and dial.
+            if system.rainKeyFitted == true then
+                entry.rkFitted  = true
+                entry.rkTripMm  = system.rainKeyTripMm or 2.5
+                entry.rkAccMm   = system.rainKeyAccumulatedMm or 0
+                entry.rkDryMin  = system.rainKeyDryElapsedMinutes or 0
+                entry.rkTripped = system.rainKeyTripped or false
+                entry.rkRev     = system.rainKeyStateRevision or 0
+                entry.rkInput   = system.rainKeyInputState or "UNAVAILABLE"
+            end
+            out.irrigation[sysId] = entry
         end
     end
 
@@ -565,6 +599,17 @@ function SaveLoadHandler:applyStateTable(data)
                 system.manualMode = s.manualMode == true
                 if s.isActive and not system.isActive then
                     irrMgr:activateSystem(sysId)
+                end
+                -- SCS-046: restore a fitted pivot's rain-key latch and dial.
+                if s.rkFitted == true then
+                    system.rainKeyFitted = true
+                    system.rainKeyTripMm = s.rkTripMm or system.rainKeyTripMm or 2.5
+                    system.rainKeyAccumulatedMm = s.rkAccMm or 0
+                    system.rainKeyDryElapsedMinutes = s.rkDryMin or 0
+                    system.rainKeyTripped = s.rkTripped or false
+                    system.rainKeyStateRevision = s.rkRev or 0
+                    system.rainKeyInputState = s.rkInput or "UNAVAILABLE"
+                    system._lastRainKeyPausePublished = nil
                 end
             end
         end

--- a/src/events/CropStressRainKeyCommandEvent.lua
+++ b/src/events/CropStressRainKeyCommandEvent.lua
@@ -5,6 +5,8 @@
 -- The server validates ownership, applies the command through the one
 -- applyRainKeyCommand path, and returns a stable result. Clients never
 -- mutate a rain key locally; they send the request and await the result.
+-- Request stream: Int32 systemId, String action, Bool hasValue,
+-- Float32 value when hasValue, Int32 expectedRevision.
 -- ============================================================
 
 CropStressRainKeyCommandEvent = CropStressRainKeyCommandEvent or {}
@@ -16,11 +18,13 @@ function CropStressRainKeyCommandEvent.emptyNew()
     return Event.new(CropStressRainKeyCommandEvent_mt)
 end
 
-function CropStressRainKeyCommandEvent.new(systemId, action, value)
+---@param expectedRevision number  rain-key state revision the requester saw
+function CropStressRainKeyCommandEvent.new(systemId, action, value, expectedRevision)
     local self = CropStressRainKeyCommandEvent.emptyNew()
     self.systemId = systemId or 0
     self.action   = action or ""
     self.value    = value
+    self.expectedRevision = expectedRevision or -1
     return self
 end
 
@@ -30,6 +34,7 @@ function CropStressRainKeyCommandEvent:writeStream(streamId, connection)
     local hasValue = self.value ~= nil
     streamWriteBool(streamId, hasValue)
     if hasValue then streamWriteFloat32(streamId, self.value) end
+    streamWriteInt32(streamId, self.expectedRevision or -1)
 end
 
 function CropStressRainKeyCommandEvent:readStream(streamId, connection)
@@ -37,6 +42,7 @@ function CropStressRainKeyCommandEvent:readStream(streamId, connection)
     self.action   = streamReadString(streamId)
     local hasValue = streamReadBool(streamId)
     self.value = hasValue and streamReadFloat32(streamId) or nil
+    self.expectedRevision = streamReadInt32(streamId)
 end
 
 -- Server applies the command (server-only; clients never mutate locally).
@@ -48,44 +54,37 @@ function CropStressRainKeyCommandEvent:run(connection)
     local irr = g_cropStressManager.irrigationManager
     local system = irr.systems[self.systemId]
 
-    -- Ownership: server derives requester farm from the connection and compares it
-    -- with the registered owner farm.
-    local requesterFarmId = nil
-    if connection ~= nil then
-        local user = connection.user
-        if user ~= nil and user.farmId ~= nil then requesterFarmId = user.farmId end
-    end
-    if requesterFarmId == nil and g_currentMission ~= nil and g_localPlayer ~= nil then
-        requesterFarmId = g_localPlayer:getFarmId()
-    end
-    local ownerFarmId = system ~= nil and system.ownerFarmId or nil
+    -- Ownership: the shared engine farm resolver only (F200). Listen-host nil
+    -- connection takes the engine host branch; no connection.user, local-player
+    -- or farm-1 fallback exists.
+    local requesterFarmId = irr.resolveRequesterFarmId ~= nil
+        and irr:resolveRequesterFarmId(connection) or nil
     if system == nil then
-        if g_client ~= nil then
-            g_client:getServerConnection():sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "UNKNOWN_SYSTEM"))
+        if connection ~= nil then
+            connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "UNKNOWN_SYSTEM"))
         end
         return
     end
-    if ownerFarmId == nil or ownerFarmId <= 0 or requesterFarmId ~= ownerFarmId then
+    if requesterFarmId == nil or requesterFarmId <= 0
+       or system.ownerFarmId == nil or system.ownerFarmId <= 0
+       or requesterFarmId ~= system.ownerFarmId then
         if connection ~= nil then
             connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "NOT_AUTHORIZED"))
-        elseif g_client ~= nil and g_client:getServerConnection() ~= nil then
-            g_client:getServerConnection():sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "NOT_AUTHORIZED"))
         end
         return
     end
 
-    local ok, reason = irr:applyRainKeyCommand(self.systemId, self.action, self.value)
+    local ok, reason = irr:applyRainKeyCommand(self.systemId, self.action, self.value, self.expectedRevision)
     local code = reason or (ok and "OK" or "FAILED")
     if connection ~= nil then
         connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, ok, code))
-    elseif g_client ~= nil and g_client:getServerConnection() ~= nil then
-        g_client:getServerConnection():sendEvent(CropStressRainKeyResultEvent.new(self.systemId, ok, code))
     end
 end
 
 -- Client helper: send the command to the server.
-function CropStressRainKeyCommandEvent.sendToServer(systemId, action, value)
+function CropStressRainKeyCommandEvent.sendToServer(systemId, action, value, expectedRevision)
     if g_client == nil or g_client:getServerConnection() == nil then return false end
-    g_client:getServerConnection():sendEvent(CropStressRainKeyCommandEvent.new(systemId, action, value))
+    g_client:getServerConnection():sendEvent(
+        CropStressRainKeyCommandEvent.new(systemId, action, value, expectedRevision or -1))
     return true
 end

--- a/src/events/CropStressRainKeyCommandEvent.lua
+++ b/src/events/CropStressRainKeyCommandEvent.lua
@@ -61,7 +61,7 @@ function CropStressRainKeyCommandEvent:run(connection)
         and irr:resolveRequesterFarmId(connection) or nil
     if system == nil then
         if connection ~= nil then
-            connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "UNKNOWN_SYSTEM"))
+            connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "UNKNOWN_SYSTEM", self.action, 0))
         end
         return
     end
@@ -69,7 +69,8 @@ function CropStressRainKeyCommandEvent:run(connection)
        or system.ownerFarmId == nil or system.ownerFarmId <= 0
        or requesterFarmId ~= system.ownerFarmId then
         if connection ~= nil then
-            connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "NOT_AUTHORIZED"))
+            connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, false, "NOT_AUTHORIZED", self.action,
+                system.rainKeyStateRevision or 0))
         end
         return
     end
@@ -77,7 +78,8 @@ function CropStressRainKeyCommandEvent:run(connection)
     local ok, reason = irr:applyRainKeyCommand(self.systemId, self.action, self.value, self.expectedRevision)
     local code = reason or (ok and "OK" or "FAILED")
     if connection ~= nil then
-        connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, ok, code))
+        connection:sendEvent(CropStressRainKeyResultEvent.new(self.systemId, ok, code, self.action,
+            (irr.systems[self.systemId] and irr.systems[self.systemId].rainKeyStateRevision) or 0))
     end
 end
 

--- a/src/events/CropStressRainKeyResultEvent.lua
+++ b/src/events/CropStressRainKeyResultEvent.lua
@@ -2,7 +2,9 @@
 -- CropStressRainKeyResultEvent.lua
 -- SCS-046 server result for a rain-key command. Stable codes:
 --   OK, RAIN_KEY_TRIPPED, NOT_AUTHORIZED, STALE_CONFIRMATION,
---   INVALID_TRIP_MM, UNKNOWN_SYSTEM, UNKNOWN_ACTION, FAILED
+--   INVALID_TRIP_MM, UNKNOWN_SYSTEM, UNKNOWN_ACTION, RELEASE_LOCKED, FAILED
+-- F200 result stream: Int32 systemId, String action, Bool accepted,
+-- String resultCode, Int32 stateRevision.
 -- ============================================================
 
 CropStressRainKeyResultEvent = CropStressRainKeyResultEvent or {}
@@ -14,31 +16,38 @@ function CropStressRainKeyResultEvent.emptyNew()
     return Event.new(CropStressRainKeyResultEvent_mt)
 end
 
-function CropStressRainKeyResultEvent.new(systemId, accepted, resultCode)
+function CropStressRainKeyResultEvent.new(systemId, accepted, resultCode, action, stateRevision)
     local self = CropStressRainKeyResultEvent.emptyNew()
     self.systemId   = systemId or 0
+    self.action     = action or ""
     self.accepted   = accepted == true
     self.resultCode = resultCode or "OK"
+    self.stateRevision = stateRevision or 0
     return self
 end
 
 function CropStressRainKeyResultEvent:writeStream(streamId, connection)
     streamWriteInt32(streamId, self.systemId or 0)
+    streamWriteString(streamId, self.action or "")
     streamWriteBool(streamId, self.accepted == true)
     streamWriteString(streamId, self.resultCode or "OK")
+    streamWriteInt32(streamId, self.stateRevision or 0)
 end
 
 function CropStressRainKeyResultEvent:readStream(streamId, connection)
     self.systemId   = streamReadInt32(streamId)
+    self.action     = streamReadString(streamId)
     self.accepted   = streamReadBool(streamId)
     self.resultCode = streamReadString(streamId)
+    self.stateRevision = streamReadInt32(streamId)
 end
 
 function CropStressRainKeyResultEvent:run(connection)
     -- Result delivery: nothing to apply client-side beyond logging for now.
     if g_logManager ~= nil then
         g_logManager:devInfo("[CropStress]",
-            string.format("rain-key result system=%d accepted=%s code=%s",
-                self.systemId or 0, tostring(self.accepted), self.resultCode or "?"))
+            string.format("rain-key result system=%d action=%s accepted=%s code=%s rev=%d",
+                self.systemId or 0, tostring(self.action), tostring(self.accepted),
+                self.resultCode or "?", self.stateRevision or 0))
     end
 end

--- a/src/integrations/CropStressNetworkSyncBridge.lua
+++ b/src/integrations/CropStressNetworkSyncBridge.lua
@@ -58,6 +58,14 @@ end
 -- Pure serialize / deserialize (server writes, client reads)
 -- =========================================================
 
+-- SCS-046 A (F200): the public irrigation animation row appended after the
+-- moisture prefix, behind a sentinel so an older payload without it reads
+-- neutral-absent. Codes are numeric and public only (no owner or source).
+CropStressNetworkSyncBridge.IRR_MARKER = "__SCS_IRR__"
+CropStressNetworkSyncBridge.IRR_ACTIVITY = { OFF = 0, RUNNING = 1, RAIN_PAUSED = 2 }
+CropStressNetworkSyncBridge.IRR_PAUSE    = { NONE = 0, RAIN_KEY_TRIPPED = 1, INPUT_UNAVAILABLE = 2 }
+CropStressNetworkSyncBridge.IRR_NEXT     = { NONE = 0, DRY_RESET = 1, PLAYER_ACTION = 2 }
+
 -- Flatten moisture/stress into one primitive array (the shape NetworkSync expects).
 -- arr[1] = field count, then per field: fieldId, moisture, stress.
 function CropStressNetworkSyncBridge.serializeFields(fieldData, fieldStress)
@@ -74,11 +82,13 @@ function CropStressNetworkSyncBridge.serializeFields(fieldData, fieldStress)
 end
 
 -- Rebuild moisture + stress maps from the flat array. Pure: no live apply. Never
--- crashes on a short or malformed array.
+-- crashes on a short or malformed array. Returns a third value, the parsed public
+-- irrigation rows (nil when the payload carries none).
 function CropStressNetworkSyncBridge.deserializeFields(arr)
     local fieldData   = {}
     local fieldStress = {}
-    if type(arr) ~= "table" then return fieldData, fieldStress end
+    local irrigation  = nil
+    if type(arr) ~= "table" then return fieldData, fieldStress, irrigation end
 
     local i = 1
     local count = tonumber(arr[i]) or 0
@@ -92,22 +102,83 @@ function CropStressNetworkSyncBridge.deserializeFields(arr)
         fieldData[fieldId]   = { moisture = moisture }
         fieldStress[fieldId] = stress
     end
-    return fieldData, fieldStress
+
+    -- Optional public irrigation block behind the sentinel.
+    if arr[i] == CropStressNetworkSyncBridge.IRR_MARKER then
+        i = i + 1
+        local n = tonumber(arr[i]) or 0
+        i = i + 1
+        irrigation = {}
+        for _ = 1, n do
+            local systemId = arr[i]; i = i + 1
+            if systemId == nil then break end
+            local isActive = (arr[i] or 0) == 1; i = i + 1
+            local tripped  = (arr[i] or 0) == 1; i = i + 1
+            local activity = tonumber(arr[i]) or 0; i = i + 1
+            local pause    = tonumber(arr[i]) or 0; i = i + 1
+            local nextWake = tonumber(arr[i]) or 0; i = i + 1
+            local revision = tonumber(arr[i]) or 0; i = i + 1
+            irrigation[#irrigation + 1] = {
+                systemId = systemId, isActive = isActive, tripped = tripped,
+                activityStateCode = activity, pauseReasonCode = pause,
+                nextWakeKindCode = nextWake, stateRevision = revision,
+            }
+        end
+    end
+    return fieldData, fieldStress, irrigation
+end
+
+-- Append the seven-field public irrigation rows to the moisture payload.
+function CropStressNetworkSyncBridge.serializeIrrigation(mgr)
+    local irr = mgr ~= nil and mgr.irrigationManager or nil
+    if irr == nil or irr.systems == nil then return {} end
+    local rows = {}
+    for id, sys in pairs(irr.systems) do
+        local fitted = sys.rainKeyFitted == true
+        local tripped = sys.rainKeyTripped == true
+        local inputOk = sys.rainKeyInputState == "OK"
+        local activity
+        if fitted and tripped then activity = CropStressNetworkSyncBridge.IRR_ACTIVITY.RAIN_PAUSED
+        elseif sys.isActive == true then activity = CropStressNetworkSyncBridge.IRR_ACTIVITY.RUNNING
+        else activity = CropStressNetworkSyncBridge.IRR_ACTIVITY.OFF end
+        local pause
+        if fitted and tripped then pause = CropStressNetworkSyncBridge.IRR_PAUSE.RAIN_KEY_TRIPPED
+        elseif fitted and not inputOk then pause = CropStressNetworkSyncBridge.IRR_PAUSE.INPUT_UNAVAILABLE
+        else pause = CropStressNetworkSyncBridge.IRR_PAUSE.NONE end
+        local nextWake
+        if fitted and tripped then nextWake = CropStressNetworkSyncBridge.IRR_NEXT.DRY_RESET
+        elseif fitted and not inputOk then nextWake = CropStressNetworkSyncBridge.IRR_NEXT.PLAYER_ACTION
+        else nextWake = CropStressNetworkSyncBridge.IRR_NEXT.NONE end
+        rows[#rows + 1] = {
+            id, sys.isActive == true and 1 or 0, tripped and 1 or 0,
+            activity, pause, nextWake, sys.rainKeyStateRevision or 0,
+        }
+    end
+    table.sort(rows, function(a, b) return a[1] < b[1] end)
+    local out = { CropStressNetworkSyncBridge.IRR_MARKER, #rows }
+    for r = 1, #rows do
+        for c = 1, #rows[r] do out[#out + 1] = rows[r][c] end
+    end
+    return out
 end
 
 -- =========================================================
 -- NetworkSync callbacks (plain functions - called with no self)
 -- =========================================================
 
--- Server: hand NetworkSync the whole moisture/stress map for the next batch.
+-- Server: hand NetworkSync the whole moisture/stress map for the next batch,
+-- followed by the public seven-field irrigation animation rows (SCS-046 A).
 function CropStressNetworkSyncBridge._onWriteState()
     local mgr = getManager()
     local soilSystem     = mgr and mgr.soilSystem
     local stressModifier = mgr and mgr.stressModifier
-    return CropStressNetworkSyncBridge.serializeFields(
+    local arr = CropStressNetworkSyncBridge.serializeFields(
         soilSystem and soilSystem.fieldData or {},
         stressModifier and stressModifier.fieldStress or {}
     )
+    local irrBlock = CropStressNetworkSyncBridge.serializeIrrigation(mgr)
+    for i = 1, #irrBlock do arr[#arr + 1] = irrBlock[i] end
+    return arr
 end
 
 -- Client: apply a received whole moisture/stress map. Mirrors
@@ -122,11 +193,22 @@ function CropStressNetworkSyncBridge._onReadState(arr)
 
     local mgr = getManager()
     if mgr == nil or mgr.soilSystem == nil or mgr.stressModifier == nil then return end
-    if mgr.soilSystem.isMoistureMapCurrent ~= nil and mgr.soilSystem:isMoistureMapCurrent() then
-        return   -- a current SCS fine map owns the ground; the mirror stands down
+
+    -- SCS-046 A: the public irrigation animation rows update on a pure client
+    -- regardless of the moisture fine-map barrier (they are not ground truth).
+    local fieldData, fieldStress, irrigation =
+        CropStressNetworkSyncBridge.deserializeFields(arr)
+    if mgr.irrigationManager ~= nil then
+        mgr.irrigationManager._publicAnimationStates = irrigation or {}
     end
 
-    local fieldData, fieldStress = CropStressNetworkSyncBridge.deserializeFields(arr)
+    -- SCS-039 v2.1 (SDS 3.8): the NetworkSync aggregate may update legacy scalars
+    -- only while the SCS fine map is NOT the current authority. Once the SCS event
+    -- barrier has published a current fine map (isMoistureMapCurrent), the mirror
+    -- must not fight it; it can never seed fine staging or claim fine currentness.
+    if mgr.soilSystem.isMoistureMapCurrent ~= nil and mgr.soilSystem:isMoistureMapCurrent() then
+        return   -- a current SCS fine map owns the ground; the moisture mirror stands down
+    end
 
     for fieldId, entry in pairs(fieldData) do
         local existing = mgr.soilSystem.fieldData[fieldId]

--- a/tools/test/lua/scs046_command_revision_test.lua
+++ b/tools/test/lua/scs046_command_revision_test.lua
@@ -4,7 +4,7 @@
 -- SET require the rain_key_pause release row live; REMOVE settles the
 -- already-run interval first. Ownership in the event resolves only through the
 -- shared engine farm resolver.
---!load: src/IrrigationManager.lua, src/events/CropStressRainKeyCommandEvent.lua
+--!load: src/IrrigationManager.lua, src/events/CropStressRainKeyCommandEvent.lua, src/events/CropStressRainKeyResultEvent.lua
 
 local function fittedManager()
   local mgr = IrrigationManager.new({ settings = { enabled = true } })
@@ -86,6 +86,21 @@ do
   T.near('wire.value', got.value, 5.0, 1e-9)
   T.eq('wire.expectedRevision', got.expectedRevision, 4)
   T.eq('wire.streamClean', s.typeErrors + s.underflows, 0)
+end
+
+-- 5. RESULT EVENT WIRE CARRIES ACTION + STATE REVISION (F200 shape).
+do
+  local s = _sfMockStream()
+  local res = CropStressRainKeyResultEvent.new(1, true, "OK", "FIT", 4)
+  res:writeStream(s)
+  local got = CropStressRainKeyResultEvent.emptyNew()
+  got:readStream(s)
+  T.eq('res.systemId', got.systemId, 1)
+  T.eq('res.action', got.action, "FIT")
+  T.eq('res.accepted', got.accepted, true)
+  T.eq('res.resultCode', got.resultCode, "OK")
+  T.eq('res.stateRevision', got.stateRevision, 4)
+  T.eq('res.streamClean', s.typeErrors + s.underflows, 0)
 end
 
 T.summary()

--- a/tools/test/lua/scs046_command_revision_test.lua
+++ b/tools/test/lua/scs046_command_revision_test.lua
@@ -1,0 +1,91 @@
+-- scs046_command_revision_test.lua
+-- SCS-046 B (F200): rain-key command idempotence. The request stream carries an
+-- expectedRevision; a stale revision is rejected before any mutation; FIT and
+-- SET require the rain_key_pause release row live; REMOVE settles the
+-- already-run interval first. Ownership in the event resolves only through the
+-- shared engine farm resolver.
+--!load: src/IrrigationManager.lua, src/events/CropStressRainKeyCommandEvent.lua
+
+local function fittedManager()
+  local mgr = IrrigationManager.new({ settings = { enabled = true } })
+  local water = { calls = 0 }
+  mgr.manager = { settings = { enabled = true } }
+  mgr.systems = {
+    [1] = { id = 1, type = "pivot", ownerFarmId = 2, isActive = true,
+            coveredFields = { 5 }, flowRatePerHour = 0.018, pressureMultiplier = 1.0,
+            activeGameHoursSinceSettle = 2 },
+  }
+  return mgr
+end
+
+-- 1. FIT APPLIES AND ADVANCES; A STALE EXPECTED REVISION IS REJECTED.
+do
+  local mgr = fittedManager()
+  local ok, err = mgr:applyRainKeyCommand(1, "FIT", nil, 0)
+  T.eq('fit.accepted', ok, true)
+  T.eq('fit.fitted', mgr.systems[1].rainKeyFitted, true)
+  T.eq('fit.revisionAdvanced', mgr.systems[1].rainKeyStateRevision, 1)
+
+  mgr.systems[1].rainKeyStateRevision = 3
+  local stale, staleErr = mgr:applyRainKeyCommand(1, "FIT", nil, 1)
+  T.eq('stale.rejected', stale, false)
+  T.eq('stale.code', staleErr, "STALE_CONFIRMATION")
+end
+
+-- 2. FIT / SET REQUIRE THE RELEASE ROW LIVE.
+do
+  ReleaseGate = { isSystemLive = function() return false end }
+  local mgr = fittedManager()
+  local ok, err = mgr:applyRainKeyCommand(1, "FIT", nil, 0)
+  T.eq('release.fitsLocked', ok, false)
+  T.eq('release.code', err, "RELEASE_LOCKED")
+  T.eq('release.noMutation', mgr.systems[1].rainKeyFitted, nil)
+  ReleaseGate = nil
+end
+
+-- 3. REMOVE SETTLES THE ALREADY-RUN INTERVAL FIRST.
+do
+  local mgr = fittedManager()
+  mgr:applyRainKeyCommand(1, "FIT", nil, 0)
+  mgr.systems[1].isActive = true
+  mgr.systems[1].activeGameHoursSinceSettle = 2
+  local water = { calls = 0, gain = 0 }
+  mgr.manager.soilSystem = {
+    fieldData = { [5] = { centerX = 0, centerZ = 0 } },
+    applyWaterAtCell = function(_s, _fid, _x, _z, gain)
+      water.calls = water.calls + 1
+      water.gain = water.gain + gain
+      return true
+    end,
+  }
+  local charged = { amount = 0, farmId = 0 }
+  mgr.manager.financeIntegration = {
+    deductFundsVanilla = function(_fi, amount, farmId) charged.amount = amount; charged.farmId = farmId end,
+  }
+  mgr.getEffectiveCostPerHour = function(_self, _s) return 15 end
+  local revBefore = mgr.systems[1].rainKeyStateRevision
+  local ok, err = mgr:applyRainKeyCommand(1, "REMOVE", nil, revBefore)
+  T.eq('remove.ok', ok, true)
+  T.eq('remove.settledWater', water.calls, 1)
+  T.near('remove.settledGain', water.gain, 0.036, 1e-6)   -- 0.018 * 1.0 * 2h
+  T.near('remove.settledCost', charged.amount, 30, 1e-6)  -- 15 * 2h
+  T.eq('remove.farm', charged.farmId, 2)
+  T.eq('remove.clearedHours', mgr.systems[1].activeGameHoursSinceSettle, 0)
+  T.eq('remove.unfitted', mgr.systems[1].rainKeyFitted, false)
+end
+
+-- 4. COMMAND EVENT WIRE CARRIES THE EXPECTED REVISION.
+do
+  local s = _sfMockStream()
+  local cmd = CropStressRainKeyCommandEvent.new(1, "SET_TRIP_MM", 5.0, 4)
+  cmd:writeStream(s)
+  local got = CropStressRainKeyCommandEvent.emptyNew()
+  got:readStream(s)
+  T.eq('wire.systemId', got.systemId, 1)
+  T.eq('wire.action', got.action, "SET_TRIP_MM")
+  T.near('wire.value', got.value, 5.0, 1e-9)
+  T.eq('wire.expectedRevision', got.expectedRevision, 4)
+  T.eq('wire.streamClean', s.typeErrors + s.underflows, 0)
+end
+
+T.summary()

--- a/tools/test/lua/scs046_f200_settlement_test.lua
+++ b/tools/test/lua/scs046_f200_settlement_test.lua
@@ -1,0 +1,68 @@
+-- scs046_f200_settlement_test.lua
+-- SCS-046 F200: fitted-pivot settlement. A fitted pivot settles its continuous
+-- active hours through the one interval path whenever it deactivates (reason
+-- travels) or at each admitted hour; deactivateSystem settles first so a trip
+-- or Stop never strands water and cost, and the legacy whole-hour path never
+-- runs for a fitted row.
+--!load: src/IrrigationManager.lua
+
+local function riggedManager()
+  local mgr = IrrigationManager.new({ settings = { enabled = true } })
+  mgr.manager = { settings = { enabled = true } }
+  mgr.systems = {
+    [1] = { id = 1, type = "pivot", ownerFarmId = 2, isActive = true,
+            coveredFields = { 5 }, flowRatePerHour = 0.018, pressureMultiplier = 1.0,
+            activeGameHoursSinceSettle = 2, rainKeyFitted = true },
+  }
+  local water = { calls = 0, gain = 0 }
+  mgr.manager.soilSystem = {
+    fieldData = { [5] = { centerX = 0, centerZ = 0 } },
+    applyWaterAtCell = function(_s, _fid, _x, _z, gain)
+      water.calls = water.calls + 1
+      water.gain = water.gain + gain
+      return true
+    end,
+  }
+  local charged = { amount = 0, farmId = 0 }
+  mgr.manager.financeIntegration = {
+    deductFundsVanilla = function(_fi, amount, farmId) charged.amount = amount; charged.farmId = farmId end,
+  }
+  mgr.getEffectiveCostPerHour = function(_self, _s) return 15 end
+  mgr._water = water
+  mgr._charged = charged
+  return mgr
+end
+
+-- 1. DEACTIVATE A FITTED ACTIVE SYSTEM SETTLES ITS RUN HOURS FIRST.
+do
+  local mgr = riggedManager()
+  mgr:deactivateSystem(1, "RAIN_KEY_TRIPPED")
+  T.eq('deact.settledWater', mgr._water.calls, 1)
+  T.near('deact.settledGain', mgr._water.gain, 0.036, 1e-6)
+  T.near('deact.settledCost', mgr._charged.amount, 30, 1e-6)
+  T.eq('deact.chargedFarm', mgr._charged.farmId, 2)
+  T.eq('deact.hoursCleared', mgr.systems[1].activeGameHoursSinceSettle, 0)
+  T.eq('deact.inactive', mgr.systems[1].isActive, false)
+end
+
+-- 2. A NON-FITTED SYSTEM NEVER SETTLES THROUGH THE FITTED PATH.
+do
+  local mgr = riggedManager()
+  mgr.systems[1].rainKeyFitted = false
+  mgr.systems[1].activeGameHoursSinceSettle = 2
+  mgr:deactivateSystem(1, "ANY_REASON")
+  T.eq('unfitted.noSettle', mgr._water.calls, 0)
+  T.eq('unfitted.inactive', mgr.systems[1].isActive, false)
+end
+
+-- 3. THE HOURLY INTERVAL SETTLE APPLIES WATER AND COST AND CLEARS HOURS.
+do
+  local mgr = riggedManager()
+  mgr:settleFittedSystem(mgr.systems[1], "HOURLY")
+  T.eq('hourly.settledWater', mgr._water.calls, 1)
+  T.near('hourly.settledGain', mgr._water.gain, 0.036, 1e-6)
+  T.near('hourly.settledCost', mgr._charged.amount, 30, 1e-6)
+  T.eq('hourly.hoursCleared', mgr.systems[1].activeGameHoursSinceSettle, 0)
+end
+
+T.summary()

--- a/tools/test/lua/scs046_join_push_test.lua
+++ b/tools/test/lua/scs046_join_push_test.lua
@@ -1,0 +1,51 @@
+-- scs046_join_push_test.lua
+-- SCS-046 A / SDS 8: on a pure client join the server pushes that connection's
+-- farm's COMPLETE private snapshot (CropStressIrrigationStateEvent) so the
+-- client _clientFarmCurrent flag becomes current for exactly that farm.
+--!load: src/IrrigationManager.lua, src/events/CropStressIrrigationStateEvent.lua
+
+local function farmManager()
+  g_i18n.hasText = function() return true end
+  local mgr = IrrigationManager.new({})
+  mgr.waterSources = {
+    [1] = { id = 1, farmId = 2, finite = true, capacity = 48, waterRemaining = 40, hasWater = true },
+  }
+  mgr.systems = {
+    [10] = { id = 10, type = "pivot", isActive = false, ownerFarmId = 2, waterSourceId = 1,
+             coveredFields = { 5 }, schedule = {}, flowRatePerHour = 0.018, operationalCostPerHour = 15 },
+  }
+  return mgr
+end
+
+do
+  g_server = {}
+  local mgr = farmManager()
+  g_currentMission.getFarmId = function(_m, connection)
+    return connection ~= nil and connection.farmId or nil
+  end
+  local received = {}
+  local conn = {
+    farmId = 2,
+    sendEvent = function(_c, ev)
+      received[#received + 1] = ev
+    end,
+  }
+  local ok = mgr:sendFarmPrivateState(conn)
+  T.eq('push.sent', ok, true)
+  T.eq('push.oneEvent', #received, 1)
+  T.eq('push.farmId', received[1].farmId, 2)
+  T.eq('push.systemRowCount', #received[1].systemRows, 1)
+  T.eq('push.systemOwner', received[1].systemRows[1].ownerFarmId, 2)
+  T.eq('push.sourceRowCount', #received[1].sourceRows, 1)
+
+  -- An unresolved connection farm pushes nothing.
+  local noFarm = { sendEvent = function() end }
+  g_currentMission.getFarmId = function() return nil end
+  T.eq('push.unresolvedNone', mgr:sendFarmPrivateState(noFarm), false)
+  T.eq('push.unresolvedNoEvent', #received, 1)
+
+  g_currentMission.getFarmId = nil
+  g_server = nil
+end
+
+T.summary()

--- a/tools/test/lua/scs046_ns_public_row_test.lua
+++ b/tools/test/lua/scs046_ns_public_row_test.lua
@@ -1,0 +1,71 @@
+-- scs046_ns_public_row_test.lua
+-- SCS-046 A (F200): the seven-field public irrigation animation row appended to
+-- the NetworkSync moisture payload. systemId, isActive01, tripped01,
+-- activityStateCode, pauseReasonCode, nextWakeKindCode, stateRevision. No owner,
+-- source, schedule, coverage, rate, cost or rain total enters the public row.
+-- An older payload without the block reads as neutral absent.
+--!load: src/SoilMoistureSystem.lua, src/integrations/CropStressNetworkSyncBridge.lua
+
+local function managerWithSystems()
+  local irr = { systems = {
+    [10] = { id = 10, isActive = true, rainKeyFitted = true, rainKeyTripped = false,
+             rainKeyInputState = "OK", rainKeyStateRevision = 3 },
+    [20] = { id = 20, isActive = false, rainKeyFitted = true, rainKeyTripped = true,
+             rainKeyInputState = "OK", rainKeyStateRevision = 7 },
+    [30] = { id = 30, isActive = false },
+  } }
+  return { irrigationManager = irr }
+end
+
+-- 1. SERIALIZE / DESERIALIZE ROUND TRIP keeps all seven public fields.
+do
+  local arr = CropStressNetworkSyncBridge.serializeIrrigation(managerWithSystems())
+  T.eq('ns.marker', arr[1], CropStressNetworkSyncBridge.IRR_MARKER)
+  T.eq('ns.count', arr[2], 3)
+
+  local _fd, _fs, rows = CropStressNetworkSyncBridge.deserializeFields(
+    { 0, CropStressNetworkSyncBridge.IRR_MARKER, 3,
+      10, 1, 0, 1, 0, 0, 3,
+      20, 0, 1, 2, 1, 1, 7,
+      30, 0, 0, 0, 0, 0, 0 })
+  T.eq('ns.rowCount', #rows, 3)
+  T.eq('ns.sortedBySystem', rows[1].systemId, 10)
+  T.eq('ns.runningActive', rows[1].isActive, true)
+  T.eq('ns.runningActivity', rows[1].activityStateCode, 1)
+  T.eq('ns.runningRevision', rows[1].stateRevision, 3)
+  T.eq('ns.trippedRow', rows[2].tripped, true)
+  T.eq('ns.trippedActivity', rows[2].activityStateCode, 2)
+  T.eq('ns.trippedPause', rows[2].pauseReasonCode, 1)
+  T.eq('ns.trippedNextWake', rows[2].nextWakeKindCode, 1)
+  T.eq('ns.offActivity', rows[3].activityStateCode, 0)
+  T.eq('ns.noPrivateOwner', rows[1].ownerFarmId, nil)
+end
+
+-- 2. AN OLD PAYLOAD WITHOUT THE BLOCK READS AS NEUTRAL ABSENT.
+do
+  local _fd, _fs, rows = CropStressNetworkSyncBridge.deserializeFields({ 1, 5, 0.6, 0.1 })
+  T.eq('ns.oldPayloadAbsent', rows, nil)
+end
+
+-- 3. _onReadState STORES PUBLIC ROWS EVEN WHEN THE FINE MAP IS CURRENT.
+do
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[5] = { moisture = 0.5 }
+  soil.providerMode = "TRUTH"
+  soil.valueMap = { available = true }
+  local mgr = managerWithSystems()
+  mgr.soilSystem = soil
+  mgr.stressModifier = { fieldStress = {} }
+  g_currentMission.cropStressManager = mgr
+
+  local arr = CropStressNetworkSyncBridge.serializeFields({ [5] = { moisture = 0.9 } }, { [5] = 0.2 })
+  local block = CropStressNetworkSyncBridge.serializeIrrigation(mgr)
+  for i = 1, #block do arr[#arr + 1] = block[i] end
+  CropStressNetworkSyncBridge._onReadState(arr)
+  T.eq('read.storedRows', #mgr.irrigationManager._publicAnimationStates, 3)
+  T.eq('read.rowRevision', mgr.irrigationManager._publicAnimationStates[1].stateRevision, 3)
+  T.eq('read.moistureStillCurrentGround', soil.fieldData[5].moisture, 0.5)
+  g_currentMission.cropStressManager = nil
+end
+
+T.summary()

--- a/tools/test/lua/scs046_persistence_gate_test.lua
+++ b/tools/test/lua/scs046_persistence_gate_test.lua
@@ -1,0 +1,88 @@
+-- scs046_persistence_gate_test.lua
+-- SCS-046: fitted rain-key latch and dial persist through the StateLedger table
+-- mirror (and the own-XML keys are written/read identically), and the rain-key
+-- sensor freezes when SCS master or the rain_key_pause release row is off.
+--!load: src/SoilMoistureSystem.lua, src/IrrigationManager.lua, src/SaveLoadHandler.lua
+
+local function baseManager()
+  local soil = SoilMoistureSystem.new({})
+  soil.fieldData[1] = { fieldId = 1, moisture = 0.5, soilType = "loamy" }
+  local irr = { systems = {}, activateSystem = function() end }
+  irr.systems[10] = {
+    id = 10, schedule = { startHour = 6, endHour = 10,
+                          activeDays = { true, true, true, true, true, false, false } },
+    isActive = false,
+    rainKeyFitted = true, rainKeyTripMm = 5.0, rainKeyAccumulatedMm = 2.0,
+    rainKeyDryElapsedMinutes = 3, rainKeyTripped = false,
+    rainKeyStateRevision = 4, rainKeyInputState = "OK",
+  }
+  return {
+    soilSystem = soil,
+    stressModifier = { fieldStress = {}, getStress = function() return 0 end },
+    irrigationManager = irr,
+    npcIntegration = nil,
+  }
+end
+
+-- 1. RAIN-KEY LATCH AND DIAL SURVIVE THE LEDGER TABLE ROUND TRIP.
+do
+  local mgr = baseManager()
+  local sh = SaveLoadHandler.new(mgr)
+  sh:initialize()
+  local state = sh:buildStateTable()
+  local entry = state.irrigation[10]
+  T.eq('build.rkFitted', entry.rkFitted, true)
+  T.near('build.rkTripMm', entry.rkTripMm, 5.0, 1e-9)
+  T.near('build.rkAccMm', entry.rkAccMm, 2.0, 1e-9)
+  T.near('build.rkDryMin', entry.rkDryMin, 3, 1e-9)
+  T.eq('build.rkRev', entry.rkRev, 4)
+  T.eq('build.rkInput', entry.rkInput, "OK")
+
+  local mgr2 = baseManager()
+  local target = mgr2.irrigationManager.systems[10]
+  target.rainKeyFitted = nil
+  target.rainKeyTripMm = 2.5
+  target.rainKeyAccumulatedMm = 0
+  local sh2 = SaveLoadHandler.new(mgr2)
+  sh2:initialize()
+  sh2:applyStateTable(state)
+  T.eq('restore.fitted', target.rainKeyFitted, true)
+  T.near('restore.tripMm', target.rainKeyTripMm, 5.0, 1e-9)
+  T.near('restore.accMm', target.rainKeyAccumulatedMm, 2.0, 1e-9)
+  T.near('restore.dryMin', target.rainKeyDryElapsedMinutes, 3, 1e-9)
+  T.eq('restore.revision', target.rainKeyStateRevision, 4)
+  T.eq('restore.input', target.rainKeyInputState, "OK")
+end
+
+-- 2. THE RAIN-KEY SENSOR FREEZES WHEN MASTER OR THE RELEASE ROW IS OFF.
+do
+  local function sensorMgr(enabled, releaseLive)
+    local settings = { enabled = enabled }
+    if releaseLive ~= nil then
+      ReleaseGate = { isSystemLive = function() return releaseLive end }
+    else
+      ReleaseGate = nil
+    end
+    g_server = {}
+    local mgr = IrrigationManager.new({ settings = settings, weatherIntegration = {
+      getCurrentRainKey = function() return false end,
+    } })
+    mgr.systems = {
+      [10] = { id = 10, rainKeyFitted = true, rainKeyTripped = false,
+               rainKeyInputState = "OK", rainKeyAccumulatedMm = 0 },
+    }
+    return mgr
+  end
+
+  local disabled = sensorMgr(false, nil)
+  T.eq('gate.masterDisabledFreezes', #disabled:updateRainKeySensor(16), 0)
+
+  local locked = sensorMgr(true, false)
+  T.eq('gate.releaseLockedFreezes', #locked:updateRainKeySensor(16), 0)
+  T.eq('gate.releaseLockedNoAccum', locked.systems[10].rainKeyAccumulatedMm, 0)
+
+  g_server = nil
+  ReleaseGate = nil
+end
+
+T.summary()


### PR DESCRIPTION
﻿## SCS-046 pivot rain key - activity transport + command revision (A/B) + F200 settlement

SCS-046 build stacked on the SCS-023 branch (base `feat/SCS-023-commit-effective-mode`, which itself stacks on the SCS-039 follow-up; retarget to `development` after the stack merges). Six slices are in; suite green 1323/0 across 44 files at tip `14233a8`.

### Item B - command idempotence (`f36d644`)
`CropStressRainKeyCommandEvent` carries an `Int32 expectedRevision`; `applyRainKeyCommand` rejects a stale revision (`STALE_CONFIRMATION`) before any mutation, gates FIT/SET behind the `rain_key_pause` release row (`RELEASE_LOCKED`), and REMOVE settles the already-run interval first. The requester farm resolves only through the shared engine `resolveRequesterFarmId`.

### F200 fitted settlement (`11e5f81`)
`deactivateSystem` takes a reason and settles a fitted active system first (sensor trip `RAIN_KEY_TRIPPED`, dial-cross `TRIP_DIAL_CROSS`); each admitted fitted hour settles through `settleFittedSystem` (water + cost), and fitted rows never run the legacy whole-hour path.

### Item A - seven-field public NS row (`665ce85`)
The NetworkSync block appends `systemId, isActive01, tripped01, activityStateCode, pauseReasonCode, nextWakeKindCode, stateRevision` after the moisture prefix; no owner/source/schedule/coverage/rate/cost/rain total enters the public row. Old payloads without the block read neutral absent; the rows store on a pure client regardless of the fine-map barrier.

### Persistence + sensor gate (`7f9bf1e`)
Fitted rain-key latch and dial persist on both the own-XML and StateLedger mirrors; the rain-key sensor freezes when SCS master or the `rain_key_pause` release row is off.

### Verification
Full offline suite **1323 passed / 0 failed across 44 files** at `14233a8`. Lua 5.1 syntax gate clean. New live tests: `scs046_command_revision_test.lua`, `scs046_f200_settlement_test.lua`, `scs046_ns_public_row_test.lua`, `scs046_persistence_gate_test.lua`, `scs046_join_push_test.lua`. Existing `SCS-046-pivot-rain-key_spec_test.lua` stays green (47/0).

### Join push (`9089f8e`)
On a pure client join, the server pushes that connection's farm's COMPLETE private snapshot (`sendFarmPrivateState` from `sendInitialClientState`), making the client `_clientFarmCurrent` flag current together for exactly that farm; an unresolved farm pushes nothing.


### F200 result stream (`14233a8`)
`CropStressRainKeyResultEvent` matches the F200 result stream (systemId, action, accepted, resultCode, stateRevision); the command event replies with the action and the post-command state revision. Existing three-argument construction still works.

### Remaining (runtime / Design-gated)
Any in-mod public-row private-leak trim the set-fold bar requires and the authoritative F200/set-fold bar re-point at member completion.

