### PR TITLE
feat: farm-scoped irrigation snapshot carries rain-key + running/paused

### DIFF
--- a/src/CropStressManager.lua
+++ b/src/CropStressManager.lua
@@ -1063,57 +1063,13 @@ function CropStressManager:getIrrigationSystems(farmId)
         end
         return nil
     end
+    -- Legacy no-arg public copy: route through the single row builder so the
+    -- public list and the farm-scoped private snapshot can never drift again.
+    -- includePrivate = false keeps the all-public field shape older FarmTablet
+    -- versions expect (no ownerFarmId / waterSourceId / stopReason).
     local out = {}
     for _, sys in pairs(irrMgr.systems) do
-        local covered = {}
-        if sys.coveredFields ~= nil then
-            for i = 1, #sys.coveredFields do covered[i] = sys.coveredFields[i] end
-        end
-        local schedule = nil
-        if sys.schedule ~= nil then
-            local days = {}
-            if sys.schedule.activeDays ~= nil then
-                for i = 1, #sys.schedule.activeDays do days[i] = sys.schedule.activeDays[i] end
-            end
-            schedule = {
-                startHour  = sys.schedule.startHour,
-                endHour    = sys.schedule.endHour,
-                activeDays = days,
-            }
-        end
-        out[#out + 1] = {
-            id                     = sys.id,
-            type                   = sys.type,
-            isActive               = sys.isActive == true,
-            coveredFields          = covered,
-            schedule               = schedule,
-            flowRatePerHour        = sys.flowRatePerHour,
-            operationalCostPerHour = sys.operationalCostPerHour,
-            -- SCS-046: the rain-key build expands the same copy-only surface. Only
-            -- filled for fitted pivots; unfitted rows carry the neutral defaults so
-            -- the old field shape is preserved for older FarmTablet versions.
-            rainKeyFitted          = sys.rainKeyFitted == true,
-            rainKeyTripMm          = sys.rainKeyTripMm,
-            rainKeyAccumulatedMm   = sys.rainKeyAccumulatedMm or 0,
-            rainKeyDryElapsedMinutes = sys.rainKeyDryElapsedMinutes or 0,
-            weatherReadable        = sys.rainKeyInputState == "OK",
-            rainKeyState           = (self.irrigationManager.getRainKeyState
-                and self.irrigationManager:getRainKeyState(sys)) or
-                (sys.rainKeyFitted == true and "ARMED" or "UNFITTED"),
-            rainKeyTripped         = sys.rainKeyTripped == true,
-            activityState          = sys.rainKeyFitted == true
-                and (sys.rainKeyTripped == true and "RAIN_PAUSED"
-                     or (sys.isActive == true and "RUNNING" or "OFF"))
-                or (sys.isActive == true and "RUNNING" or "OFF"),
-            pauseReason            = sys.rainKeyFitted == true and sys.rainKeyTripped == true
-                and "RAIN_KEY_TRIPPED"
-                or (sys.rainKeyFitted == true and sys.rainKeyInputState ~= "OK"
-                     and "INPUT_UNAVAILABLE" or "NONE"),
-            nextWakeKind           = sys.rainKeyFitted == true and sys.rainKeyTripped == true
-                and "DRY_RESET" or "NONE",
-            nextWakeGameMinutes    = nil,
-            stateRevision          = sys.rainKeyStateRevision or 0,
-        }
+        out[#out + 1] = irrMgr:copyIrrigationSystemRow(sys, false)
     end
     return out
 end

--- a/src/IrrigationManager.lua
+++ b/src/IrrigationManager.lua
@@ -1707,24 +1707,67 @@ end
 --- omits farm-private fields; includePrivate adds ownerFarmId, waterSourceId and
 --- the derived stopReason. Used by the farm getters and the private state event,
 --- never a second snapshot protocol.
+-- SCS-046 / F200 follow-up: the SINGLE builder for one irrigation system row.
+-- Both the farm-scoped surface (getIrrigationSystemsRows -> the tablet's private
+-- snapshot) and the legacy no-arg public copy route through here, so the two can
+-- never drift again - the drift (the farm-only copy dropping rain-key + the
+-- composed running/paused state, forcing the tablet to peek the public list) is
+-- exactly the bug this closes. Rain-key + activityState are emitted UNCONDITIONALLY;
+-- only ownerFarmId / waterSourceId / stopReason are private.
 function IrrigationManager:copyIrrigationSystemRow(system, includePrivate)
     local covered = {}
     if system.coveredFields ~= nil then
         for i = 1, #system.coveredFields do covered[i] = system.coveredFields[i] end
+    end
+    -- Deep-copy the schedule so a reader can never mutate live state.
+    local schedule = nil
+    if system.schedule ~= nil then
+        local days = {}
+        if system.schedule.activeDays ~= nil then
+            for i = 1, #system.schedule.activeDays do days[i] = system.schedule.activeDays[i] end
+        end
+        schedule = {
+            startHour  = system.schedule.startHour,
+            endHour    = system.schedule.endHour,
+            activeDays = days,
+        }
     end
     local row = {
         id                     = system.id,
         type                   = system.type,
         isActive               = system.isActive == true,
         coveredFields          = covered,
-        schedule               = system.schedule,
+        schedule               = schedule,
         flowRatePerHour        = system.flowRatePerHour,
         operationalCostPerHour = system.operationalCostPerHour,
+        -- Rain-key readout + composed activity (RUNNING / RAIN_PAUSED / OFF).
+        -- Only fitted pivots carry meaningful rain-key values; unfitted rows keep
+        -- neutral defaults so the legacy field shape is preserved.
+        rainKeyFitted            = system.rainKeyFitted == true,
+        rainKeyTripMm            = system.rainKeyTripMm,
+        rainKeyAccumulatedMm     = system.rainKeyAccumulatedMm or 0,
+        rainKeyDryElapsedMinutes = system.rainKeyDryElapsedMinutes or 0,
+        weatherReadable          = system.rainKeyInputState == "OK",
+        rainKeyState             = (self.getRainKeyState and self:getRainKeyState(system))
+            or (system.rainKeyFitted == true and "ARMED" or "UNFITTED"),
+        rainKeyTripped           = system.rainKeyTripped == true,
+        activityState            = system.rainKeyFitted == true
+            and (system.rainKeyTripped == true and "RAIN_PAUSED"
+                 or (system.isActive == true and "RUNNING" or "OFF"))
+            or (system.isActive == true and "RUNNING" or "OFF"),
+        pauseReason              = system.rainKeyFitted == true and system.rainKeyTripped == true
+            and "RAIN_KEY_TRIPPED"
+            or (system.rainKeyFitted == true and system.rainKeyInputState ~= "OK"
+                 and "INPUT_UNAVAILABLE" or "NONE"),
+        nextWakeKind             = system.rainKeyFitted == true and system.rainKeyTripped == true
+            and "DRY_RESET" or "NONE",
+        nextWakeGameMinutes      = nil,
+        stateRevision            = system.rainKeyStateRevision or 0,
     }
     if includePrivate then
-        row.ownerFarmId  = system.ownerFarmId
+        row.ownerFarmId   = system.ownerFarmId
         row.waterSourceId = system.waterSourceId
-        row.stopReason   = self:getSystemStopReason(system)
+        row.stopReason    = self:getSystemStopReason(system)
     end
     return row
 end

--- a/src/events/CropStressIrrigationStateEvent.lua
+++ b/src/events/CropStressIrrigationStateEvent.lua
@@ -17,7 +17,12 @@
 --   systemCount        : Int32
 --   per system: id, type String, isActive Bool, ownerFarmId, waterSourceId,
 --               stopReason String, flowRatePerHour Float32,
---               operationalCostPerHour Float32, coveredCount Int32, field ids Int32
+--               operationalCostPerHour Float32,
+--               rainKeyFitted Bool, rainKeyTripMm Float32, rainKeyAccumulatedMm Float32,
+--               rainKeyDryElapsedMinutes Int32, weatherReadable Bool,
+--               rainKeyState String, rainKeyTripped Bool, activityState String,
+--               pauseReason String, nextWakeKind String, stateRevision Int32,
+--               coveredCount Int32, field ids Int32
 -- ============================================================
 
 CropStressIrrigationStateEvent = CropStressIrrigationStateEvent or {}
@@ -72,6 +77,19 @@ function CropStressIrrigationStateEvent:writeStream(streamId, connection)
         streamWriteString(streamId, tostring(r.stopReason or ""))
         streamWriteFloat32(streamId, r.flowRatePerHour or 0)
         streamWriteFloat32(streamId, r.operationalCostPerHour or 0)
+        -- rain-key + composed activity (so the private snapshot carries running/
+        -- paused and the tablet need not peek the public list). Order MUST match readStream.
+        streamWriteBool(streamId, r.rainKeyFitted == true)
+        streamWriteFloat32(streamId, r.rainKeyTripMm or 0)
+        streamWriteFloat32(streamId, r.rainKeyAccumulatedMm or 0)
+        streamWriteInt32(streamId, r.rainKeyDryElapsedMinutes or 0)
+        streamWriteBool(streamId, r.weatherReadable == true)
+        streamWriteString(streamId, tostring(r.rainKeyState or "UNFITTED"))
+        streamWriteBool(streamId, r.rainKeyTripped == true)
+        streamWriteString(streamId, tostring(r.activityState or "OFF"))
+        streamWriteString(streamId, tostring(r.pauseReason or "NONE"))
+        streamWriteString(streamId, tostring(r.nextWakeKind or "NONE"))
+        streamWriteInt32(streamId, r.stateRevision or 0)
         local covered = r.coveredFields or {}
         streamWriteInt32(streamId, #covered)
         for j = 1, #covered do
@@ -118,6 +136,18 @@ function CropStressIrrigationStateEvent:readStream(streamId, connection)
             stopReason = streamReadString(streamId),
             flowRatePerHour = streamReadFloat32(streamId),
             operationalCostPerHour = streamReadFloat32(streamId),
+            -- rain-key + composed activity. Order MUST match writeStream.
+            rainKeyFitted = streamReadBool(streamId),
+            rainKeyTripMm = streamReadFloat32(streamId),
+            rainKeyAccumulatedMm = streamReadFloat32(streamId),
+            rainKeyDryElapsedMinutes = streamReadInt32(streamId),
+            weatherReadable = streamReadBool(streamId),
+            rainKeyState = streamReadString(streamId),
+            rainKeyTripped = streamReadBool(streamId),
+            activityState = streamReadString(streamId),
+            pauseReason = streamReadString(streamId),
+            nextWakeKind = streamReadString(streamId),
+            stateRevision = streamReadInt32(streamId),
         }
         local covered = {}
         local n = streamReadInt32(streamId)


### PR DESCRIPTION
## What (Wizard/Ash inbox item: irrigation host remainder)

The Farm Tablet Irrigation Suite is Wizard-complete; this is the **Crop Stress host** remainder. The farm-scoped snapshot the tablet reads was dropping rain-key + running/paused, forcing the tablet to peek a second public list. This closes that gap.

### Part 1 - farm-only snapshot carries the fields
- **`copyIrrigationSystemRow` is now the single row builder.** The legacy no-arg public copy (`CropStressManager:getIrrigationSystems()`) now routes through it too, so the two copies can never drift again - that drift *is* this bug.
- The builder emits **rain-key readout** (`rainKeyFitted/State/Tripped/TripMm/AccumulatedMm/DryElapsedMinutes`, `weatherReadable`) and **composed `activityState`** (`RUNNING` / `RAIN_PAUSED` / `OFF`) + `pauseReason` / `nextWakeKind` / `stateRevision` **unconditionally**. Only `ownerFarmId` / `waterSourceId` / `stopReason` remain private.
- **`CropStressIrrigationStateEvent`** write/read extended in **matching order** so pure clients receive these fields in their private snapshot (previously they didn't cross the wire at all).

### Part 2 - same truth for pumps / remaining water / schedule surfaces
Verified rather than re-plumbed: the host PDA/schedule guest (`CsRfPdaGuest`) reads the **same live `irr.systems`** objects, and pumps/remaining water come from the **shared `getIrrigationWaterSources` getter**. So once Part 1 makes the snapshot carry the same rain-key/activity truth, the tablet and the host surfaces agree by construction. The guest's "Watering now: On/Off" label + rain-key warning line is left unchanged (Wizard-owned layout, `[BUILD 22:43]`); reversing that deliberate simplification would touch the Esc-door PDA subsystem and is flagged as an optional follow-up, not done here.

## Guardrails honored
Fast-path correction of an already-decided data contract (not new design). No FarmTablet rebuild requested. SF-54 / growth screen untouched. No new hydrology surface.

## Verify
All FS25 stream/API calls read from source first; MP write/read order matched (silent-corruption rule). Lua 5.1 gate passed; built and deployed. Needs in-game MP verification (client sees running/paused + rain-key on the tablet without the public-list peek).
