### PR TITLE
Group Crop Stress field lists by GPS outline and match the Soil Esc door

### DIFF
--- a/gui/CropConsultantDialog.lua
+++ b/gui/CropConsultantDialog.lua
@@ -134,6 +134,21 @@ end
 -- Populates fieldListContainer with up to 5 fields sorted by risk.
 -- ============================================================
 
+--- BUILD 19:23 (George CLOSED DESIGN 19:12): the Soil list-row merge module on the mission bridge
+--- (Soil attaches it next to soilFertilityManager; getfenv(0) does not cross mods). nil when Soil is
+--- absent, and then every caller keeps today's per-farmland rows. Only Soil drives the outline walks;
+--- this side only calls buildGroups (may queue a walk on Soil's driver) or readGroups (cached only).
+local function getSoilMerge()
+    if g_currentMission == nil or g_currentMission.soilFertilityManager == nil then
+        return nil
+    end
+    local merge = g_currentMission.RfPdaSoilMerge
+    if type(merge) ~= "table" then
+        return nil
+    end
+    return merge
+end
+
 function CropConsultantDialog:buildFieldList()
     if self.fieldListContainer == nil then return end
 
@@ -163,6 +178,42 @@ function CropConsultantDialog:buildFieldList()
             local moisture = data.moisture or 0.5
             local risk     = stress * 0.6 + (1 - moisture) * 0.4
             table.insert(riskList, { fieldId = fieldId, moisture = moisture, stress = stress, risk = risk })
+        end
+    end
+    -- BUILD 19:23 (George CLOSED DESIGN 19:12): owned ids group into GPS-outline blocks through the
+    -- Soil merge bridge; a block carries the max member risk (worst wins), min moisture, max
+    -- stress and its shortLabel. Soil absent = the per-farmland list above.
+    local merge = getSoilMerge()
+    if merge ~= nil and type(merge.buildGroups) == "function" and #riskList > 1 then
+        local byId, ids = {}, {}
+        for _, e in ipairs(riskList) do
+            byId[e.fieldId] = e
+            ids[#ids + 1] = e.fieldId
+        end
+        local ok, groups = pcall(merge.buildGroups, ids)
+        if ok and type(groups) == "table" then
+            local grouped = {}
+            for _, g in ipairs(groups) do
+                local lead = byId[g.fieldId]
+                local members = g.memberIds or { g.fieldId }
+                if lead ~= nil then
+                    local e = { fieldId = g.fieldId, memberIds = members, moisture = lead.moisture, stress = lead.stress, risk = lead.risk }
+                    for _, mid in ipairs(members) do
+                        local m = byId[mid]
+                        if m ~= nil then
+                            if m.moisture < e.moisture then e.moisture = m.moisture end
+                            if m.stress > e.stress then e.stress = m.stress end
+                            if m.risk > e.risk then e.risk = m.risk end
+                        end
+                    end
+                    if #members > 1 and type(merge.shortLabel) == "function" then
+                        local okL, text = pcall(merge.shortLabel, members)
+                        if okL and type(text) == "string" then e.label = "Field " .. text end
+                    end
+                    grouped[#grouped + 1] = e
+                end
+            end
+            riskList = grouped
         end
     end
     table.sort(riskList, function(a, b) return a.risk > b.risk end)
@@ -210,8 +261,8 @@ function CropConsultantDialog:buildFieldList()
             severityStr = "[OK]"
         end
         local labelStr = string.format(
-            "Field %d · %s  %d%% moisture  Yield %s  %s",
-            entry.fieldId, cropName, math.floor(entry.moisture * 100), yieldImpact, severityStr
+            "%s · %s  %d%% moisture  Yield %s  %s",
+            entry.label or ("Field " .. tostring(entry.fieldId)), cropName, math.floor(entry.moisture * 100), yieldImpact, severityStr
         )
         addRow(labelStr, y)
         y = y - 22

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.135</version>
+    <version>1.2.5.137</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/src/HUDOverlay.lua
+++ b/src/HUDOverlay.lua
@@ -1327,6 +1327,21 @@ function HUDOverlay:resolveCropName(field)
     return "Fallow"
 end
 
+--- BUILD 19:23 (George CLOSED DESIGN 19:12): the Soil list-row merge module on the mission bridge
+--- (Soil attaches it next to soilFertilityManager; getfenv(0) does not cross mods). nil when Soil is
+--- absent, and then every caller keeps today's per-farmland rows. Only Soil drives the outline walks;
+--- this side only calls buildGroups (may queue a walk on Soil's driver) or readGroups (cached only).
+local function getSoilMerge()
+    if g_currentMission == nil or g_currentMission.soilFertilityManager == nil then
+        return nil
+    end
+    local merge = g_currentMission.RfPdaSoilMerge
+    if type(merge) ~= "table" then
+        return nil
+    end
+    return merge
+end
+
 function HUDOverlay:rebuildDisplayRows()
     self.displayRows = {}
     if self.manager == nil or self.manager.soilSystem == nil then return end
@@ -1360,6 +1375,41 @@ function HUDOverlay:rebuildDisplayRows()
     local fieldsToDisplay = #ownedFields > 0 and ownedFields or sortedFields
     if #ownedFields == 0 and #sortedFields > 0 then
         csLog("HUDOverlay: No owned fields found, showing all tracked fields as a fallback.")
+    end
+
+    -- BUILD 19:23 (George CLOSED DESIGN 19:12): owned entries group into GPS-outline blocks
+    -- through the Soil merge bridge, readGroups ONLY: this runs on the HUD refresh, and
+    -- readGroups reads the cached outlines without ever queueing a walk. A block entry keeps
+    -- the lead farmland id, the min moisture and every member id; the per-member math (max
+    -- stress, Mixed crop, any stress window) runs in the loop below. Soil absent = per-farmland.
+    local merge = getSoilMerge()
+    if merge ~= nil and type(merge.readGroups) == "function" and #ownedFields > 1 and fieldsToDisplay == ownedFields then
+        local byId, ids = {}, {}
+        for _, e in ipairs(fieldsToDisplay) do
+            byId[e.fieldId] = e
+            ids[#ids + 1] = e.fieldId
+        end
+        local ok, groups = pcall(merge.readGroups, ids)
+        if ok and type(groups) == "table" then
+            local grouped = {}
+            for _, g in ipairs(groups) do
+                local lead = byId[g.fieldId]
+                local members = g.memberIds or { g.fieldId }
+                if lead ~= nil then
+                    local e = { fieldId = g.fieldId, moisture = lead.moisture, memberIds = members }
+                    for _, mid in ipairs(members) do
+                        local m = byId[mid]
+                        if m ~= nil and m.moisture ~= nil and (e.moisture == nil or m.moisture < e.moisture) then
+                            e.moisture = m.moisture
+                        end
+                    end
+                    grouped[#grouped + 1] = e
+                end
+            end
+            -- driest first, the order getFieldsSortedByMoisture gave the singles
+            table.sort(grouped, function(a, b) return (a.moisture or 0) < (b.moisture or 0) end)
+            fieldsToDisplay = grouped
+        end
     end
 
     -- BUG FIX: allValidFields was never declared — table.insert into nil silently
@@ -1397,6 +1447,33 @@ function HUDOverlay:rebuildDisplayRows()
             if win ~= nil and growthStage ~= nil then
                 for _, s in ipairs(win.stages) do
                     if growthStage == s then inStressWindow = true; break end
+                end
+            end
+        end
+
+        -- BUILD 19:23: the other members of a block fold in here: max stress, Mixed when a
+        -- member grows something else, any member in its stress window. HUD-local math only.
+        if entry.memberIds ~= nil and #entry.memberIds > 1 then
+            for _, mid in ipairs(entry.memberIds) do
+                if mid ~= entry.fieldId then
+                    if self.manager.stressModifier ~= nil then
+                        local ms = self.manager:getStress(mid)
+                        if type(ms) == "number" and ms > stress then stress = ms end
+                    end
+                    local mf = fieldById[mid]
+                    if mf ~= nil then
+                        local mc = self:resolveCropName(mf)
+                        if mc ~= nil and cropName ~= nil and mc ~= cropName then
+                            cropName = "Mixed"
+                        end
+                        local mg = mf.fieldState and mf.fieldState.growthState
+                        local mwin = mc ~= nil and CropStressModifier.CROP_WINDOWS[mc:lower()] or nil
+                        if mwin ~= nil and mg ~= nil then
+                            for _, s in ipairs(mwin.stages) do
+                                if mg == s then inStressWindow = true; break end
+                            end
+                        end
+                    end
                 end
             end
         end

--- a/src/ui/CsPDAScreen.lua
+++ b/src/ui/CsPDAScreen.lua
@@ -72,6 +72,21 @@ end
 
 -- ── Data helpers ──────────────────────────────────────────
 
+--- BUILD 19:23 (George CLOSED DESIGN 19:12): the Soil list-row merge module on the mission bridge
+--- (Soil attaches it next to soilFertilityManager; getfenv(0) does not cross mods). nil when Soil is
+--- absent, and then every caller keeps today's per-farmland rows. Only Soil drives the outline walks;
+--- this side only calls buildGroups (may queue a walk on Soil's driver) or readGroups (cached only).
+local function getSoilMerge()
+    if g_currentMission == nil or g_currentMission.soilFertilityManager == nil then
+        return nil
+    end
+    local merge = g_currentMission.RfPdaSoilMerge
+    if type(merge) ~= "table" then
+        return nil
+    end
+    return merge
+end
+
 local function getMgr()
     return g_cropStressManager
 end
@@ -446,6 +461,50 @@ function CsPDAScreen:_rebuildData()
                 irrigated = irrigated,
                 systemId  = systemId,
             })
+        end
+    end
+
+    -- BUILD 19:23 (George CLOSED DESIGN 19:12): one row per GPS-outline block. Owned rows group
+    -- through the Soil merge bridge (foreign rows come back as singles); a block row keeps the
+    -- lead farmland id, min moisture, max stress, irrigated if any member is, the first system,
+    -- Mixed when the crops differ. Soil absent = the rows above, untouched. Irrigation tab is
+    -- systems, not fields: untouched.
+    local merge = getSoilMerge()
+    if merge ~= nil and type(merge.buildGroups) == "function" and #rows > 1 then
+        local byId, ids = {}, {}
+        for _, r in ipairs(rows) do
+            byId[r.fieldId] = r
+            ids[#ids + 1] = r.fieldId
+        end
+        local ok, groups = pcall(merge.buildGroups, ids)
+        if ok and type(groups) == "table" then
+            local grouped = {}
+            for _, g in ipairs(groups) do
+                local lead = byId[g.fieldId]
+                local members = g.memberIds or { g.fieldId }
+                if lead ~= nil and #members > 1 then
+                    local row = {
+                        fieldId = g.fieldId, memberFieldIds = members,
+                        cropName = lead.cropName, moisture = lead.moisture, stress = lead.stress,
+                        irrigated = lead.irrigated, systemId = lead.systemId,
+                    }
+                    for _, mid in ipairs(members) do
+                        local m = byId[mid]
+                        if m ~= nil then
+                            if m.moisture < row.moisture then row.moisture = m.moisture end
+                            if m.stress > row.stress then row.stress = m.stress end
+                            if m.irrigated then row.irrigated = true end
+                            if row.systemId == nil then row.systemId = m.systemId end
+                            if m.cropName ~= row.cropName then row.cropName = tr("cs_rf_pda_crop_mixed", "Mixed") end
+                        end
+                    end
+                    grouped[#grouped + 1] = row
+                elseif lead ~= nil then
+                    lead.memberFieldIds = members
+                    grouped[#grouped + 1] = lead
+                end
+            end
+            rows = grouped
         end
     end
 

--- a/src/ui/CsRfPdaGuest.lua
+++ b/src/ui/CsRfPdaGuest.lua
@@ -393,9 +393,25 @@ function CsRfPdaGuest.buildNextStepLine(fieldId)
     return tip, color
 end
 
+--- BUILD 19:23 (George CLOSED DESIGN 19:12): the Soil list-row merge module on the mission bridge
+--- (Soil attaches it next to soilFertilityManager; getfenv(0) does not cross mods). nil when Soil is
+--- absent, and then every caller keeps today's per-farmland rows. Only Soil drives the outline walks;
+--- this side only calls buildGroups (may queue a walk on Soil's driver) or readGroups (cached only).
+local function getSoilMerge()
+    if g_currentMission == nil or g_currentMission.soilFertilityManager == nil then
+        return nil
+    end
+    local merge = g_currentMission.RfPdaSoilMerge
+    if type(merge) ~= "table" then
+        return nil
+    end
+    return merge
+end
+
 --- Owned-field rows for Esc content table (Wizard ruling: owned-only).
 --- Keys are farmland ids (CropStressManager.fieldById / coveredFields contract).
---- Rows are session farm patches (polygon edge-proximity), not raw field ids.
+--- BUILD 19:23: rows are GPS-outline blocks from the Soil merge bridge (one row per helper
+--- outline, Montana 86-87 is one row); Soil absent = one row per farmland id.
 --- Spectator (farmId nil/0) returns empty rows — never default to farm 1.
 ---@return table
 function CsRfPdaGuest.buildFieldRows()
@@ -455,17 +471,27 @@ function CsRfPdaGuest.buildFieldRows()
         end
     end
 
+    -- BUILD 19:23 (George CLOSED DESIGN 19:12): blocks from the Soil merge bridge, the same rows
+    -- the Soil panel shows. buildOneRow below keeps the block math (min moisture, max stress,
+    -- irrigated if any member is covered, Mixed when the crops differ); memberFieldIds keeps
+    -- feeding pivot coverage. Labels via the merge (Field 86-87), else the Field N fallback.
     local patchList = nil
-    if FarmPatchUtil ~= nil and type(FarmPatchUtil.buildPatches) == "function" then
-        local ok, result = pcall(function()
-            return FarmPatchUtil.buildPatches(ownedIds, {
-                fieldLookup = function(id) return fieldById[id] end,
-                useDensmapConfirm = true,
-                tr = tr,
-            })
-        end)
-        if ok then
-            patchList = result
+    local merge = getSoilMerge()
+    if merge ~= nil and type(merge.buildGroups) == "function" then
+        local ok, groups = pcall(merge.buildGroups, ownedIds)
+        if ok and type(groups) == "table" then
+            patchList = {}
+            for _, g in ipairs(groups) do
+                local members = g.memberIds or { g.fieldId }
+                local label = nil
+                if #members > 1 and type(merge.label) == "function" then
+                    local okL, text = pcall(merge.label, members, tr)
+                    if okL and type(text) == "string" and text ~= "" then
+                        label = text
+                    end
+                end
+                patchList[#patchList + 1] = { patchId = g.fieldId, memberFieldIds = members, label = label }
+            end
         end
     end
 

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1247,11 +1247,11 @@ function RfPdaMenuPage:_refreshDotLegend(panels, activeIndex)
         end
         table.insert(shorts, title)
     end
-    local joined = table.concat(shorts, " - ")
+    local joined = table.concat(shorts, " Â· ")
     if joined == "" then
         joined = tr("rf_pda_module_soil_short", "Soil")
     end
-    self.rfDotLegend:setText(string.format("%d/%d - %s", activeIndex or 1, n, joined))
+    self.rfDotLegend:setText(string.format("%d/%d Â· %s", activeIndex or 1, n, joined))
 end
 
 --- Match SoilMapHooks / Map: grow/shrink from first seed RoundCorner in the BoxLayout.
@@ -2898,9 +2898,11 @@ local function _csPivotRemote(self, action)
     end
 end
 
--- [SCS-046] Rain-key clicks take the same host-then-resolved-guest route as the
--- pivot remotes above, but a DIFFERENT handler: these become
--- CropStressRainKeyCommandEvent, never a pivot remote action.
+-- [SCS-046] Rain-key clicks. Same host-then-resolved-guest route as the pivot
+-- remotes below, but a DIFFERENT handler: these become
+-- CropStressRainKeyCommandEvent, never a pivot remote action. Vendored into
+-- every host copy of this page, because the Esc page that actually loads is the
+-- HOST mod's copy and a button whose onClick name is missing there never paints.
 local function _csRainKey(self, token)
     -- [BUILD 15:58] The pcall stays, because a UI click must never take the
     -- menu down, but the error is PRINTED now. A bare pcall here is what made


### PR DESCRIPTION
## Summary
- Crop Stress owned-field lists (Esc table, tablet overview, consultant, HUD) use Soil's GPS-outline groups when Soil is present.
- The shared Realistic Farming Esc door copy matches the working Soil host so leftover chrome from the last page cannot stick when Crop Stress wins first-writer.
- HUD reads cached groups only and does not start outline walks on the draw tick.

## Test plan
- [ ] Full start.
- [ ] With Soil loaded, Crop Stress field lists show the same joined outline as Soil (Montana 86-87).
- [ ] Without Soil, lists stay per farmland.
- [ ] Esc Realistic Farming: switch Crop Stress / Market / Worker Costs; leftover chrome from the previous page must hide.
- [ ] Crop Stress Help footer still appears on that module.
