### PR TITLE
Unbind irrigation pivot from numpad 2, 4, 6, and 8

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.119</version>
+    <version>1.2.5.121</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>
@@ -176,12 +176,16 @@ FUNKTIONER:
         <!-- Reel retract, consumed by the vendored RWSM53AutoReel spec. -->
         <action name="RWSM53_REEL_TOGGLE" category="VEHICLE"/>
         <!-- Reinke A22 pivot controls (vendored from FS25_ReinkeA22). KP defaults
-             ship so the pivot works out of the box; players may rebind in Controls. -->
+             ship so the pivot works out of the box; players may rebind in Controls.
+             Master power, auto rotation and the two angle steps ship unbound: their
+             old KP 2/8/4/6 defaults sit on the numpad arrow cluster (the look keys
+             when NumLock is off) and bare KP 2 / KP 6 are the vanilla hazard-light
+             and rear-work-light keys. Assign them in Controls if you want keys. -->
         <action name="REINKE_DOOR_TOGGLE"           axisType="HALF" ignoreRestrictions="true"/>
-        <action name="REINKE_MASTER_POWER"          axisType="HALF" ignoreRestrictions="true"/>
-        <action name="REINKE_PIVOT_INTERACT"        axisType="HALF" ignoreRestrictions="true"/>
-        <action name="REINKE_PIVOT_ANGLE_PLUS"      axisType="HALF" ignoreRestrictions="true"/>
-        <action name="REINKE_PIVOT_ANGLE_MINUS"     axisType="HALF" ignoreRestrictions="true"/>
+        <action name="REINKE_MASTER_POWER"          axisType="HALF" ignoreRestrictions="false"/>
+        <action name="REINKE_PIVOT_INTERACT"        axisType="HALF" ignoreRestrictions="false"/>
+        <action name="REINKE_PIVOT_ANGLE_PLUS"      axisType="HALF" ignoreRestrictions="false"/>
+        <action name="REINKE_PIVOT_ANGLE_MINUS"     axisType="HALF" ignoreRestrictions="false"/>
         <action name="REINKE_PIVOT_AUTO_MIN_UP"     axisType="HALF" ignoreRestrictions="true"/>
         <action name="REINKE_PIVOT_SWEEP_MIN_DN"    axisType="HALF" ignoreRestrictions="true"/>
         <action name="REINKE_PIVOT_AUTO_MAX_UP"     axisType="HALF" ignoreRestrictions="true"/>
@@ -207,21 +211,24 @@ FUNKTIONER:
         <actionBinding action="CS_EDIT_HUD">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_n" />
         </actionBinding>
-        <!-- Reinke A22 pivot KP bindings (vendored from FS25_ReinkeA22). -->
+        <!-- Reinke A22 pivot KP bindings (vendored from FS25_ReinkeA22). The four
+             empty entries below are deliberate: no default on the numpad arrow
+             cluster (KP 2/8/4/6), which doubles as the look keys and carries the
+             vanilla hazard-light (KP 2) and rear-work-light (KP 6) defaults. -->
         <actionBinding action="REINKE_DOOR_TOGGLE">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_decimal" axisComponent="+" />
         </actionBinding>
         <actionBinding action="REINKE_MASTER_POWER">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_2" axisComponent="+" />
+            <!-- unbound by default: KP 2 is on the numpad arrow cluster -->
         </actionBinding>
         <actionBinding action="REINKE_PIVOT_INTERACT">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_8" axisComponent="+" />
+            <!-- unbound by default: KP 8 is on the numpad arrow cluster -->
         </actionBinding>
         <actionBinding action="REINKE_PIVOT_ANGLE_PLUS">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_6" axisComponent="+" />
+            <!-- unbound by default: KP 6 is on the numpad arrow cluster -->
         </actionBinding>
         <actionBinding action="REINKE_PIVOT_ANGLE_MINUS">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_4" axisComponent="+" />
+            <!-- unbound by default: KP 4 is on the numpad arrow cluster -->
         </actionBinding>
         <actionBinding action="REINKE_PIVOT_AUTO_MIN_UP">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_kp_7" axisComponent="+" />

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -495,7 +495,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -479,7 +479,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -494,7 +494,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -499,7 +499,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -492,7 +492,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -492,7 +492,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -492,7 +492,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -492,7 +492,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -479,7 +479,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -460,7 +460,7 @@
     <text name="reinke_pivot_toggle"      text="Toggle Pivot Rotation"/>
     <text name="input_REINKE_DOOR_TOGGLE"           text="Open / Close Control Panel"/>
     <text name="input_REINKE_MASTER_POWER"          text="Master Power On / Off"/>
-    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation (KP8)"/>
+    <text name="input_REINKE_PIVOT_INTERACT"        text="Toggle Auto Rotation"/>
     <text name="input_REINKE_PIVOT_ANGLE_PLUS"      text="Step Arm +10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_ANGLE_MINUS"     text="Step Arm -10 deg (Manual)"/>
     <text name="input_REINKE_PIVOT_AUTO_MIN_UP"     text="Raise Min Sweep Bound"/>


### PR DESCRIPTION
﻿## Summary

- Irrigation pivot master power, auto rotation, and the two angle steps ship with no default on numpad 2 / 4 / 6 / 8.
- Those keys are the numpad look cluster (NumLock off) and overlap vanilla hazard / rear-work lights. Players can still assign the actions in Controls.
- Help text no longer bakes "KP8" into auto rotation.
- Version 1.2.5.121 on current development. This PC's playtest zip is 1.2.5.120 on an earlier tree; that local zip is not this branch.

## Test plan

- [ ] Fresh profile: numpad 2 / 4 / 6 / 8 do not fire irrigation pivot.
- [ ] Look still works with NumLock off.
- [ ] Remaining Reinke numpad defaults (door, sweep bounds, spray, and so on) still bind.
- [ ] Esc door and Buy/Run unchanged.
