### PR TITLE
Esc Dairy: scrollable breed tables, no page chips

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.5.137</version>
+    <version>1.2.5.139</version>
 
     <title>
         <en>Seasonal Crop Stress &amp; Irrigation Manager</en>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -770,77 +770,162 @@
                                  Button is inert (ButtonElement:getIsActive needs a callback), so no other door can
                                  fire them. Hidden by default. Byte-same in all nine door files. rfDairyCardsHint is
                                  the page hint for this layout (rfFwHintTable sits at -336, under the cards). -->
+                            <!-- BUILD 11:40 (George CLOSED DESIGN 11:25): herd / milk breed rows are in-card SmoothLists
+                                 (NPC Favor nest: GuiElement box, clippers, slider box that shows only on overflow), 20px rows,
+                                 four visible in the 80px box, the rest scroll. No breed chips. The box is 520 wide: the
+                                 engine slider box sits 8px past its parent's right edge and the card frame line is at 555.
+                                 The clippers carry their own 12px profiles (the engine's are 39px, half of an 80px list). -->
                             <GuiElement profile="RF_EscCardFrame" id="rfDairyCard1" position="10px -8px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard1Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard1State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard1HerdHead" position="10px -52px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard1HerdNames" position="10px -72px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard1HerdVals" position="340px -72px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard1HerdBox" position="10px -72px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard1HerdList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard1HerdStart" endClipperElementName="rfDairyCard1HerdEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard1HerdStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard1HerdEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard1HerdList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard1MilkHead" position="10px -152px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard1MilkNames" position="10px -172px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard1MilkVals" position="340px -172px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard1MilkBox" position="10px -172px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard1MilkList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard1MilkStart" endClipperElementName="rfDairyCard1MilkEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard1MilkStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard1MilkEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard1MilkList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard1Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard1BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard1BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="rfDairyCard2" position="575px -8px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard2Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard2State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard2HerdHead" position="10px -52px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard2HerdNames" position="10px -72px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard2HerdVals" position="340px -72px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard2HerdBox" position="10px -72px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard2HerdList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard2HerdStart" endClipperElementName="rfDairyCard2HerdEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard2HerdStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard2HerdEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard2HerdList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard2MilkHead" position="10px -152px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard2MilkNames" position="10px -172px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard2MilkVals" position="340px -172px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard2MilkBox" position="10px -172px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard2MilkList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard2MilkStart" endClipperElementName="rfDairyCard2MilkEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard2MilkStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard2MilkEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard2MilkList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard2Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard2BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard2BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="rfDairyCard3" position="10px -396px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard3Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard3State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard3HerdHead" position="10px -52px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard3HerdNames" position="10px -72px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard3HerdVals" position="340px -72px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard3HerdBox" position="10px -72px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard3HerdList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard3HerdStart" endClipperElementName="rfDairyCard3HerdEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard3HerdStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard3HerdEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard3HerdList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard3MilkHead" position="10px -152px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard3MilkNames" position="10px -172px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard3MilkVals" position="340px -172px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard3MilkBox" position="10px -172px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard3MilkList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard3MilkStart" endClipperElementName="rfDairyCard3MilkEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard3MilkStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard3MilkEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard3MilkList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard3Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard3BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard3BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="rfDairyCard4" position="575px -396px" size="555px 380px" visible="false">
                                 <Text profile="RF_SectionTitle" id="rfDairyCard4Name" position="10px -6px" size="535px 24px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard4State" position="10px -32px" size="535px 20px" text=""/>
                                 <Text profile="RF_HintText" id="rfDairyCard4HerdHead" position="10px -52px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard4HerdNames" position="10px -72px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard4HerdVals" position="340px -72px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard4HerdBox" position="10px -72px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard4HerdList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard4HerdStart" endClipperElementName="rfDairyCard4HerdEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard4HerdStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard4HerdEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard4HerdList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard4MilkHead" position="10px -152px" size="535px 20px" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard4MilkNames" position="10px -172px" size="330px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" text=""/>
-                                <Text profile="RF_HintText" id="rfDairyCard4MilkVals" position="340px -172px" size="205px 80px"
-                                      textMaxNumLines="4" textVerticalAlignment="top" textAlignment="right" text=""/>
+                                <GuiElement profile="RF_FwListBox" id="rfDairyCard4MilkBox" position="10px -172px" size="520px 80px">
+                                    <SmoothList id="rfDairyCard4MilkList" profile="RF_DairyBreedList" size="520px 80px" handleFocus="false"
+                                                startClipperElementName="rfDairyCard4MilkStart" endClipperElementName="rfDairyCard4MilkEnd">
+                                        <ListItem profile="RF_DairyBreedItem" height="20px">
+                                            <Bitmap profile="RF_RowBg" name="alternating"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedName" position="0px 0px" size="330px 20px"/>
+                                            <Text profile="RF_DairyBreedCell" name="rfDairyBreedVal" position="330px 0px" size="190px 20px" textAlignment="right"/>
+                                        </ListItem>
+                                    </SmoothList>
+                                    <Bitmap profile="RF_DairyBreedStartClipper" name="rfDairyCard4MilkStart"/>
+                                    <Bitmap profile="RF_DairyBreedStopClipper" name="rfDairyCard4MilkEnd"/>
+                                    <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                        <Slider profile="fs25_listSlider" dataElementId="rfDairyCard4MilkList" hideParentWhenEmpty="true"/>
+                                    </ThreePartBitmap>
+                                </GuiElement>
                                 <Text profile="RF_HintText" id="rfDairyCard4Stored" position="10px -252px" size="535px 60px"
                                       textMaxNumLines="3" textVerticalAlignment="top" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard4BreedPrev" position="10px -346px" size="120px 24px" handleFocus="false" visible="false" text=""/>
-                                <Button profile="RF_CsPivotBtn" id="rfDairyCard4BreedNext" position="140px -346px" size="160px 24px" handleFocus="false" visible="false" text=""/>
                             </GuiElement>
                             <Text profile="RF_HintText" id="rfDairyCardsHint" position="10px -390px" size="860px 80px"
                                   textMaxNumLines="4" textVerticalAlignment="top" visible="false" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -785,6 +785,30 @@
         <textVerticalAlignment value="middle"/>
     </Profile>
 
+    <!-- BUILD 11:40 (George CLOSED DESIGN 11:25): the in-card herd / milk breed lists on the Dairy cards.
+         20px rows = four visible in the 80px box (today's density); the slider shows only when rows overflow. -->
+    <Profile name="RF_DairyBreedList" extends="RF_SmoothList">
+        <size value="520px 80px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <Profile name="RF_DairyBreedItem" extends="RF_ListRow">
+        <height value="20px"/>
+    </Profile>
+    <Profile name="RF_DairyBreedCell" extends="RF_FwListCell">
+        <textSize value="16px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="1"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- The engine clippers are 39px tall (sized for the 420px roster box); in an 80px list they would
+         fade two of the four rows. Same gradient, anchors and offset, 12px tall. -->
+    <Profile name="RF_DairyBreedStartClipper" extends="fs25_secondaryMenuStartClipper">
+        <height value="12px"/>
+    </Profile>
+    <Profile name="RF_DairyBreedStopClipper" extends="fs25_secondaryMenuStopClipper">
+        <height value="12px"/>
+    </Profile>
+
     <!-- F12: STATUS body cells centered. -->
     <Profile name="RF_StatusCell" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="17px"/>


### PR DESCRIPTION
## Player

On Esc Realistic Farming, Dairy barn cards must never show `< BREEDS` / `BREEDS (n/n) >`.

If a barn has more herd-now rows or milk-in-tank rows than fit in the card table, those extra rows stay in **the same table** and the player **scrolls**. No second page. No leftover chips on NPC Favor (those chips were Dairy leftover paint on the shared overlay table).

Comma / period still turn **barn cards**, not breed rows.

This is one shared Esc-door change. **All ten companions below must land together.** If only DairyCore lands and Soil (or Crop Stress, Worker Costs, …) is first-writer, the player still gets the old door: four-line Texts plus the breed chips.

## This PR (wave)

Same branch on every fork: `wizard/esc-dairy-breed-scroll-20260907`  
Base on every org repo: **`development`**  
Do **not** GitHub-merge if that would pull extra files. Prefer the checkout recipe below (four files on DairyCore, three on the others).

| Org repo | Fork (head) | Commit | Files |
|---|---|---|---|
| [Realistic-Farming/FS25_DairyCore](https://github.com/Realistic-Farming/FS25_DairyCore) | WizardlyPayload/FS25_DairyCore | `25c4587ae019457964c8cc22e16440882d2a38d4` | guest Lua + door XML + profiles + `modDesc.xml` |
| [Realistic-Farming/FS25_SoilFertilizer](https://github.com/Realistic-Farming/FS25_SoilFertilizer) | WizardlyPayload/**FS25_SoilFertilizer-RF-org** (name differs) | `39aeebfb9e60fd68695ba46a5ba76d5d27a7adb0` | door XML + profiles + `modDesc.xml` |
| [Realistic-Farming/FS25_SeasonalCropStress](https://github.com/Realistic-Farming/FS25_SeasonalCropStress) | WizardlyPayload/FS25_SeasonalCropStress | `eed82d957cfca6205e3e8be6c03eca200edda8ac` | same three |
| [Realistic-Farming/FS25_ProStaffCoOp](https://github.com/Realistic-Farming/FS25_ProStaffCoOp) | WizardlyPayload/FS25_ProStaffCoOp | `138f08b4cc09e0d193a4e8f36a4d0a2d2182ad4c` | same three |
| [Realistic-Farming/FS25_FertilizerDepot](https://github.com/Realistic-Farming/FS25_FertilizerDepot) | WizardlyPayload/FS25_FertilizerDepot | `7586d9a3cbce889ef6d6744c1698cb30070c57c5` | same three |
| [Realistic-Farming/FS25_IncomeMod](https://github.com/Realistic-Farming/FS25_IncomeMod) | WizardlyPayload/FS25_IncomeMod | `0eb018bc5e0959c83140ef55eb2de1ca5640c06f` | same three |
| [Realistic-Farming/FS25_MarketDynamics](https://github.com/Realistic-Farming/FS25_MarketDynamics) | WizardlyPayload/FS25_MarketDynamics | `b982f345545deb296c95dbea3664481338dcf844` | same three |
| [Realistic-Farming/FS25_NPCFavor](https://github.com/Realistic-Farming/FS25_NPCFavor) | WizardlyPayload/FS25_NPCFavor | `fdc79edf242bfac5dba70dbfdfedfd3105d76919` | same three |
| [Realistic-Farming/FS25_TaxMod](https://github.com/Realistic-Farming/FS25_TaxMod) | WizardlyPayload/FS25_TaxMod | `6e8182319fa63e20f20d1aa7891db1781a8fd946` | same three |
| [Realistic-Farming/FS25_WorkerCosts](https://github.com/Realistic-Farming/FS25_WorkerCosts) | WizardlyPayload/FS25_WorkerCosts | `e3dad1a585c9322a21019bb54831684c0ad7d0d8` | same three |

**Open PRs (same change, one per repo):**

- https://github.com/Realistic-Farming/FS25_DairyCore/pull/52 (guest Lua + door; do this first)
- https://github.com/Realistic-Farming/FS25_SoilFertilizer/pull/924
- https://github.com/Realistic-Farming/FS25_SeasonalCropStress/pull/182
- https://github.com/Realistic-Farming/FS25_ProStaffCoOp/pull/18
- https://github.com/Realistic-Farming/FS25_FertilizerDepot/pull/67
- https://github.com/Realistic-Farming/FS25_IncomeMod/pull/66
- https://github.com/Realistic-Farming/FS25_MarketDynamics/pull/146
- https://github.com/Realistic-Farming/FS25_NPCFavor/pull/105
- https://github.com/Realistic-Farming/FS25_TaxMod/pull/49
- https://github.com/Realistic-Farming/FS25_WorkerCosts/pull/125

**Not in any of these PRs (leave your tree as-is):** host `src/ui/RfPdaMenuPage.lua` / Dairy host equivalent, Soil GPS field-list Lua (`RfPdaSoilMerge.lua`), Farm Tablet, Crop Stress HUD, translations (`dairy_rf_pda_breed_prev` / `_next` keys stay, unused).

## Why every companion must take the door XML

`RfEscBootstrap.ensureDoor` is first-writer. Whichever companion builds the Esc page first owns `xml/gui/RfPdaMenuPage.xml` for the whole session. Later companions are guests on that copy.

After this wave, all ten `RfPdaMenuPage.xml` files must be **byte-identical**.

Do **not** merge only `DairyRfPdaGuest.lua`. Do **not** merge only one companion’s XML.

## Manual merge (recommended: no GitHub merge button)

You are copying **named files** onto `development`. That avoids pulling any other Wizard local Esc work.

Canon **door XML** SHA256 (must match on all ten clones):

`18C0C30AF2022C4D04180C5B3A20E5AB43F72AACE5BABA4B0EBC3013F53DA900` (171052 bytes)

Host Lua is **unchanged** by this wave (do not overwrite it from any other branch):

`B03EC737E1E7A3B1DB6821FD5D9239F56728AE0E19B41F84D209F8FE67E3A315` (168678 bytes)

### Conflicts

If `development` moved `RfPdaMenuPage.xml` after these branches were cut:

- **Take this wave’s XML entirely.** Do not three-way the Dairy card block. The lists, clippers, and 520px width are measured; a merge of old four-line Texts with new lists will ship both chips and lists.
- **Do not take DairyCore’s `rfEscProfiles.xml` into another repo.** Profiles files are **not** byte-same across mods (line endings / existing comments). Each repo’s PR head already has the five new profiles inserted in **that** file.
- `modDesc.xml` is version-only for this wave. If your `development` `modDesc` moved for other reasons, keep your other edits and bump / keep the version line from this head if you still want the playtest version stamp.

### DairyCore (do this first)

```text
git fetch origin
git checkout development
git pull --ff-only origin development
git fetch https://github.com/WizardlyPayload/FS25_DairyCore.git wizard/esc-dairy-breed-scroll-20260907
git checkout FETCH_HEAD -- src/gui/DairyRfPdaGuest.lua xml/gui/RfPdaMenuPage.xml xml/gui/rfEscProfiles.xml modDesc.xml
```

Raw (same bytes as FETCH_HEAD):

- https://raw.githubusercontent.com/WizardlyPayload/FS25_DairyCore/wizard/esc-dairy-breed-scroll-20260907/src/gui/DairyRfPdaGuest.lua
- https://raw.githubusercontent.com/WizardlyPayload/FS25_DairyCore/wizard/esc-dairy-breed-scroll-20260907/xml/gui/RfPdaMenuPage.xml
- https://raw.githubusercontent.com/WizardlyPayload/FS25_DairyCore/wizard/esc-dairy-breed-scroll-20260907/xml/gui/rfEscProfiles.xml
- https://raw.githubusercontent.com/WizardlyPayload/FS25_DairyCore/wizard/esc-dairy-breed-scroll-20260907/modDesc.xml

Confirm after checkout:

| File | SHA256 | Size |
|---|---|---|
| `xml/gui/RfPdaMenuPage.xml` | `18C0C30AF2022C4D04180C5B3A20E5AB43F72AACE5BABA4B0EBC3013F53DA900` | 171052 |
| `src/gui/DairyRfPdaGuest.lua` | `EAD2F92FCF68A5FC9F7DFD9951C53F4D8C1FB40DB49A85C4DF578E4106AE2456` | 51129 |
| `xml/gui/rfEscProfiles.xml` (DairyCore copy) | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 |
| `modDesc.xml` | `5BE36B3454F04B48EEBA29F214CD746D43C1EAF668D3F8D140BC24DE56C8E926` | 28880 |

Content checks:

- no `BreedPrev` / `BreedNext` / `HerdNames` / `HerdVals` / `MilkNames` / `MilkVals` in the door XML
- eight lists exist: `rfDairyCard1..4HerdList` and `rfDairyCard1..4MilkList`
- guest has `dairyListSource` and `beltHideBreedChips`, and has no `paintBreedPager`

Commit on `development` with whatever message you use for a hand merge.

### The other nine

XML **is** byte-same. You may copy `RfPdaMenuPage.xml` from DairyCore after the DairyCore step, or check out the file from each PR head. Either way the SHA256 must be `18C0C30A…`.

Soil fork URL if the short name 404s:

`https://github.com/WizardlyPayload/FS25_SoilFertilizer-RF-org.git`

For each of Soil, SeasonalCropStress, ProStaffCoOp, FertilizerDepot, IncomeMod, MarketDynamics, NPCFavor, TaxMod, WorkerCosts:

```text
git fetch origin
git checkout development
git pull --ff-only origin development
git fetch https://github.com/WizardlyPayload/FS25_<Mod>.git wizard/esc-dairy-breed-scroll-20260907
git checkout FETCH_HEAD -- xml/gui/RfPdaMenuPage.xml xml/gui/rfEscProfiles.xml modDesc.xml
```

Soil:

```text
git fetch https://github.com/WizardlyPayload/FS25_SoilFertilizer-RF-org.git wizard/esc-dairy-breed-scroll-20260907
git checkout FETCH_HEAD -- xml/gui/RfPdaMenuPage.xml xml/gui/rfEscProfiles.xml modDesc.xml
```

#### Per-repo hashes (profiles and modDesc differ; XML must not)

**Door XML (all ten):** `18C0C30AF2022C4D04180C5B3A20E5AB43F72AACE5BABA4B0EBC3013F53DA900` (171052)

| Repo | `rfEscProfiles.xml` SHA256 | size | `modDesc.xml` SHA256 | size |
|---|---|---|---|---|
| FS25_DairyCore | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `5BE36B3454F04B48EEBA29F214CD746D43C1EAF668D3F8D140BC24DE56C8E926` | 28880 |
| FS25_SoilFertilizer | `D2B8BAD6D33415AFAD223112596D8DC82725813B88CEF84201BA9C0FD104CD47` | 38896 | `4347AC26607EB58478BCCED82BD3787DEB500743A9AE0880742227E427CB4105` | 65569 |
| FS25_SeasonalCropStress | `75A7C44ED0C8D0B7B727B270D4265C5F7ACAD3107F852CECBB2FFB9092BC0358` | 41547 | `74C897EE171F239D8BD093185C18E848622C14F03DB0D5699B2FD75F8C6CB215` | 35767 |
| FS25_ProStaffCoOp | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `288F7CE12602AB07425FED0DD36C3256C5EDCCE0CABE362387DA00A38BD0A661` | 21623 |
| FS25_FertilizerDepot | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `D56D024A5A418AD0097C36013A6B7BF4B0A0F604F23FCA3FF4EF62CB5B6001DA` | 14989 |
| FS25_IncomeMod | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `7229D238C22253135C9FA541FF92EED6B092C89119BE2C66670B0C82B380FD05` | 234173 |
| FS25_MarketDynamics | `D2B8BAD6D33415AFAD223112596D8DC82725813B88CEF84201BA9C0FD104CD47` | 38896 | `59EE1B8B3B89B427B31F429F85AB9A6EFD784FBCD9771DE3EC05DFCCC0E85270` | 5334 |
| FS25_NPCFavor | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `D9F25C6E86EF410D7776E2F7454249E3942838E6307EC65B3480FBE369A66BBE` | 6757 |
| FS25_TaxMod | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `93BEAEC59E22F3BE0229A076B76FB1A371DCA77A524FB87372BD677608EC68C2` | 77859 |
| FS25_WorkerCosts | `D71279A679BEBFF83F60148B1891CB8653D59F48B0166AD38ED4889D9CD2369C` | 38900 | `5B7E1BD1A29100DC94BAC3BEF344645556F5640F140AF882526D12A959F3A1F8` | 93536 |

Soil / Market profiles hash `D2B8BAD6…` (38896) vs Dairy-family `D71279A6…` (38900): line endings / existing file, **not** a missing profile. SeasonalCropStress is larger because that file already had more profiles. After merge, each file must still contain `RF_DairyBreedList`, `RF_DairyBreedItem`, `RF_DairyBreedCell`, `RF_DairyBreedStartClipper`, `RF_DairyBreedStopClipper`.

After all ten:

```text
python tools/esc_door_independence_test.py
```

Must print `RESULT: PASS (0 fail)` when clones **and** My Games zips match. If you only merge git and do not pack zips, at least confirm all ten clone `RfPdaMenuPage.xml` SHA256 values equal `18C0C30A…`.

## What changed in the door XML

Inside each `rfDairyCard1..4` (`RF_EscCardFrame`, 555x380):

**Removed**

- Eight buttons: `rfDairyCardNBreedPrev` / `rfDairyCardNBreedNext` (`RF_CsPivotBtn`)
- Sixteen multi-line Texts: `rfDairyCardNHerdNames` / `HerdVals` / `MilkNames` / `MilkVals` (`textMaxNumLines="4"`)

**Added** (NPC Favor list nest, smaller)

- `rfDairyCardNHerdBox` at `10px -72px`, size `520px 80px`
- SmoothList `rfDairyCardNHerdList`, profile `RF_DairyBreedList`, `handleFocus="false"`
- ListItem `RF_DairyBreedItem` height 20px: `rfDairyBreedName` 330x20, `rfDairyBreedVal` 330,0 190x20 `textAlignment="right"`
- Clippers `rfDairyCardNHerdStart` / `HerdEnd`, profiles `RF_DairyBreedStartClipper` / `StopClipper` (12px tall)
- `ThreePartBitmap` `fs25_subCategoryListSliderBox` + `fs25_listSlider` `dataElementId` on that list, `hideParentWhenEmpty="true"`
- Milk copy at `10px -172px`: `rfDairyCardNMilkBox` / `MilkList` / milk clippers

**Unchanged on the card:** Name, State, `HerdHead` (-52), `MilkHead` (-152), Stored (-252). Parent is the card GuiElement, never a Map-style Bitmap.

### Measured deviations (do not “fix” back to 535 / engine 39px clippers)

1. **List width 520px, not 535px.** Engine `fs25_subCategoryListSliderBox` sits 8px past its parent’s right edge (`fs25_listSliderBox` is 6px, `anchorStretchingYRight`). Card frame line is at 555. A 535 box puts the slider on the frame. Value cell is 190 wide (205 minus 15) so the slider sits about 538..544 when rows overflow.
2. **Clippers 12px, not vanilla 39px.** `fs25_secondaryMenuStartClipper` / `StopClipper` are 39px (sized for the 420px NPC roster). In an 80px list that fades two of four visible rows. New profiles keep the same gradient/anchors/offset at 12px.
3. **`clipChildren` is not an engine key.** GuiElement reads `clipping`. Do not add `clipChildren`.

Slider visibility: engine `SliderElement:onBindUpdate` sets `needsSlider` when `minValue < maxValue` and content is non-empty, then `parent:setVisible(needsSlider)`. Empty or fitting lists hide the slider box. No extra Lua.

## What changed in `rfEscProfiles.xml` (every companion)

Insert before the F12 STATUS comment (exact names):

- `RF_DairyBreedList` extends `RF_SmoothList`: 520x80, `handleFocus` false
- `RF_DairyBreedItem` extends `RF_ListRow`: height 20px (four visible rows in 80px = previous density)
- `RF_DairyBreedCell` extends `RF_FwListCell`: 16px, not bold, `textMaxNumLines` 1, vertical middle
- `RF_DairyBreedStartClipper` extends `fs25_secondaryMenuStartClipper`: height 12px
- `RF_DairyBreedStopClipper` extends `fs25_secondaryMenuStopClipper`: height 12px

Do not replace the rest of the profiles file with another mod’s copy.

## What changed in `DairyRfPdaGuest.lua` only

Replace the in-card breed **pager** with SmoothList data sources.

**Removed:** `paintBreedPager`, `_breedPage`, `breedPagesFor`, `breedPageOf`, `tableColumns`, `paintTable`, `stepBreedPage`, `repaint`, `wireDairyChipPaint`, `_pageRows`, `_lastContainer`, and the vendored chip helpers (`setChipBtn`, `renderChip`, `wireChipPaint`).

**Added:**

- `_cardRows[slot] = { herd = rows, milk = rows }` from existing `herdTable` / `milkTable` `{name, value}` pairs (milk fill-type section rows and indented breed rows unchanged)
- `_cardBarn[slot]` = barn id last painted on that slot
- `dairyListSource`: `getNumberOfItemsInSection`, `populateCellForItemInSection` (set `rfDairyBreedName` / `rfDairyBreedVal` via `getDescendantByName`), empty `onListSelectionChanged` (read-only)
- List identity from id: `rfDairyCardNHerdList` / `MilkList` → slot + part
- `syncList`: `setDataSource` only when `list.dataSource ~= dairyListSource`; `setDelegate(dairyListSource)` explicitly (XML loader otherwise leaves the host page as delegate); `reloadData` only when asked **and** `list.isLoaded`
- Full show (`lightOnly ~= true`, including barn page turns): reload headers + lists
- 2s light tick: Name, State, stored feed, side rail only. Headers/lists freeze unless `_cardBarn[slot]` changed (barn arrived, moved, or swapped between full shows). Then one reload on that tick, never periodic. **No timer `reloadData`.**
- `beltHideBreedChips` at the top of `onShow`: if an old first-writer door still has the eight chip ids, hide, `rfChipLabel = nil`, disable. Also blank/hide old `HerdNames`/`Vals`/`MilkNames`/`Vals` so a Lua reload before XML restart cannot show a frozen four-line column.

**Kept:** barn pager (`,` `.`, `onPageStep`), `stripButtonGlyph`, side teach, Stored readout.

## Engine fences (do not regress)

- GuiElement parent for SmoothList. Never SmoothList under a Map-style Bitmap. No timer `reloadData` (client hang class: GuiElement mouseEvent/update stack overflow + GC thrash).
- No new Esc buttons. Overlay chips law: we **deleted** buttons; do not add `RF_FwPagerBtn` / `buttonActivate` pagers.
- No Map inject.
- XML loads at door creation: **full game restart** after merge. Lua guest can hot-reload after that.

## Playtest zip (this PC, not a substitute for git)

Local My Games packs already match this tree. Independence test `RESULT: PASS (0 fail)`.

DairyCore `1.0.5.37` SHA256 `454D9C7EB511D5B1B904B3C552FF82E1C237339F8F73966A4C88747C6176F3DD` (328200 bytes).

Soil `2.5.0.124` keeps glance, overlay pairs, Buy/Run, Right Shift+End, and the GPS field-grouping Lua from development (this PR only touches Soil door XML + profiles + version).

## Eyes-on after your merge

1. Full client (and dedicated, if that pack is in play) restart. XML does not hot-patch.
2. Dairy: a barn with more than four herd or milk rows → table scrolls, **no** `< BREEDS` chips.
3. Dairy then NPC Favor: **no** leftover breed chips on the roster.
4. One-page breed table: no slider (engine hide-when-empty).
5. Comma / period still change barn cards.

## Out of scope

Farm Tablet. Soil GPS list logic (already on Soil `development`). Parked byte-same glance copy that was HOLD on this PC. GPortal. Translations sweep.
